### PR TITLE
fix(gnb-search-dropdown): fix no-data exposure conditions

### DIFF
--- a/src/common/modules/navigations/gnb/modules/gnb-search/modules/GNBSearchDropdown.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-search/modules/GNBSearchDropdown.vue
@@ -37,7 +37,7 @@
                         {{ $t('COMMON.GNB.SEARCH.HELP_TEXT') }}
                     </p>
                 </div>
-                <div class="no-data">
+                <div v-if="inputText" class="no-data">
                     <img src="@/assets/images/illust_ghost.svg" class="img-no-data">
                     <p class="no-data-text">
                         <i18n path="COMMON.GNB.SEARCH.NO_RESULT_1">
@@ -224,7 +224,6 @@ export default defineComponent<Props>({
 
     .no-data {
         margin: 2.5rem 0;
-
         > img {
             @apply ml-auto mr-auto;
 
@@ -244,6 +243,7 @@ export default defineComponent<Props>({
             margin-top: 1.5rem;
             font-size: 0.875rem;
             line-height: 1.5;
+            word-break: break-word;
             em {
                 @apply font-bold text-gray-500;
             }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [X] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [X] `Error / Warning / Lint / Type`

### 작업 내용
gnb 검색이 없는 경우 아래와 같은 두 종류의 도움말이 노출 됩니다. 아래 스크린샷의 빨강박스 도움말은 검색어 입력시 노출되어야 하는 영역으로 수정하였습니다.
![image](https://user-images.githubusercontent.com/19162140/190954904-aacffedc-9d0c-4ba8-a200-a826dd985267.png)


### 생각해볼 문제
