### PR TITLE
fix(service-account): get secrets by service account type

### DIFF
--- a/src/services/asset-inventory/service-account/modules/ServiceAccountCredentials.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountCredentials.vue
@@ -24,6 +24,7 @@
             />
             <service-account-credentials-form v-if="mode === 'UPDATE'"
                                               edit-mode="UPDATE"
+                                              :service-account-type="serviceAccountType"
                                               :provider="provider"
                                               :is-valid.sync="isFormValid"
                                               :origin-form-data="credentialForm"
@@ -39,6 +40,7 @@ import { ApiQueryHelper } from '@spaceone/console-core-lib/space-connector/helpe
 import {
     PPaneLayout, PPanelTop, PButton,
 } from '@spaceone/design-system';
+import type { PropType } from 'vue';
 import {
     defineComponent, reactive, toRefs, watch,
 } from 'vue';
@@ -49,13 +51,14 @@ import ServiceAccountCredentialsDetail
     from '@/services/asset-inventory/service-account/modules/ServiceAccountCredentialsDetail.vue';
 import ServiceAccountCredentialsForm
     from '@/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue';
-import type { PageMode, CredentialForm } from '@/services/asset-inventory/service-account/type';
+import type { PageMode, CredentialForm, AccountType } from '@/services/asset-inventory/service-account/type';
 import { EDIT_MODE } from '@/services/asset-inventory/service-account/type';
 
 
 interface Props {
     provider?: string;
     serviceAccountId?: string;
+    serviceAccountType: AccountType;
 }
 
 interface CredentialModel {
@@ -82,6 +85,10 @@ export default defineComponent<Props>({
         serviceAccountId: {
             type: String,
             default: undefined,
+        },
+        serviceAccountType: {
+            type: String as PropType<AccountType>,
+            default: 'GENERAL',
         },
     },
     setup(props) {

--- a/src/services/asset-inventory/service-account/service-account-add/ServiceAccountAddPage.vue
+++ b/src/services/asset-inventory/service-account/service-account-add/ServiceAccountAddPage.vue
@@ -44,6 +44,7 @@
             <p-pane-layout class="form-wrapper">
                 <p-panel-top :title="$t('IDENTITY.SERVICE_ACCOUNT.MAIN.TAB_CREDENTIALS')" />
                 <service-account-credentials-form v-if="enableCredentialInput"
+                                                  :service-account-type="accountType"
                                                   :provider="provider"
                                                   :is-valid.sync="isCredentialFormValid"
                                                   @change="handleChangeCredentialForm"
@@ -193,33 +194,24 @@ export default {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.SERVICE_ACCOUNT.ADD.ALT_E_CREATE_ACCOUNT_TITLE'));
             }
         };
-        const createSecretWithForm = async () => {
-            await SpaceConnector.client.secret.secret.create({
-                name: formState.baseInformationForm.accountName + state.serviceAccountId,
-                data: formState.credentialForm,
-                schema: formState.credentialForm.selectedSecretType,
-                secret_type: 'CREDENTIALS',
-                service_account_id: state.serviceAccountId,
-                project_id: formState.projectForm.selectedProject?.id || null,
-            });
-        };
-        const createSecretWithJson = async (jsonData) => {
-            await SpaceConnector.client.secret.secret.create({
-                name: formState.baseInformationForm.accountName + state.serviceAccountId,
-                data: jsonData,
-                schema: formState.credentialForm.selectedSecretType,
-                secret_type: 'CREDENTIALS',
-                service_account_id: state.serviceAccountId,
-                project_id: formState.projectForm.selectedProject?.id || null,
-            });
-        };
         const createSecret = async (): Promise<boolean> => {
-            let isSucceed = false;
+            let isSucceed: boolean;
             try {
+                let data;
                 if (formState.credentialForm.activeDataType === 'json') {
-                    const json = JSON.parse(formState.credentialForm.credentialJson);
-                    await createSecretWithJson(json);
-                } else if (formState.credentialForm.activeDataType === 'input') await createSecretWithForm();
+                    data = JSON.parse(formState.credentialForm.credentialJson);
+                } else if (formState.credentialForm.activeDataType === 'input') {
+                    data = formState.credentialForm;
+                }
+
+                await SpaceConnector.client.secret.secret.create({
+                    name: formState.baseInformationForm.accountName + state.serviceAccountId,
+                    data,
+                    schema: formState.credentialForm.selectedSecretType,
+                    secret_type: 'CREDENTIALS',
+                    service_account_id: state.serviceAccountId,
+                    project_id: formState.projectForm.selectedProject?.id || null,
+                });
 
                 showSuccessMessage(i18n.t('IDENTITY.SERVICE_ACCOUNT.ADD.ALT_S_CREATE_ACCOUNT_TITLE'), '', vm);
                 isSucceed = true;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- attach trust account 질문 추가
- account type 별로 secret 가져오기
![스크린샷 2022-09-20 오후 2 13 11](https://user-images.githubusercontent.com/18563857/191181524-ec69c77d-da76-4c86-a50e-833904d8ef51.png)

