### PR TITLE
refactor: remove `root` in `setup`

### DIFF
--- a/src/common/components/editor/ColorPicker.vue
+++ b/src/common/components/editor/ColorPicker.vue
@@ -27,7 +27,7 @@
 <script lang="ts">
 import { PI, PSelectDropdown } from '@spaceone/design-system';
 import type { Editor } from '@tiptap/core';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     defineComponent, reactive, toRefs,
 } from 'vue';
@@ -58,7 +58,7 @@ export default defineComponent<Props>({
             required: true,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             textColorItems: COLOR_PICKER_COLOR_SETS.flatMap(color => ({ name: color })),
         });

--- a/src/common/components/editor/TextEditor.vue
+++ b/src/common/components/editor/TextEditor.vue
@@ -17,7 +17,7 @@ import { Editor, EditorContent } from '@tiptap/vue-2';
 import {
     defineComponent, onBeforeUnmount, onMounted, reactive, toRefs, watch,
 } from 'vue';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 
 import { createImageExtension } from '@/common/components/editor/extensions/image';
 import { getAttachments, setAttachmentsToContents } from '@/common/components/editor/extensions/image/helper';
@@ -60,7 +60,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         loadMonospaceFonts();
 
         const state = reactive({

--- a/src/common/components/forms/tags-input-group/TagsInputGroup.vue
+++ b/src/common/components/forms/tags-input-group/TagsInputGroup.vue
@@ -60,6 +60,7 @@ import {
     PButton, PFieldGroup, PIconButton, PTextInput,
 } from '@spaceone/design-system';
 import { isEmpty } from 'lodash';
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs, watch,
 } from 'vue';
@@ -67,7 +68,7 @@ import {
 import { i18n } from '@/translations';
 
 import type {
-    Tag, TagItem, TagsInputGroupProps, ValidationData,
+    Tag, TagItem, ValidationData,
 } from '@/common/components/forms/tags-input-group/type';
 
 
@@ -117,7 +118,7 @@ export default defineComponent({
             default: true,
         },
     },
-    setup(props: TagsInputGroupProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             items: dictToArray(props.tags) as TagItem[],
             keyValidations: computed<ValidationData[]>(() => {

--- a/src/common/components/forms/tags-input-group/type.ts
+++ b/src/common/components/forms/tags-input-group/type.ts
@@ -13,12 +13,3 @@ export type ValidationData = {
     isValid: boolean;
     message: string | TranslateResult;
 };
-
-export interface TagsInputGroupProps {
-    tags: Tag;
-    disabled: boolean;
-    isValid: boolean;
-    showValidation: boolean;
-    showHeader: boolean;
-    focused: boolean;
-}

--- a/src/common/components/forms/vue-diff/Code.vue
+++ b/src/common/components/forms/vue-diff/Code.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang="ts">
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     defineComponent, nextTick, onMounted, ref, watch,
 } from 'vue';
@@ -31,7 +31,7 @@ export default defineComponent({
         },
     },
     emits: ['rendered'],
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const highlightCode = ref('');
 
         onMounted(() => {

--- a/src/common/components/forms/vue-diff/Line.vue
+++ b/src/common/components/forms/vue-diff/Line.vue
@@ -56,7 +56,7 @@
 
 <script lang="ts">
 import { useResizeObserver, useThrottleFn } from '@vueuse/core';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     computed, defineComponent, ref,
 } from 'vue';
@@ -100,7 +100,7 @@ export default defineComponent({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const lineRef = ref<null | HTMLElement>(null);
         const rowStyle = computed(() => {
             if (!props.scrollOptions) return undefined;

--- a/src/common/components/layouts/PdfDownloadOverlay/PdfDownloadOverlay.vue
+++ b/src/common/components/layouts/PdfDownloadOverlay/PdfDownloadOverlay.vue
@@ -52,7 +52,7 @@ import {
     defineComponent,
     reactive, toRefs, watch,
 } from 'vue';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 
 import type { PdfFontFamily, Language } from '@/common/components/layouts/PdfDownloadOverlay/fonts';
 import {
@@ -152,7 +152,7 @@ export default defineComponent<Props>({
             },
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxyVisible: props.visible,
             loading: true,

--- a/src/common/components/modals/DeleteModal.vue
+++ b/src/common/components/modals/DeleteModal.vue
@@ -36,7 +36,7 @@
 
 <script lang="ts">
 import { PButtonModal, PButton } from '@spaceone/design-system';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import { reactive, toRefs } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
@@ -91,7 +91,7 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
         });

--- a/src/common/components/vertical-timeline/VerticalTimeline.vue
+++ b/src/common/components/vertical-timeline/VerticalTimeline.vue
@@ -34,6 +34,7 @@ import {
     PBadge,
 } from '@spaceone/design-system';
 import dayjs from 'dayjs';
+import type { SetupContext } from 'vue';
 import { defineComponent } from 'vue';
 
 
@@ -87,7 +88,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         /* Util */
         const getBadgeStyleType = (itemColor: string): string => {
             if (itemColor === 'GREEN') return 'green200';

--- a/src/common/modules/collection/collect-modal/CollectModal.vue
+++ b/src/common/modules/collection/collect-modal/CollectModal.vue
@@ -77,7 +77,6 @@ import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import { useProxyValue } from '@/common/composables/proxy-state';
-import type { CollectModalProps } from '@/common/modules/collection/collect-modal/type';
 
 export default {
     name: 'CollectModal',
@@ -105,7 +104,7 @@ export default {
             default: 'name',
         },
     },
-    setup(props: CollectModalProps, context: SetupContext) {
+    setup(props, context: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
 
         const state = reactive({

--- a/src/common/modules/collection/collect-modal/type.ts
+++ b/src/common/modules/collection/collect-modal/type.ts
@@ -1,9 +1,0 @@
-interface CollectModalType {
-    resources: any[];
-    idKey: string;
-    nameKey: string;
-}
-interface CollectModalSyncType {
-    visible: boolean;
-}
-export interface CollectModalProps extends CollectModalType, CollectModalSyncType {}

--- a/src/common/modules/custom-table/custom-field-modal/CustomFieldModal.vue
+++ b/src/common/modules/custom-table/custom-field-modal/CustomFieldModal.vue
@@ -84,7 +84,7 @@ import {
     PButton, PButtonModal, PCheckBox, PDataLoader, PSearch,
 } from '@spaceone/design-system';
 import type { DynamicField } from '@spaceone/design-system/dist/src/data-display/dynamic/dynamic-field/type/field-schema';
-import type Vue from 'vue';
+import type Vue, { SetupContext } from 'vue';
 import {
     computed, defineComponent, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
@@ -162,7 +162,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         let schema: any = {};
 

--- a/src/common/modules/custom-table/custom-field-modal/modules/ColumnItem.vue
+++ b/src/common/modules/custom-table/custom-field-modal/modules/ColumnItem.vue
@@ -21,7 +21,7 @@
 <script lang="ts">
 import { PCheckBox, PI } from '@spaceone/design-system';
 import type { DynamicField } from '@spaceone/design-system/dist/src/data-display/dynamic/dynamic-field/type/field-schema';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
@@ -62,7 +62,7 @@ export default defineComponent<Props>({
             default: '',
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             regex: computed(() => new RegExp(props.searchText || '', 'i')),
             proxySelectedKeys: useProxyValue('selectedKeys', props, emit),

--- a/src/common/modules/custom-table/custom-field-modal/modules/SelectTagColumns.vue
+++ b/src/common/modules/custom-table/custom-field-modal/modules/SelectTagColumns.vue
@@ -30,7 +30,7 @@ import {
     PAutocompleteSearch, PCheckBox, PTag,
 } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     computed, defineComponent, getCurrentInstance, reactive, toRefs,
 } from 'vue';
@@ -66,7 +66,7 @@ export default defineComponent<Props>({
             default: true,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
 
         const state = reactive({

--- a/src/common/modules/dropdown/service-provider-dropdown/ServiceProviderDropdown.vue
+++ b/src/common/modules/dropdown/service-provider-dropdown/ServiceProviderDropdown.vue
@@ -30,6 +30,7 @@
 
 <script lang="ts">
 import { PSelectDropdown, PLazyImg } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import { computed, reactive, toRefs } from 'vue';
 
 
@@ -58,7 +59,7 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxySelected: useProxyValue('selectedProvider', props, emit),
             providerList: computed(() => store.state.reference.provider.items),

--- a/src/common/modules/favorites/favorite-button/FavoriteButton.vue
+++ b/src/common/modules/favorites/favorite-button/FavoriteButton.vue
@@ -56,7 +56,7 @@ export default defineComponent<FavoriteButtonProps>({
             default: false,
         },
     },
-    setup(props: FavoriteButtonProps) {
+    setup(props) {
         const state = reactive({
             isLoading: computed(() => store.state.favorite.isLoading[props.favoriteType]),
             hasLoaded: computed(() => Array.isArray(state.favoriteItems)),

--- a/src/common/modules/favorites/favorite-list/FavoriteList.vue
+++ b/src/common/modules/favorites/favorite-list/FavoriteList.vue
@@ -57,7 +57,6 @@ import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
 
 import { referenceRouter } from '@/lib/reference/referenceRouter';
 
-import type { FavoriteListProps } from '@/common/modules/favorites/favorite-list/type';
 
 const LIMIT_COUNT = 5;
 export default {
@@ -77,7 +76,7 @@ export default {
             default: undefined,
         },
     },
-    setup(props: FavoriteListProps) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             displayItems: computed<FavoriteItem[]>(() => {

--- a/src/common/modules/favorites/favorite-list/type.ts
+++ b/src/common/modules/favorites/favorite-list/type.ts
@@ -1,7 +1,0 @@
-import type { FavoriteItem } from '@/store/modules/favorite/type';
-
-export interface FavoriteListProps {
-    items: FavoriteItem[];
-    loading?: boolean;
-    beforeRoute?: (item: FavoriteItem, event: MouseEvent) => Promise<void>|void;
-}

--- a/src/common/modules/monitoring/Monitoring.vue
+++ b/src/common/modules/monitoring/Monitoring.vue
@@ -116,7 +116,7 @@ import {
 } from '@/common/modules/monitoring/config';
 import type {
     AvailableResource,
-    Metric, MetricChartData, MonitoringProps, StatisticsType, StatItem,
+    Metric, MetricChartData, StatisticsType, StatItem,
 } from '@/common/modules/monitoring/type';
 
 
@@ -160,7 +160,7 @@ export default {
             default: undefined,
         },
     },
-    setup(props: MonitoringProps) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             showLoader: computed(() => props.loading || state.metricsLoading),

--- a/src/common/modules/navigations/gnb/modules/GNBSuggestionList.vue
+++ b/src/common/modules/navigations/gnb/modules/GNBSuggestionList.vue
@@ -68,7 +68,7 @@
 import {
     PContextMenu, PI, PLazyImg, PTooltip,
 } from '@spaceone/design-system';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     defineComponent, onUnmounted,
     reactive, toRefs, watch,
@@ -122,7 +122,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             contextMenuRef: null as null | any,
         });

--- a/src/common/modules/navigations/gnb/modules/GNBToolset.vue
+++ b/src/common/modules/navigations/gnb/modules/GNBToolset.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script lang="ts">
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
@@ -47,7 +48,7 @@ export default defineComponent({
             default: null,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             isDomainOwner: computed(() => store.getters['user/isDomainOwner']),
             timezone: computed(() => store.state.user.timezone),

--- a/src/common/modules/navigations/gnb/modules/SiteMap.vue
+++ b/src/common/modules/navigations/gnb/modules/SiteMap.vue
@@ -65,7 +65,7 @@
 
 import { PI } from '@spaceone/design-system';
 import vClickOutside from 'v-click-outside';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 
 import type { DisplayMenu } from '@/store/modules/display/type';
 
@@ -96,7 +96,7 @@ export default {
             default: () => ([]),
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const showSiteMap = () => {
             emit('update:visible', true);
         };

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
@@ -42,7 +42,7 @@
 import { PI } from '@spaceone/design-system';
 import { vOnClickOutside } from '@vueuse/components';
 import { defineComponent } from 'vue';
-import type { PropType, DirectiveFunction } from 'vue';
+import type { PropType, DirectiveFunction, SetupContext } from 'vue';
 
 import { SpaceRouter } from '@/router';
 
@@ -94,7 +94,7 @@ export default defineComponent({
             default: () => [],
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const handleMenu = () => {
             if (props.subMenuList?.length > 0) {
                 emit('open-menu', props.name);

--- a/src/common/modules/navigations/gnb/modules/gnb-noti/GNBNoti.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-noti/GNBNoti.vue
@@ -49,7 +49,7 @@ import { vOnClickOutside } from '@vueuse/components';
 import {
     computed, defineComponent, onMounted, onUnmounted, reactive, toRefs, watch,
 } from 'vue';
-import type { DirectiveFunction } from 'vue';
+import type { DirectiveFunction, SetupContext } from 'vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -84,7 +84,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             hasNotifications: computed(() => store.getters['display/hasUncheckedNotifications']),
             domainName: computed(() => store.state.domain.name),

--- a/src/common/modules/navigations/gnb/modules/gnb-noti/modules/GNBNotiItem.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-noti/modules/GNBNotiItem.vue
@@ -33,6 +33,7 @@ import {
     PI, PIconButton,
 } from '@spaceone/design-system';
 import dayjs from 'dayjs';
+import type { SetupContext } from 'vue';
 import {
     computed,
     defineComponent, reactive, toRefs,
@@ -88,7 +89,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             timezone: computed(() => store.state.user.timezone),
             occurred: computed(() => {

--- a/src/common/modules/navigations/gnb/modules/gnb-noti/modules/GNBNoticeTab.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-noti/modules/GNBNoticeTab.vue
@@ -57,6 +57,7 @@ import { ApiQueryHelper } from '@spaceone/console-core-lib/space-connector/helpe
 import {
     PDataLoader, PI, PDivider,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
     computed, reactive, toRefs,
 } from 'vue';
@@ -108,7 +109,7 @@ export default {
             default: 0,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             loading: true,
             timezone: computed(() => store.state.user.timezone),

--- a/src/common/modules/navigations/gnb/modules/gnb-noti/modules/GNBNotificationsTab.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-noti/modules/GNBNotificationsTab.vue
@@ -95,6 +95,7 @@ import {
 import { useInfiniteScroll } from '@vueuse/core';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
+import type { SetupContext } from 'vue';
 import {
     computed,
     onMounted, reactive, toRefs, watch,
@@ -151,7 +152,7 @@ export default {
             default: 0,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const { i18nDayjs } = useI18nDayjs();
         const state = reactive({
             loading: true,

--- a/src/common/modules/navigations/gnb/modules/gnb-profile/GNBProfile.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-profile/GNBProfile.vue
@@ -109,7 +109,7 @@ import {
     defineComponent, getCurrentInstance, reactive, toRefs,
 } from 'vue';
 import type Vue from 'vue';
-import type { DirectiveFunction } from 'vue';
+import type { DirectiveFunction, SetupContext } from 'vue';
 import type { Location } from 'vue-router';
 
 import { store } from '@/store';
@@ -145,7 +145,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
 
         const state = reactive({

--- a/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/GNBRecentFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/GNBRecentFavorite.vue
@@ -38,7 +38,7 @@ import { vOnClickOutside } from '@vueuse/components';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
-import type { DirectiveFunction } from 'vue';
+import type { DirectiveFunction, SetupContext } from 'vue';
 
 import { i18n } from '@/translations';
 
@@ -65,7 +65,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             tabs: computed(() => ([
                 { label: i18n.t('COMMON.GNB.RECENT.RECENT'), name: 'recent', keepAlive: true },

--- a/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBFavorite.vue
@@ -64,6 +64,7 @@
 import {
     PButton, PI, PIconButton, PDataLoader,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import { computed, reactive, toRefs } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
@@ -107,7 +108,7 @@ export default {
         PIconButton,
     },
     props: {},
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             loading: true,
             showAll: false,

--- a/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBRecent.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBRecent.vue
@@ -26,6 +26,7 @@
 
 import { PDataLoader } from '@spaceone/design-system';
 import { sortBy } from 'lodash';
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs, watch,
 } from 'vue';
@@ -74,7 +75,7 @@ export default defineComponent({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const storeState = reactive({
             menuItems: computed<DisplayMenu[]>(() => store.getters['display/allMenuList']),
             projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),

--- a/src/common/modules/navigations/gnb/modules/gnb-search/GNBSearch.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-search/GNBSearch.vue
@@ -61,7 +61,7 @@ import {
     computed, defineComponent, onMounted, onUnmounted,
     reactive, toRefs, watch,
 } from 'vue';
-import type { DirectiveFunction } from 'vue';
+import type { DirectiveFunction, SetupContext } from 'vue';
 
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
@@ -125,7 +125,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             isFocusOnInput: false,
             isFocusOnSuggestion: false,

--- a/src/common/modules/navigations/gnb/modules/gnb-search/modules/GNBSearchDropdown.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-search/modules/GNBSearchDropdown.vue
@@ -55,7 +55,7 @@
 
 <script lang="ts">
 import { PDataLoader } from '@spaceone/design-system';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     computed,
     defineComponent,
@@ -119,7 +119,7 @@ export default defineComponent<Props>({
             default: 15,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             menuTotalCount: computed<undefined|number>(() => props.items?.find(d => d.itemType === SUGGESTION_TYPE.MENU)?.totalCount),
             cloudServiceTotalCount: computed<undefined|number>(() => props.items?.find(d => d.itemType === SUGGESTION_TYPE.CLOUD_SERVICE)?.totalCount),

--- a/src/common/modules/portals/HandbookButton.vue
+++ b/src/common/modules/portals/HandbookButton.vue
@@ -40,6 +40,7 @@
 import {
     PI, PCheckBox, PTab,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
     computed, reactive, toRefs, watch, onMounted, onUnmounted, defineComponent,
 } from 'vue';
@@ -49,11 +50,6 @@ import { store } from '@/store';
 
 import { useProxyValue } from '@/common/composables/proxy-state';
 
-interface Props {
-    tabs?: any[];
-    activeTab?: string;
-    type: string;
-}
 
 export default defineComponent({
     name: 'HandbookButton',
@@ -74,7 +70,7 @@ export default defineComponent({
             required: true,
         },
     },
-    setup(props: Props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxyActiveTab: useProxyValue('activeTab', props, emit),
             storageKey: computed<string>(() => `handbook:${store.state.user.userId}:${props.type}`),

--- a/src/common/modules/project/ProjectChangeModal.vue
+++ b/src/common/modules/project/ProjectChangeModal.vue
@@ -44,19 +44,14 @@
 </template>
 
 <script lang="ts">
-/* eslint-disable no-await-in-loop */
 import { PButtonModal, PRadio } from '@spaceone/design-system';
 import { reactive, toRefs, watch } from 'vue';
+import type { SetupContext } from 'vue';
 import type Vue from 'vue';
 
 import { useProxyValue } from '@/common/composables/proxy-state';
 import ProjectSelectDropdown from '@/common/modules/project/ProjectSelectDropdown.vue';
 
-interface Props {
-    visible: boolean;
-    projectId: string;
-    loading: boolean;
-}
 
 export default {
     name: 'ProjectTreeModal',
@@ -79,7 +74,7 @@ export default {
             default: false,
         },
     },
-    setup(props: Props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             treeRef: null as null|Vue,
             selectedProjectIds: [] as string[],

--- a/src/common/modules/project/ProjectSelectDropdown.vue
+++ b/src/common/modules/project/ProjectSelectDropdown.vue
@@ -69,6 +69,7 @@ import {
     PCheckBox, PI, PRadio, PSearchDropdown, PSelectDropdown, PTag, PTree, PButton,
 } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
+import type { SetupContext } from 'vue';
 import {
     computed, reactive, toRefs, watch,
 } from 'vue';
@@ -128,7 +129,7 @@ export default {
             default: true,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             loading: true,
             visibleMenu: false,

--- a/src/common/modules/survey/SurveyModal.vue
+++ b/src/common/modules/survey/SurveyModal.vue
@@ -55,9 +55,9 @@
 import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import { PButtonModal, PSelectCard } from '@spaceone/design-system';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
-
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 
@@ -76,7 +76,9 @@ export default {
     },
     props: {
     },
-    setup(props, { root }) {
+    setup() {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             visible: false,
             isSessionExpired: computed(() => store.state.user.isSessionExpired),
@@ -149,7 +151,7 @@ export default {
                         answer2: state.selectedAnswer2,
                     },
                 });
-                showSuccessMessage('소중한 의견 감사합니다.', '', root);
+                showSuccessMessage('소중한 의견 감사합니다.', '', vm);
             } catch (e) {
                 ErrorHandler.handleError(e);
             }

--- a/src/common/modules/tags/tags-panel/TagsPanel.vue
+++ b/src/common/modules/tags/tags-panel/TagsPanel.vue
@@ -46,11 +46,6 @@ import type { Vue } from 'vue/types/vue';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import TagsOverlay from '@/common/modules/tags/tags-panel/modules/TagsOverlay.vue';
 
-interface Props {
-    resourceKey: string;
-    resourceId: string;
-    resourceType: string;
-}
 export default {
     name: 'TagsPanel',
     components: {
@@ -80,7 +75,7 @@ export default {
             default: false,
         },
     },
-    setup(props: Props) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const apiKeys = computed(() => props.resourceType.split('.').map(d => camelCase(d)));
         const api = computed(() => get(SpaceConnector.client, apiKeys.value));

--- a/src/common/modules/tags/tags-panel/modules/TagsOverlay.vue
+++ b/src/common/modules/tags/tags-panel/modules/TagsOverlay.vue
@@ -53,6 +53,7 @@ import {
 import {
     camelCase, isEmpty, get,
 } from 'lodash';
+import type { SetupContext } from 'vue';
 import {
     reactive, toRefs, computed, onMounted,
 } from 'vue';
@@ -65,12 +66,6 @@ import TagsInputGroup from '@/common/components/forms/tags-input-group/TagsInput
 import type { Tag } from '@/common/components/forms/tags-input-group/type';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
-interface Props {
-    tags: Tag;
-    resourceKey: string;
-    resourceId: string;
-    resourceType: string;
-}
 
 export default {
     name: 'TagsOverlay',
@@ -101,7 +96,7 @@ export default {
             required: true,
         },
     },
-    setup(props: Props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             loading: false,
             showHeader: computed(() => state.newTags.length > 0),

--- a/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
+++ b/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
@@ -40,6 +40,7 @@ import {
     PStatus, PTableCheckModal,
 } from '@spaceone/design-system';
 import { map } from 'lodash';
+import type { SetupContext } from 'vue';
 import {
     computed, getCurrentInstance, reactive, toRefs,
 } from 'vue';
@@ -77,7 +78,7 @@ export default {
             default: '',
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             fields: computed(() => ([
@@ -105,7 +106,7 @@ export default {
             try {
                 await SpaceConnector.client.identity.user.delete(getUsersParam(items));
                 await administrationStore.dispatch('user/selectIndex', []);
-                showSuccessMessage(vm.$tc('IDENTITY.USER.MAIN.ALT_S_DELETE_USER', state.selectedIndex.length), '', root);
+                showSuccessMessage(vm.$tc('IDENTITY.USER.MAIN.ALT_S_DELETE_USER', state.selectedIndex.length), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, vm.$tc('IDENTITY.USER.MAIN.ALT_E_DELETE_USER', state.selectedIndex.length));
             } finally {
@@ -116,7 +117,7 @@ export default {
         const enableUser = async (items) => {
             try {
                 await SpaceConnector.client.identity.user.enable(getUsersParam(items));
-                showSuccessMessage(vm.$tc('IDENTITY.USER.MAIN.ALT_S_ENABLE', state.selectedIndex.length), '', root);
+                showSuccessMessage(vm.$tc('IDENTITY.USER.MAIN.ALT_S_ENABLE', state.selectedIndex.length), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, vm.$tc('IDENTITY.USER.MAIN.ALT_E_ENABLE', state.selectedIndex.length));
             } finally {
@@ -127,7 +128,7 @@ export default {
         const disableUser = async (items) => {
             try {
                 await SpaceConnector.client.identity.user.disable(getUsersParam(items));
-                showSuccessMessage(vm.$tc('IDENTITY.USER.MAIN.ALT_S_DISABLE', state.selectedIndex.length), '', root);
+                showSuccessMessage(vm.$tc('IDENTITY.USER.MAIN.ALT_S_DISABLE', state.selectedIndex.length), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, vm.$tc('IDENTITY.USER.MAIN.ALT_E_DISABLE', state.selectedIndex.length));
             } finally {

--- a/src/services/alert-manager/alert/alert-detail/AlertDetailPage.vue
+++ b/src/services/alert-manager/alert/alert-detail/AlertDetailPage.vue
@@ -121,7 +121,7 @@ export default {
             default: null,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
 
         const state = reactive({
@@ -146,7 +146,7 @@ export default {
                 await SpaceConnector.client.monitoring.alert.delete({
                     alerts: [props.id],
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.ALT_S_DELETE_ALERT'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.ALT_S_DELETE_ALERT'), '', vm);
                 await vm.$router.push({ name: ALERT_MANAGER_ROUTE.ALERT._NAME });
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.DETAIL.ALT_E_DELETE_ALERT'));

--- a/src/services/alert-manager/alert/alert-detail/modules/AlertStatusUpdate.vue
+++ b/src/services/alert-manager/alert/alert-detail/modules/AlertStatusUpdate.vue
@@ -33,8 +33,10 @@
 import {
     PButtonModal, PPaneLayout, PTextarea, PFieldGroup, PEmpty,
 } from '@spaceone/design-system';
-import { computed, reactive, toRefs } from 'vue';
-
+import {
+    computed, getCurrentInstance, reactive, toRefs,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -67,7 +69,9 @@ export default {
             default: false,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             modalVisible: false,
             status: computed(() => alertManagerStore.state.alert.alertData?.status_message),
@@ -88,7 +92,7 @@ export default {
                     },
                     alertId: props.id,
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.STATUS_UPDATE.ALT_S_UPDATE_STATUS'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.STATUS_UPDATE.ALT_S_UPDATE_STATUS'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.DETAIL.STATUS_UPDATE.ALT_E_UPDATE_STATUS'));
             } finally {

--- a/src/services/alert-manager/alert/alert-detail/modules/AlertTitleEditModal.vue
+++ b/src/services/alert-manager/alert/alert-detail/modules/AlertTitleEditModal.vue
@@ -27,10 +27,11 @@
 
 <script lang="ts">
 import { PButtonModal, PFieldGroup, PTextInput } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs,
+    computed, getCurrentInstance, reactive, toRefs,
 } from 'vue';
-
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -71,7 +72,9 @@ export default {
             default: null,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             loading: true,
             proxyVisible: useProxyValue('visible', props, emit),
@@ -97,7 +100,7 @@ export default {
                     },
                     alertId: props.alertId,
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_S_UPDATE_TITLE'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_S_UPDATE_TITLE'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_E_UPDATE_TITLE'));
             } finally {

--- a/src/services/alert-manager/alert/alert-detail/modules/alert-summary/AlertSummary.vue
+++ b/src/services/alert-manager/alert/alert-detail/modules/alert-summary/AlertSummary.vue
@@ -70,8 +70,9 @@ import {
 } from '@spaceone/design-system';
 import dayjs from 'dayjs';
 import {
-    computed, reactive, toRefs,
+    computed, getCurrentInstance, reactive, toRefs,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -85,7 +86,6 @@ import {
     ALERT_STATE, ALERT_URGENCY,
 } from '@/services/alert-manager/lib/config';
 import { alertManagerStore } from '@/services/alert-manager/store';
-import type { AlertDataModel } from '@/services/alert-manager/type';
 
 
 // interface HeaderState {
@@ -96,12 +96,6 @@ import type { AlertDataModel } from '@/services/alert-manager/type';
 //     alertStateList: MenuItem[];
 //     alertUrgencyList: MenuItem[];
 // }
-
-interface PropsType {
-    id: string;
-    alertData: AlertDataModel;
-    manageDisabled: boolean;
-}
 
 const calculateTime = (time) => {
     const today = dayjs().toISOString();
@@ -138,7 +132,9 @@ export default {
             default: false,
         },
     },
-    setup(props: PropsType, { root }) {
+    setup(props) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             alertInfo: computed(() => alertManagerStore.state.alert.alertData),
             alertState: computed(() => state.alertInfo?.state),
@@ -168,7 +164,7 @@ export default {
                     },
                     alertId: props.id,
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_S_UPDATE_STATE'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_S_UPDATE_STATE'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_E_UPDATE_URGENCY'));
             }
@@ -182,7 +178,7 @@ export default {
                     },
                     alertId: props.id,
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_S_UPDATE_URGENCY'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_S_UPDATE_URGENCY'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_E_UPDATE_URGENCY'));
             }

--- a/src/services/alert-manager/alert/alert-detail/modules/alert-summary/modules/AlertAssignModal.vue
+++ b/src/services/alert-manager/alert/alert-detail/modules/alert-summary/modules/AlertAssignModal.vue
@@ -37,9 +37,11 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import { ApiQueryHelper } from '@spaceone/console-core-lib/space-connector/helper';
 import { PButtonModal, PToolboxTable } from '@spaceone/design-system';
 import { uniqBy } from 'lodash';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs,
+    computed, getCurrentInstance, reactive, toRefs,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -74,7 +76,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             modalLoading: false,
             proxyVisible: useProxyValue('visible', props, emit),
@@ -99,7 +103,7 @@ export default {
                     },
                     alertId: props.alertId,
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_S_ASSIGN_MEMBER'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_S_ASSIGN_MEMBER'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.DETAIL.HEADER.ALT_E_ASSIGN_MEMBER'));
             } finally {

--- a/src/services/alert-manager/alert/modules/AlertAcknowledgeModal.vue
+++ b/src/services/alert-manager/alert/modules/AlertAcknowledgeModal.vue
@@ -22,7 +22,11 @@
 
 import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import { PButtonModal, PCheckBox } from '@spaceone/design-system';
-import { reactive, toRefs, watch } from 'vue';
+import type { SetupContext } from 'vue';
+import {
+    getCurrentInstance, reactive, toRefs, watch,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -52,7 +56,9 @@ export default {
             default: () => [],
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             isAssignedToMe: true,
@@ -76,7 +82,7 @@ export default {
             try {
                 await updateToAcknowledge();
                 emit('confirm');
-                showSuccessMessage(i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_S_STATE_CHANGED'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_S_STATE_CHANGED'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_E_STATE_CHANGED'));
             } finally {

--- a/src/services/alert-manager/alert/modules/AlertActions.vue
+++ b/src/services/alert-manager/alert/modules/AlertActions.vue
@@ -79,7 +79,11 @@ import {
     PButton, PSelectDropdown, PTableCheckModal, PI, PBadge,
 } from '@spaceone/design-system';
 import dayjs from 'dayjs';
-import { computed, reactive, toRefs } from 'vue';
+import type { SetupContext } from 'vue';
+import {
+    computed, getCurrentInstance, reactive, toRefs,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -136,7 +140,9 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             timezone: computed(() => store.state.user.timezone),
             projects: computed(() => store.getters['reference/projectItems']),
@@ -185,7 +191,7 @@ export default {
                 await SpaceConnector.client.monitoring.alert.delete({
                     alerts: props.selectedItems.map(d => d.alert_id),
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_S_DELETE'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_S_DELETE'), '', vm);
                 state.visibleDeleteModal = false;
                 emit('refresh');
                 await store.dispatch('service/projectDetail/getAlertCounts');

--- a/src/services/alert-manager/alert/modules/AlertFormModal.vue
+++ b/src/services/alert-manager/alert/modules/AlertFormModal.vue
@@ -60,9 +60,11 @@ import {
     PAnchor, PButton,
     PButtonModal, PFieldGroup, PRadio, PTextarea, PTextInput,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -98,7 +100,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             loading: false,
@@ -155,7 +159,7 @@ export default {
                     project_id: state.selectedProjectId,
                     description: state.description,
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_S_CREATE'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_S_CREATE'), '', vm);
                 emit('confirm');
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_E_CREATE'));

--- a/src/services/alert-manager/alert/modules/AlertResolveModal.vue
+++ b/src/services/alert-manager/alert/modules/AlertResolveModal.vue
@@ -25,9 +25,12 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PButtonModal, PTextarea, PFieldGroup,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
+    getCurrentInstance,
     reactive, toRefs, watch,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -57,7 +60,9 @@ export default {
             default: () => [],
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             noteInput: '',
@@ -82,7 +87,7 @@ export default {
             try {
                 await updateToResolve();
                 emit('confirm');
-                showSuccessMessage(i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_S_STATE_CHANGED'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_S_STATE_CHANGED'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.ALERT_LIST.ALT_E_STATE_CHANGED'));
             } finally {

--- a/src/services/alert-manager/escalation-policy/modules/EscalationPolicyFormModal.vue
+++ b/src/services/alert-manager/escalation-policy/modules/EscalationPolicyFormModal.vue
@@ -27,9 +27,12 @@
 
 import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import { PButtonModal } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
+    getCurrentInstance,
     reactive, toRefs,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -63,7 +66,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             inputModel: {} as EscalationPolicyFormModel,
@@ -74,7 +79,7 @@ export default {
         const createEscalationPolicy = async () => {
             try {
                 await SpaceConnector.client.monitoring.escalationPolicy.create(state.inputModel);
-                showSuccessMessage(i18n.t('MONITORING.ALERT.ESCALATION_POLICY.FORM.ALT_S_CREATE_POLICY'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.ESCALATION_POLICY.FORM.ALT_S_CREATE_POLICY'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.ESCALATION_POLICY.FORM.ALT_E_CREATE_POLICY'));
             } finally {
@@ -90,7 +95,7 @@ export default {
                     repeat_count: state.inputModel.repeat_count,
                     finish_condition: state.inputModel.finish_condition,
                 });
-                showSuccessMessage(i18n.t('MONITORING.ALERT.ESCALATION_POLICY.FORM.ALT_S_UPDATE_POLICY'), '', root);
+                showSuccessMessage(i18n.t('MONITORING.ALERT.ESCALATION_POLICY.FORM.ALT_S_UPDATE_POLICY'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('MONITORING.ALERT.ESCALATION_POLICY.FORM.ALT_E_UPDATE_POLICY'));
             } finally {

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/CloudServiceDetailPage.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/CloudServiceDetailPage.vue
@@ -239,7 +239,7 @@ export default {
             default: false,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const queryHelper = new QueryHelper();
         /* Sidebar */
@@ -515,7 +515,7 @@ export default {
                     ...checkTableModalState.params,
                     cloud_services: tableState.selectedItems.map(item => item.cloud_service_id),
                 });
-                showSuccessMessage(i18n.t('INVENTORY.CLOUD_SERVICE.MAIN.ALT_S_CHECK_MODAL', { action: checkTableModalState.title }), '', root);
+                showSuccessMessage(i18n.t('INVENTORY.CLOUD_SERVICE.MAIN.ALT_S_CHECK_MODAL', { action: checkTableModalState.title }), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('INVENTORY.CLOUD_SERVICE.MAIN.ALT_E_CHECK_MODAL', { action: checkTableModalState.title }));
             } finally {

--- a/src/services/asset-inventory/collector/create-collector/CreateCollectorPage.vue
+++ b/src/services/asset-inventory/collector/create-collector/CreateCollectorPage.vue
@@ -84,14 +84,14 @@ export default {
         PLazyImg,
         PToggleButton,
     },
-    setup(props, { root }) {
+    setup() {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             loading: true,
             plugin: {},
             imageUrl: computed(() => state.plugin?.tags?.icon),
             provider: computed(() => get(state.plugin, 'provider', '')),
-            pluginId: get(root, '$route.params.pluginId', ''),
+            pluginId: get(vm, '$route.params.pluginId', ''),
             tags: {},
             supportedSchema: [],
             //

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountBaseInformation.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountBaseInformation.vue
@@ -67,7 +67,7 @@ import {
     PPanelTop,
     PTextInput,
 } from '@spaceone/design-system';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, watch,
 } from 'vue';
@@ -122,7 +122,7 @@ export default defineComponent<Props>({
             default: undefined,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const {
             forms: { serviceAccountName },
             invalidState,

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountProviderList.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountProviderList.vue
@@ -16,6 +16,7 @@
 <script lang="ts">
 
 import { PLazyImg } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import { defineComponent, reactive, toRefs } from 'vue';
 
 
@@ -36,7 +37,7 @@ export default defineComponent({
             default: 'atlassian',
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxySelectedProvider: useProxyValue('selectedProvider', props, emit),
         });

--- a/src/services/asset-inventory/service-account/service-account-add/ServiceAccountAddPage.vue
+++ b/src/services/asset-inventory/service-account/service-account-add/ServiceAccountAddPage.vue
@@ -68,7 +68,10 @@ import {
     PButton, PLazyImg, PMarkdown, PPageTitle,
 } from '@spaceone/design-system';
 import { get } from 'lodash';
-import { computed, reactive, toRefs } from 'vue';
+import {
+    computed, getCurrentInstance, reactive, toRefs,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
@@ -110,7 +113,9 @@ export default {
             default: null,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             providerLoading: true,
             providerData: {} as ProviderModel,
@@ -205,7 +210,7 @@ export default {
                     await createSecretWithJson(json);
                 } else if (formState.credentialForm.activeDataType === 'input') await createSecretWithForm();
 
-                showSuccessMessage(i18n.t('IDENTITY.SERVICE_ACCOUNT.ADD.ALT_S_CREATE_ACCOUNT_TITLE'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.SERVICE_ACCOUNT.ADD.ALT_S_CREATE_ACCOUNT_TITLE'), '', vm);
                 isSucceed = true;
             } catch (e) {
                 isSucceed = false;

--- a/src/services/auth/sign-in/external/GOOGLE_OAUTH2/template/GOOGLE_OAUTH2.vue
+++ b/src/services/auth/sign-in/external/GOOGLE_OAUTH2/template/GOOGLE_OAUTH2.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script lang="ts">
+import type { SetupContext } from 'vue';
 import {
     defineComponent, onMounted,
 } from 'vue';
@@ -15,7 +16,7 @@ import { loadAuth } from '@/services/auth/authenticator/loader';
 
 export default defineComponent({
     name: 'GoogleSignIn',
-    setup(props, context) {
+    setup(props, context: SetupContext) {
         const onSignIn = () => {
             context.emit('sign-in');
         };

--- a/src/services/auth/sign-in/local/template/ID_PW.vue
+++ b/src/services/auth/sign-in/local/template/ID_PW.vue
@@ -42,6 +42,7 @@
 <script lang="ts">
 /* eslint-disable camelcase */
 import { PButton, PTextInput, PFieldGroup } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
     getCurrentInstance,
     reactive,
@@ -71,7 +72,7 @@ export default defineComponent({
             default: false,
         },
     },
-    setup(props, context) {
+    setup(props, context: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             userId: '' as string | undefined,

--- a/src/services/cost-explorer/budget/modules/BudgetCostTypeSelect.vue
+++ b/src/services/cost-explorer/budget/modules/BudgetCostTypeSelect.vue
@@ -42,7 +42,7 @@ import {
     defineComponent,
     reactive, toRefs, watch,
 } from 'vue';
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
 import { store } from '@/store';
@@ -90,7 +90,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const {
             forms: {
                 selectedCostType, selectedResources,

--- a/src/services/cost-explorer/budget/modules/BudgetTargetSelect.vue
+++ b/src/services/cost-explorer/budget/modules/BudgetTargetSelect.vue
@@ -19,6 +19,7 @@
 
 import { PFieldGroup } from '@spaceone/design-system';
 import { debounce } from 'lodash';
+import type { SetupContext } from 'vue';
 import { defineComponent, watch } from 'vue';
 
 import { i18n } from '@/translations';
@@ -52,7 +53,7 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const {
             forms: {
                 selectedTargets,

--- a/src/services/cost-explorer/budget/modules/budget-form/BudgetForm.vue
+++ b/src/services/cost-explorer/budget/modules/budget-form/BudgetForm.vue
@@ -27,9 +27,10 @@
 import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import { PButton } from '@spaceone/design-system';
 import {
-    computed,
+    computed, getCurrentInstance,
     reactive, toRefs,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { SpaceRouter } from '@/router';
 import { i18n } from '@/translations';
@@ -58,7 +59,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { root }) {
+    setup() {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             baseInfo: {} as BudgetBaseInfo,
             isBaseInfoValid: false,
@@ -78,7 +81,7 @@ export default {
                     ...state.amountPlanInfo,
                 });
 
-                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.BUDGET.ALT_S_CREATE_BUDGET'), '', root);
+                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.BUDGET.ALT_S_CREATE_BUDGET'), '', vm);
                 SpaceRouter.router.push({
                     name: COST_EXPLORER_ROUTE.BUDGET._NAME,
                 });

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
@@ -73,11 +73,11 @@ import {
 import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
 import dayjs from 'dayjs';
 import {
-    computed,
+    computed, getCurrentInstance,
     reactive, toRefs, watch,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
-
+import type { Vue } from 'vue/types/vue';
 
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
@@ -122,7 +122,9 @@ export default {
             default: false,
         },
     },
-    setup(props, { root }) {
+    setup() {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             defaultTitle: computed<TranslateResult>(() => i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.COST_ANALYSIS')),
             costQueryList: computed<CostQuerySetModel[]>(() => costExplorerStore.state.costAnalysis.costQueryList),
@@ -238,7 +240,7 @@ export default {
                     },
                 });
                 await costExplorerStore.dispatch('costAnalysis/listCostQueryList');
-                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_S_SAVED_QUERY'), '', root);
+                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_S_SAVED_QUERY'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_E_SAVED_QUERY'));
             }
@@ -249,7 +251,7 @@ export default {
             try {
                 await SpaceConnector.client.costAnalysis.costQuerySet.delete({ cost_query_set_id: state.itemIdForDeleteQuery });
                 await costExplorerStore.dispatch('costAnalysis/listCostQueryList');
-                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_S_DELETE_QUERY'), '', root);
+                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_S_DELETE_QUERY'), '', vm);
                 if (state.selectedQueryId === state.itemIdForDeleteQuery) {
                     await SpaceRouter.router.push({ name: COST_EXPLORER_ROUTE.COST_ANALYSIS._NAME });
                     setQueryOptions();

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisSaveQueryFormModal.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisSaveQueryFormModal.vue
@@ -29,10 +29,11 @@
 import {
     PButtonModal, PFieldGroup, PTextInput,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
-
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -46,15 +47,7 @@ import {
     REQUEST_TYPE,
 } from '@/services/cost-explorer/cost-analysis/lib/config';
 import { costExplorerStore } from '@/services/cost-explorer/store';
-import type { CostQuerySetModel } from '@/services/cost-explorer/type';
 
-
-interface Props {
-    visible: boolean;
-    headerTitle: string;
-    selectedQuery: CostQuerySetModel;
-    requestType: RequestType;
-}
 
 export default {
     name: 'CostAnalysisSaveQueryFormModal',
@@ -84,7 +77,9 @@ export default {
             },
         },
     },
-    setup(props: Props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const formState = reactive({
             queryName: undefined as undefined | string,
         });
@@ -108,7 +103,7 @@ export default {
         const saveQuery = async () => {
             try {
                 const updatedQuery = await costExplorerStore.dispatch('costAnalysis/saveQuery', formState.queryName);
-                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_S_SAVED_QUERY'), '', root);
+                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_S_SAVED_QUERY'), '', vm);
                 emit('confirm', { updatedQuery, requestType: REQUEST_TYPE.SAVE });
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_E_SAVED_QUERY'));
@@ -121,7 +116,7 @@ export default {
                     selectedQuery: props.selectedQuery, formState,
                 });
                 if (!updatedQuery) return;
-                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_S_EDITED_QUERY'), '', root);
+                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_S_EDITED_QUERY'), '', vm);
                 emit('confirm', { updatedQuery, requestType: REQUEST_TYPE.EDIT });
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_E_EDITED_QUERY'));

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisSetQueryModal.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisSetQueryModal.vue
@@ -56,6 +56,7 @@ import {
     PToggleButton,
 } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
+import type { SetupContext } from 'vue';
 import {
     computed, reactive, toRefs, watch,
 } from 'vue';
@@ -87,7 +88,7 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             granularity: '' as Granularity,

--- a/src/services/cost-explorer/cost-dashboard/modules/CostDashboardFilter.vue
+++ b/src/services/cost-explorer/cost-dashboard/modules/CostDashboardFilter.vue
@@ -32,7 +32,11 @@
 import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import { PButton, PIconButton } from '@spaceone/design-system';
 import { isEmpty } from 'lodash';
-import { computed, reactive, toRefs } from 'vue';
+import type { SetupContext } from 'vue';
+import {
+    computed, getCurrentInstance, reactive, toRefs,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -49,13 +53,6 @@ import { FILTER, FILTER_ITEM_MAP } from '@/services/cost-explorer/lib/config';
 import SetFilterModal from '@/services/cost-explorer/modules/SetFilterModal.vue';
 import type { CostQueryFilters } from '@/services/cost-explorer/type';
 
-
-interface Props {
-    dashboardId: string;
-    filters: CostQueryFilters;
-    printMode: boolean;
-    manageDisabled: boolean;
-}
 
 export default {
     name: 'CostDashboardFilter',
@@ -84,7 +81,9 @@ export default {
             default: false,
         },
     },
-    setup(props: Props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyFilters: useProxyValue<CostQueryFilters>('filters', props, emit),
             filterLabel: computed(() => {
@@ -112,7 +111,7 @@ export default {
                     default_filter: filters,
                 });
                 state.proxyFilters = filters;
-                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.MAIN.ALT_S_EDIT_FILTER'), '', root);
+                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.MAIN.ALT_S_EDIT_FILTER'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('BILLING.COST_MANAGEMENT.MAIN.ALT_E_EDIT_FILTER'));
             }
@@ -125,7 +124,7 @@ export default {
                     default_filter: filters,
                 });
                 state.proxyFilters = filters;
-                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.MAIN.ALT_S_EDIT_FILTER'), '', root);
+                showSuccessMessage(i18n.t('BILLING.COST_MANAGEMENT.MAIN.ALT_S_EDIT_FILTER'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('BILLING.COST_MANAGEMENT.MAIN.ALT_E_EDIT_FILTER'));
             }

--- a/src/services/my-page/my-account/user-account/UserAccountPage.vue
+++ b/src/services/my-page/my-account/user-account/UserAccountPage.vue
@@ -103,9 +103,10 @@ import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-m
 import type { SearchDropdownMenuItem } from '@spaceone/design-system/dist/src/inputs/dropdown/search-dropdown/type';
 import { map } from 'lodash';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -137,7 +138,9 @@ export default {
             default: '',
         },
     },
-    setup(props, { root }) {
+    setup() {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             userId: computed(() => store.state.user.userId),
             userRole: computed(() => {
@@ -210,7 +213,7 @@ export default {
         const updateUser = async (userParam) => {
             try {
                 await store.dispatch('user/setUser', userParam);
-                showSuccessMessage(i18n.t('IDENTITY.USER.MAIN.ALT_S_UPDATE_USER'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.MAIN.ALT_S_UPDATE_USER'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.MAIN.ALT_E_UPDATE_USER'));
             }

--- a/src/services/notification/modules/AddNotificationSchedule.vue
+++ b/src/services/notification/modules/AddNotificationSchedule.vue
@@ -50,6 +50,7 @@ import {
     PRadio, PSelectButton, PSelectDropdown,
 } from '@spaceone/design-system';
 import { range } from 'lodash';
+import type { SetupContext } from 'vue';
 import {
     computed, getCurrentInstance, reactive, toRefs,
 } from 'vue';
@@ -89,7 +90,7 @@ export default {
             default: null,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const timezoneForFormatter = computed(() => store.state.user.timezone).value;
         const {

--- a/src/services/notification/modules/AddNotificationTopic.vue
+++ b/src/services/notification/modules/AddNotificationTopic.vue
@@ -29,6 +29,7 @@
 
 <script lang="ts">
 import { PRadio, PCheckBox } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
     computed, getCurrentInstance, reactive, toRefs,
 } from 'vue';
@@ -56,7 +57,7 @@ export default {
             default: null,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             topicModeList: computed(() => [{

--- a/src/services/notification/modules/notification-channel-item/NotificationChannelItem.vue
+++ b/src/services/notification/modules/notification-channel-item/NotificationChannelItem.vue
@@ -59,9 +59,12 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PDivider, PIconButton, PPaneLayout, PToggleButton,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
+    getCurrentInstance,
     reactive, toRefs,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -125,7 +128,9 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             isActivated: props.channelData?.state === STATE_TYPE.ENABLED,
             userChannelId: props.channelData?.user_channel_id,
@@ -143,7 +148,7 @@ export default {
                     project_channel_id: state.projectChannelId,
                 });
                 state.isActivated = true;
-                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_ENABLE_PROJECT_CHANNEL'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_ENABLE_PROJECT_CHANNEL'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.NOTIFICATION.ALT_E_ENABLE_PROJECT_CHANNEL'));
             }
@@ -155,7 +160,7 @@ export default {
                     user_channel_id: state.userChannelId,
                 });
                 state.isActivated = true;
-                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_ENABLE_USER_CHANNEL'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_ENABLE_USER_CHANNEL'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.NOTIFICATION.ALT_E_ENABLE_USER_CHANNEL'));
             }
@@ -172,7 +177,7 @@ export default {
                     project_channel_id: state.projectChannelId,
                 });
                 state.isActivated = false;
-                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_DISABLE_PROJECT_CHANNEL'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_DISABLE_PROJECT_CHANNEL'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.NOTIFICATION.ALT_E_DISABLE_PROJECT_CHANNEL'));
             }
@@ -184,7 +189,7 @@ export default {
                     user_channel_id: state.userChannelId,
                 });
                 state.isActivated = false;
-                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_DISABLE_USER_CHANNEL'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_DISABLE_USER_CHANNEL'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.NOTIFICATION.ALT_E_DISABLE_USER_CHANNEL'));
             }
@@ -214,7 +219,7 @@ export default {
                 await SpaceConnector.client.notification.projectChannel.delete({
                     project_channel_id: state.projectChannelId,
                 });
-                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_DELETE_PROJECT_CHANNEL'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_DELETE_PROJECT_CHANNEL'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.NOTIFICATION.ALT_E_DELETE_PROJECT_CHANNEL'));
             } finally {
@@ -228,7 +233,7 @@ export default {
                 await SpaceConnector.client.notification.userChannel.delete({
                     user_channel_id: state.userChannelId,
                 });
-                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_DELETE_USER_CHANNEL'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.ALT_S_DELETE_USER_CHANNEL'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.NOTIFICATION.ALT_E_DELETE_USER_CHANNEL'));
             } finally {

--- a/src/services/notification/modules/notification-channel-item/modules/NotificationChannelItemSchedule.vue
+++ b/src/services/notification/modules/notification-channel-item/modules/NotificationChannelItemSchedule.vue
@@ -45,8 +45,11 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PButton, PI,
 } from '@spaceone/design-system';
-import { computed, reactive, toRefs } from 'vue';
-
+import type { SetupContext } from 'vue';
+import {
+    computed, getCurrentInstance, reactive, toRefs,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -86,7 +89,9 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const timezoneForFormatter = computed(() => store.state.user.timezone).value;
         const state = reactive({
             scheduleModeForEdit: props.channelData?.is_scheduled,
@@ -121,7 +126,7 @@ export default {
                     is_scheduled: state.scheduleModeForEdit,
                     schedule: state.scheduleForEdit,
                 });
-                showSuccessMessage(i18n.t('PLUGIN.COLLECTOR.MAIN.ALT_S_UPDATE_SCHEDULE_TITLE'), '', root);
+                showSuccessMessage(i18n.t('PLUGIN.COLLECTOR.MAIN.ALT_S_UPDATE_SCHEDULE_TITLE'), '', vm);
                 notificationItemState.isEditMode = false;
                 emit('edit', undefined);
             } catch (e) {
@@ -135,7 +140,7 @@ export default {
                     is_scheduled: state.scheduleModeForEdit,
                     schedule: state.scheduleForEdit,
                 });
-                showSuccessMessage(i18n.t('PLUGIN.COLLECTOR.MAIN.ALT_S_UPDATE_SCHEDULE_TITLE'), '', root);
+                showSuccessMessage(i18n.t('PLUGIN.COLLECTOR.MAIN.ALT_S_UPDATE_SCHEDULE_TITLE'), '', vm);
                 notificationItemState.isEditMode = false;
                 emit('edit', undefined);
             } catch (e) {

--- a/src/services/notification/modules/notification-channel-item/modules/NotificationChannelItemTopic.vue
+++ b/src/services/notification/modules/notification-channel-item/modules/NotificationChannelItemTopic.vue
@@ -50,7 +50,9 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PBadge, PButton, PI,
 } from '@spaceone/design-system';
-import { reactive, toRefs } from 'vue';
+import type { SetupContext } from 'vue';
+import { getCurrentInstance, reactive, toRefs } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -89,7 +91,9 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             topicModeForEdit: undefined,
             topicForEdit: props.channelData?.subscriptions,
@@ -116,7 +120,7 @@ export default {
                     is_subscribe: state.topicModeForEdit,
                     subscriptions: state.topicForEdit,
                 });
-                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.FORM.ALT_S_UPDATE_TOPIC'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.FORM.ALT_S_UPDATE_TOPIC'), '', vm);
                 notificationItemState.isEditMode = false;
                 emit('edit', undefined);
             } catch (e) {
@@ -130,7 +134,7 @@ export default {
                     is_subscribe: state.topicModeForEdit,
                     subscriptions: state.topicForEdit,
                 });
-                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.FORM.ALT_S_UPDATE_TOPIC'), '', root);
+                showSuccessMessage(i18n.t('IDENTITY.USER.NOTIFICATION.FORM.ALT_S_UPDATE_TOPIC'), '', vm);
                 notificationItemState.isEditMode = false;
                 emit('edit', undefined);
             } catch (e) {

--- a/src/services/notification/notification-add/modules/AddNotificationData.vue
+++ b/src/services/notification/notification-add/modules/AddNotificationData.vue
@@ -38,6 +38,7 @@ import { ApiQueryHelper } from '@spaceone/console-core-lib/space-connector/helpe
 import {
     PFieldGroup, PTextInput, PJsonSchemaForm,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
     computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
@@ -88,7 +89,7 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const protocol = vm.$route.params.protocol;
 

--- a/src/services/project/modules/ProjectGroupFormModal.vue
+++ b/src/services/project/modules/ProjectGroupFormModal.vue
@@ -32,9 +32,10 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import { ApiQueryHelper } from '@spaceone/console-core-lib/space-connector/helper';
 import { PButtonModal, PFieldGroup, PTextInput } from '@spaceone/design-system';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
 import VueI18n from 'vue-i18n';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -59,7 +60,9 @@ export default {
             },
         },
     },
-    setup(props, { root }) {
+    setup() {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyVisible: computed({
                 get() { return store.state.service.project.projectGroupFormVisible; },
@@ -115,7 +118,7 @@ export default {
                 await store.dispatch('service/project/createProjectGroup', item);
                 await store.dispatch('reference/projectGroup/load');
                 await store.commit('service/project/setShouldUpdateProjectList', true);
-                showSuccessMessage(i18n.t('PROJECT.LANDING.ALT_S_CREATE_PROJECT_GROUP'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.LANDING.ALT_S_CREATE_PROJECT_GROUP'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.LANDING.ALT_E_CREATE_PROJECT_GROUP'));
             }
@@ -124,7 +127,7 @@ export default {
         const updateProjectGroup = async (item) => {
             try {
                 await store.dispatch('service/project/updateProjectGroup', item);
-                showSuccessMessage(i18n.t('PROJECT.LANDING.ALT_S_UPDATE_PROJECT_GROUP'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.LANDING.ALT_S_UPDATE_PROJECT_GROUP'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.LANDING.ALT_E_UPDATE_PROJECT_GROUP'));
             }

--- a/src/services/project/project-detail/ProjectDetailPage.vue
+++ b/src/services/project/project-detail/ProjectDetailPage.vue
@@ -164,7 +164,7 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
 
         registerServiceStore<ProjectDetailState>('projectDetail', ProjectDetailStoreModule);
@@ -266,7 +266,7 @@ export default {
                     project_id: state.projectId,
                 });
                 // await store.dispatch('favorite/project/removeItem', { id: projectId.value });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DELETE_PROJECT'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DELETE_PROJECT'), '', vm);
                 vm.$router.go(-1);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_DELETE_PROJECT'));

--- a/src/services/project/project-detail/modules/MaintenanceWindowFormModal.vue
+++ b/src/services/project/project-detail/modules/MaintenanceWindowFormModal.vue
@@ -97,9 +97,11 @@ import {
     PButton, PButtonModal, PFieldGroup, PRadio, PSelectButton, PTextInput,
 } from '@spaceone/design-system';
 import dayjs from 'dayjs';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -161,7 +163,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             loading: false,
@@ -262,7 +266,7 @@ export default {
                     ...getTimeParams(),
                 });
 
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_S_CREATE_MAINTENANCE_WINDOW'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_S_CREATE_MAINTENANCE_WINDOW'), '', vm);
                 return res.maintenance_window_id;
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_E_CREATE_MAINTENANCE_WINDOW'));
@@ -280,7 +284,7 @@ export default {
                     ...getTimeParams(),
                 });
 
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_S_UPDATE_MAINTENANCE_WINDOW'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_S_UPDATE_MAINTENANCE_WINDOW'), '', vm);
                 return res.maintenance_window_id;
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_E_UPDATE_MAINTENANCE_WINDOW'));

--- a/src/services/project/project-detail/project-alert/ProjectAlertPage.vue
+++ b/src/services/project/project-detail/project-alert/ProjectAlertPage.vue
@@ -51,7 +51,7 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             loading: true,
@@ -89,7 +89,7 @@ export default {
                 });
                 state.isActivated = true;
                 tabState.activeTab = 'settings';
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_ACTIVATE_ALERT'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_ACTIVATE_ALERT'), '', vm);
             } catch (e) {
                 state.isActivated = false;
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_ACTIVATE_ALERT'));

--- a/src/services/project/project-detail/project-alert/project-alert-event-rule/ProjectAlertEventRulePage.vue
+++ b/src/services/project/project-detail/project-alert/project-alert-event-rule/ProjectAlertEventRulePage.vue
@@ -114,7 +114,10 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PPageTitle, PBreadcrumbs, PCard, PI, PButton,
 } from '@spaceone/design-system';
-import { computed, reactive, toRefs } from 'vue';
+import {
+    computed, getCurrentInstance, reactive, toRefs,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -156,7 +159,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             loading: true,
             project: {},
@@ -231,10 +236,10 @@ export default {
                     event_rule_id: data.event_rule_id,
                     order: tempOrder - 1,
                 });
-                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_REORDER_EVENT_RULES'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_REORDER_EVENT_RULES'), '', vm);
             } catch (e) {
                 changeOrder(tempCardData[data.order], tempCardData[data.order - 1], tempOrder);
-                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_E_REORDER_EVENT_RULES'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_E_REORDER_EVENT_RULES'), '', vm);
             } finally {
                 state.cardData = tempCardData;
             }
@@ -249,10 +254,10 @@ export default {
                     order: tempOrder + 1,
                 });
                 state.cardData = tempCardData;
-                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_REORDER_EVENT_RULES'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_REORDER_EVENT_RULES'), '', vm);
             } catch (e) {
                 changeOrder(tempCardData[data.order - 2], tempCardData[data.order - 1], tempOrder);
-                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_E_REORDER_EVENT_RULES'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_E_REORDER_EVENT_RULES'), '', vm);
             } finally {
                 state.cardData = tempCardData;
             }
@@ -262,7 +267,7 @@ export default {
                 await SpaceConnector.client.monitoring.eventRule.delete({
                     event_rule_id: state.orderedCardData[state.selectedOrder - 1].event_rule_id,
                 });
-                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_DELETE_EVENT_RULE'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_DELETE_EVENT_RULE'), '', vm);
                 await listEventRule();
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.EVENT_RULE.ALT_E_DELETE_EVENT_RULE'));

--- a/src/services/project/project-detail/project-alert/project-alert-event-rule/modules/EventRuleForm.vue
+++ b/src/services/project/project-detail/project-alert/project-alert-event-rule/modules/EventRuleForm.vue
@@ -31,7 +31,11 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PButton,
 } from '@spaceone/design-system';
-import { reactive, toRefs, watch } from 'vue';
+import type { SetupContext } from 'vue';
+import {
+    getCurrentInstance, reactive, toRefs, watch,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -103,7 +107,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             conditionsPolicy: CONDITIONS_POLICY.ALL as ConditionsPolicy,
             conditions: [
@@ -151,7 +157,7 @@ export default {
                     options: state.options,
                     project_id: props.projectId,
                 });
-                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_CREATE_EVENT_RULE'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_CREATE_EVENT_RULE'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.EVENT_RULE.ALT_E_CREATE_EVENT_RULE'));
             }
@@ -165,7 +171,7 @@ export default {
                     actions: state.actions,
                     options: state.options,
                 });
-                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_UPDATE_EVENT_RULE'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.EVENT_RULE.ALT_S_UPDATE_EVENT_RULE'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.EVENT_RULE.ALT_E_UPDATE_EVENT_RULE'));
             }

--- a/src/services/project/project-detail/project-alert/project-alert-settings/modules/ProjectAutoRecoveryUpdateModal.vue
+++ b/src/services/project/project-detail/project-alert/project-alert-settings/modules/ProjectAutoRecoveryUpdateModal.vue
@@ -27,9 +27,11 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PButtonModal, PSelectCard,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -65,7 +67,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             selectOptions: computed(() => ([
@@ -89,7 +93,7 @@ export default {
                         recovery_mode: state.recoveryMode,
                     },
                 });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.ALT_S_CHANGE_AUTO_RECOVERY'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.ALT_S_CHANGE_AUTO_RECOVERY'), '', vm);
                 emit('confirm');
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALERT.ALT_E_CHANGE_AUTO_RECOVERY'));

--- a/src/services/project/project-detail/project-alert/project-alert-settings/modules/ProjectEscalationPolicyChangeModal.vue
+++ b/src/services/project/project-detail/project-alert/project-alert-settings/modules/ProjectEscalationPolicyChangeModal.vue
@@ -46,9 +46,11 @@ import { ApiQueryHelper } from '@spaceone/console-core-lib/space-connector/helpe
 import {
     PButtonModal, PBoxTab,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -90,7 +92,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const tableState = reactive({
             loading: true,
             items: [] as any,
@@ -197,7 +201,7 @@ export default {
             }
             if (newEscalationPolicyId) {
                 await updateProjectAlertConfig(newEscalationPolicyId);
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.ALT_S_CHANGE_ESCALATION_POLICY'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.ALT_S_CHANGE_ESCALATION_POLICY'), '', vm);
             }
             emit('confirm');
             state.proxyVisible = false;

--- a/src/services/project/project-detail/project-alert/project-alert-settings/modules/ProjectNotificationPolicyUpdateModal.vue
+++ b/src/services/project/project-detail/project-alert/project-alert-settings/modules/ProjectNotificationPolicyUpdateModal.vue
@@ -29,8 +29,11 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PButtonModal, PSelectCard,
 } from '@spaceone/design-system';
-import { reactive, toRefs, watch } from 'vue';
-
+import type { SetupContext } from 'vue';
+import {
+    getCurrentInstance, reactive, toRefs, watch,
+} from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -65,7 +68,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             notificationUrgency: undefined,
@@ -79,7 +84,7 @@ export default {
                         notification_urgency: state.notificationUrgency,
                     },
                 });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.ALT_S_CHANGE_NOTIFICATION_POLICY'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.ALT_S_CHANGE_NOTIFICATION_POLICY'), '', vm);
                 emit('confirm');
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALERT.ALT_E_CHANGE_NOTIFICATION_POLICY'));

--- a/src/services/project/project-detail/project-alert/project-maintenance-window/ProjectMaintenanceWindowPage.vue
+++ b/src/services/project/project-detail/project-alert/project-maintenance-window/ProjectMaintenanceWindowPage.vue
@@ -138,7 +138,7 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
 
         const tagQueryHandler = new QueryHelper()
@@ -216,7 +216,7 @@ export default {
                 });
                 state.visibleCloseCheckModal = false;
 
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_S_CLOSE_MAINTENANCE_WINDOW'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_S_CLOSE_MAINTENANCE_WINDOW'), '', vm);
                 await getMaintenanceWindows();
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALERT.MAINTENANCE_WINDOW.ALT_E_CLOSE_MAINTENANCE_WINDOW'));

--- a/src/services/project/project-detail/project-alert/project-webhook/ProjectWebhookPage.vue
+++ b/src/services/project/project-detail/project-alert/project-webhook/ProjectWebhookPage.vue
@@ -193,8 +193,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { root }) {
+    setup(props) {
         const vm = getCurrentInstance()?.proxy as Vue;
+
         const handlers = {
             keyItemSets: [{
                 title: 'Properties',
@@ -309,7 +310,7 @@ export default {
                     // eslint-disable-next-line camelcase
                     webhook_id: state.selectedItem[0].webhook_id,
                 });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_ENABLE_WEBHOOK'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_ENABLE_WEBHOOK'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_ENABLE_WEBHOOK'));
             } finally {
@@ -324,7 +325,7 @@ export default {
                     // eslint-disable-next-line camelcase
                     webhook_id: state.selectedItem[0].webhook_id,
                 });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DISABLE_WEBHOOK'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DISABLE_WEBHOOK'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_DISABLE_WEBHOOK'));
             } finally {
@@ -338,7 +339,7 @@ export default {
                 await SpaceConnector.client.monitoring.webhook.delete({
                     webhook_id: state.selectedItem[0].webhook_id,
                 });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DELETE_WEBHOOK'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DELETE_WEBHOOK'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, 'PROJECT.DETAIL.ALT_E_DELETE_WEBHOOK');
             } finally {

--- a/src/services/project/project-detail/project-alert/project-webhook/modules/WebhookAddFormModal.vue
+++ b/src/services/project/project-detail/project-alert/project-webhook/modules/WebhookAddFormModal.vue
@@ -52,10 +52,11 @@ import { ApiQueryHelper } from '@spaceone/console-core-lib/space-connector/helpe
 import {
     PButtonModal, PFieldGroup, PTextInput, PSelectCard,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
-
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -90,7 +91,9 @@ export default {
             default: '',
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             plugins: computed(() => store.state.reference.plugin.items),
             proxyVisible: useProxyValue('visible', props, emit),
@@ -148,7 +151,7 @@ export default {
                     },
                     project_id: props.projectId,
                 });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_ADD_WEBHOOK'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_ADD_WEBHOOK'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_ADD_WEBHOOK'));
             } finally {

--- a/src/services/project/project-detail/project-alert/project-webhook/modules/WebhookUpdateFormModal.vue
+++ b/src/services/project/project-detail/project-alert/project-webhook/modules/WebhookUpdateFormModal.vue
@@ -31,9 +31,11 @@ import { SpaceConnector } from '@spaceone/console-core-lib/space-connector';
 import {
     PButtonModal, PFieldGroup, PTextInput,
 } from '@spaceone/design-system';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs,
+    computed, getCurrentInstance, reactive, toRefs,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -59,7 +61,9 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             loading: false,
             proxyVisible: useProxyValue('visible', props, emit),
@@ -100,7 +104,7 @@ export default {
 
             try {
                 await updateWebhook();
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_WEBHOOK'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_WEBHOOK'), '', vm);
                 state.proxyVisible = false;
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_UPDATE_WEBHOOK'));

--- a/src/services/project/project-detail/project-member/modules/ProjectMemberAddModal.vue
+++ b/src/services/project/project-detail/project-member/modules/ProjectMemberAddModal.vue
@@ -113,10 +113,12 @@ import {
 import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
 import type { SelectedItem as InputItem } from '@spaceone/design-system/dist/src/inputs/input/type';
 import { debounce } from 'lodash';
+import type { SetupContext } from 'vue';
 import {
-    reactive, toRefs, computed, watch,
+    reactive, toRefs, computed, watch, getCurrentInstance,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -170,7 +172,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             loading: false,
             proxyVisible: useProxyValue('visible', props, emit),
@@ -331,7 +335,7 @@ export default {
                     params.project_id = props.projectId;
                     await SpaceConnector.client.identity.project.member.add(params);
                 }
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.MEMBER.ALS_S_ADD_MEMBER'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.MEMBER.ALS_S_ADD_MEMBER'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.MEMBER.ALT_E_ADD_MEMBER'));
             }

--- a/src/services/project/project-detail/project-member/modules/ProjectMemberTab.vue
+++ b/src/services/project/project-detail/project-member/modules/ProjectMemberTab.vue
@@ -88,9 +88,11 @@ import {
 } from '@spaceone/design-system';
 import type { DataTableField } from '@spaceone/design-system/dist/src/data-display/tables/data-table/type';
 import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
+import type { SetupContext } from 'vue';
 import {
-    computed, reactive, toRefs, watch,
+    computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
@@ -148,7 +150,9 @@ export default {
             default: false,
         },
     },
-    setup(props, { root, emit }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const apiQueryHelper = new ApiQueryHelper().setPageLimit(15).setFilters(props.filters);
         const storeState = reactive({
             users: computed(() => store.state.reference.user.items),
@@ -254,7 +258,7 @@ export default {
                     project_id: props.projectId,
                     users: items.map(it => it.resource_id),
                 });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DELETE_MEMBER'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DELETE_MEMBER'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_DELETE_MEMBER'));
             }
@@ -265,7 +269,7 @@ export default {
                     project_group_id: props.projectGroupId,
                     users: items.map(it => it.resource_id),
                 });
-                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DELETE_MEMBER'), '', root);
+                showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_DELETE_MEMBER'), '', vm);
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_DELETE_MEMBER'));
             }

--- a/src/services/project/project-detail/project-member/modules/ProjectMemberUpdateModal.vue
+++ b/src/services/project/project-detail/project-member/modules/ProjectMemberUpdateModal.vue
@@ -65,8 +65,9 @@ import {
 } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
 import type { SelectedItem as InputItem } from '@spaceone/design-system/dist/src/inputs/input/type';
-import { reactive, toRefs } from 'vue';
-import type { PropType } from 'vue';
+import { getCurrentInstance, reactive, toRefs } from 'vue';
+import type { PropType, SetupContext } from 'vue';
+import type { Vue } from 'vue/types/vue';
 
 import { i18n } from '@/translations';
 
@@ -80,14 +81,6 @@ import { useProxyValue } from '@/common/composables/proxy-state';
 
 import type { MemberItem } from '@/services/project/project-detail/project-member/type';
 
-
-interface Props {
-    visible: boolean;
-    selectedMember: MemberItem;
-    isProjectGroup: boolean;
-    projectGroupId?: string;
-    projectId?: string;
-}
 
 export default {
     name: 'ProjectMemberUpdateModal',
@@ -126,7 +119,9 @@ export default {
             default: undefined,
         },
     },
-    setup(props: Props, { emit, root }) {
+    setup(props, { emit }: SetupContext) {
+        const vm = getCurrentInstance()?.proxy as Vue;
+
         const state = reactive({
             loading: false,
             proxyVisible: useProxyValue('visible', props, emit),
@@ -199,11 +194,11 @@ export default {
                 if (props.isProjectGroup) {
                     params.project_group_id = props.projectGroupId;
                     await SpaceConnector.client.identity.projectGroup.member.add(params);
-                    showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_GROUP_MEMBER'), '', root);
+                    showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_GROUP_MEMBER'), '', vm);
                 } else {
                     params.project_id = props.projectId;
                     await SpaceConnector.client.identity.project.member.add(params);
-                    showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_MEMBER'), '', root);
+                    showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_MEMBER'), '', vm);
                 }
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_UPDATE_MEMBER'));
@@ -218,11 +213,11 @@ export default {
                 if (props.isProjectGroup) {
                     params.project_group_id = props.projectGroupId;
                     await SpaceConnector.client.identity.projectGroup.member.modify(params);
-                    showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_GROUP_MEMBER'), '', root);
+                    showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_GROUP_MEMBER'), '', vm);
                 } else {
                     params.project_id = props.projectId;
                     await SpaceConnector.client.identity.project.member.modify(params);
-                    showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_MEMBER'), '', root);
+                    showSuccessMessage(i18n.t('PROJECT.DETAIL.ALT_S_UPDATE_MEMBER'), '', vm);
                 }
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('PROJECT.DETAIL.ALT_E_UPDATE_MEMBER'));


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

vue instance 를 쓸 때,
`setup(props, { root }) `
1. root 를 활용하거나
`const vm = getCurrentInstance()?.proxy as Vue;`
2. vm 을 활용하거나

두 가지 방식을 혼용해서 쓰고 있었는데요,
vue2.7 및 3 에서는 더 이상 `setup` 에서 `root` 를 제공하지 않습니다.
2번 방식만 활용하라고 하는데요,  https://github.com/vuejs/core/issues/1056
앞으로 `vm` 을 써야할 때, `setup` 바로 아래에 적는건 어떠신가요 ?
요런 모양새가 나올 것 같습니다
```setup(props) {
    const vm = getCurrentInstance()?.proxy as Vue;

    const state = reactive({
        …
    });

    …
}
```
### 생각해볼 문제
