### PR TITLE
feat(service-account-badge): create service-account-badge

### DIFF
--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -46,9 +46,7 @@
                 </div>
             </template>
             <!--            <template #col-service_account_type-format="{data}">-->
-            <!--                <p-badge v-if="data" :outline="true" :style-type="ACCOUNT_TYPE_BADGE_OPTION[data].styleType">-->
-            <!--                    {{ ACCOUNT_TYPE_BADGE_OPTION[data] ? ACCOUNT_TYPE_BADGE_OPTION[data].label : '' }}-->
-            <!--                </p-badge>-->
+            <!--                <service-account-badge v-if="data" :account-type="data" />-->
             <!--            </template>-->
         </p-dynamic-layout>
         <custom-field-modal v-model="tableState.visibleCustomFieldModal"
@@ -94,18 +92,9 @@ import { useManagePermissionState } from '@/common/composables/page-manage-permi
 import CustomFieldModal from '@/common/modules/custom-table/custom-field-modal/CustomFieldModal.vue';
 
 import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
+import { ACCOUNT_TYPE, ACCOUNT_TYPE_BADGE_OPTION } from '@/services/asset-inventory/service-account/config';
 import ServiceAccountProviderList
     from '@/services/asset-inventory/service-account/modules/ServiceAccountProviderList.vue';
-
-const ACCOUNT_TYPE = Object.freeze({
-    GENERAL_ACCOUNT: 'general_account',
-    TRUST_ACCOUNT: 'trust_account',
-});
-
-const ACCOUNT_TYPE_BADGE_OPTION = Object.freeze({
-    [ACCOUNT_TYPE.TRUST_ACCOUNT]: { label: 'General Account', styleType: 'primary' },
-    [ACCOUNT_TYPE.GENERAL_ACCOUNT]: { label: 'Trust Account', styleType: 'gray' },
-});
 
 export default {
     name: 'ServiceAccountPage',
@@ -159,8 +148,8 @@ export default {
             visibleCustomFieldModal: false,
             accountTypeList: computed(() => [
                 { name: 'all', label: 'All' },
-                { name: ACCOUNT_TYPE.TRUST_ACCOUNT, label: ACCOUNT_TYPE_BADGE_OPTION[ACCOUNT_TYPE.TRUST_ACCOUNT].label },
-                { name: ACCOUNT_TYPE.GENERAL_ACCOUNT, label: ACCOUNT_TYPE_BADGE_OPTION[ACCOUNT_TYPE.GENERAL_ACCOUNT].label },
+                { name: ACCOUNT_TYPE.TRUST, label: ACCOUNT_TYPE_BADGE_OPTION[ACCOUNT_TYPE.TRUST].label },
+                { name: ACCOUNT_TYPE.GENERAL, label: ACCOUNT_TYPE_BADGE_OPTION[ACCOUNT_TYPE.GENERAL].label },
             ]),
             selectedAccountType: 'all',
             searchFilters: computed<QueryStoreFilter[]>(() => queryHelper.setFiltersAsQueryTag(fetchOptionState.queryTags).filters),

--- a/src/services/asset-inventory/service-account/config.ts
+++ b/src/services/asset-inventory/service-account/config.ts
@@ -1,1 +1,11 @@
 export const TRUST_ACCOUNT_ALLOWED = ['aws'] as const;
+
+export const ACCOUNT_TYPE = Object.freeze({
+    GENERAL: 'GENERAL',
+    TRUST: 'TRUST',
+});
+
+export const ACCOUNT_TYPE_BADGE_OPTION = Object.freeze({
+    [ACCOUNT_TYPE.GENERAL]: { label: 'General Account', styleType: 'gray' },
+    [ACCOUNT_TYPE.TRUST]: { label: 'Trust Account', styleType: 'primary' },
+});

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountBadge.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountBadge.vue
@@ -1,0 +1,32 @@
+<template>
+    <p-badge v-if="accountType" :outline="true" :style-type="ACCOUNT_TYPE_BADGE_OPTION[accountType].styleType">
+        {{ ACCOUNT_TYPE_BADGE_OPTION[accountType] ? ACCOUNT_TYPE_BADGE_OPTION[accountType].label : '' }}
+    </p-badge>
+</template>
+
+<script lang="ts">
+import { PBadge } from '@spaceone/design-system';
+import type { PropType } from 'vue';
+
+import { ACCOUNT_TYPE, ACCOUNT_TYPE_BADGE_OPTION } from '@/services/asset-inventory/service-account/config';
+import type { AccountType } from '@/services/asset-inventory/service-account/type';
+
+export default {
+    name: 'ServiceAccountBadge',
+    components: { PBadge },
+    props: {
+        accountType: {
+            type: String as PropType<AccountType>,
+            default: ACCOUNT_TYPE.GENERAL,
+            validator(value: AccountType) {
+                return Object.values(ACCOUNT_TYPE).includes(value);
+            },
+        },
+    },
+    setup() {
+        return {
+            ACCOUNT_TYPE_BADGE_OPTION,
+        };
+    },
+};
+</script>

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountBadge.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountBadge.vue
@@ -1,5 +1,5 @@
 <template>
-    <p-badge v-if="accountType" :outline="true" :style-type="ACCOUNT_TYPE_BADGE_OPTION[accountType].styleType">
+    <p-badge :outline="true" :style-type="ACCOUNT_TYPE_BADGE_OPTION[accountType].styleType">
         {{ ACCOUNT_TYPE_BADGE_OPTION[accountType] ? ACCOUNT_TYPE_BADGE_OPTION[accountType].label : '' }}
     </p-badge>
 </template>

--- a/src/services/asset-inventory/service-account/type.ts
+++ b/src/services/asset-inventory/service-account/type.ts
@@ -4,6 +4,7 @@ import type { Tags, TimeStamp } from '@/models';
 
 import type { Tag } from '@/common/components/forms/tags-input-group/type';
 
+import type { ACCOUNT_TYPE } from '@/services/asset-inventory/service-account/config';
 import type { ProjectItemResp } from '@/services/project/type';
 
 const idField = 'provider';
@@ -45,7 +46,7 @@ export interface ServiceAccountModel {
         [key: string]: string;
     }
 }
-export type AccountType = 'GENERAL' | 'TRUST';
+export type AccountType = typeof ACCOUNT_TYPE[keyof typeof ACCOUNT_TYPE];
 
 export type ActiveDataType = 'input' | 'json';
 export interface CredentialForm {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
![image](https://user-images.githubusercontent.com/50662170/191197169-157c5888-b60f-4d4f-a161-330003dfdb72.png)

serviceAccount에서 중복 사용되는 배지를 컴포넌트로 생성하였습니다.
props
- accountType : AccountType 주입 시, 해당하는 배지를 렌더링합니다.
### 생각해볼 문제
