### PR TITLE
fix(service-account-badge): add isManaged prop & fix css

### DIFF
--- a/src/services/asset-inventory/service-account/config.ts
+++ b/src/services/asset-inventory/service-account/config.ts
@@ -6,6 +6,7 @@ export const ACCOUNT_TYPE = Object.freeze({
 });
 
 export const ACCOUNT_TYPE_BADGE_OPTION = Object.freeze({
-    [ACCOUNT_TYPE.GENERAL]: { label: 'General Account', styleType: 'gray' },
-    [ACCOUNT_TYPE.TRUSTED]: { label: 'Trusted Account', styleType: 'primary' },
+    [ACCOUNT_TYPE.GENERAL]: { label: 'General Account', styleType: 'gray200' },
+    [ACCOUNT_TYPE.TRUSTED]: { label: 'Trusted Account', styleType: 'blue200' },
+    'TRUST-MANAGED': { label: 'Trusted Account - Managed', styleType: 'primary3' },
 });

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountBadge.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountBadge.vue
@@ -1,17 +1,25 @@
 <template>
-    <p-badge :outline="true" :style-type="ACCOUNT_TYPE_BADGE_OPTION[accountType].styleType">
-        {{ ACCOUNT_TYPE_BADGE_OPTION[accountType] ? ACCOUNT_TYPE_BADGE_OPTION[accountType].label : '' }}
+    <p-badge :style-type="badgeOption.styleType">
+        {{ badgeOption.label }}
     </p-badge>
 </template>
 
 <script lang="ts">
 import { PBadge } from '@spaceone/design-system';
 import type { PropType } from 'vue';
+import {
+    computed, defineComponent, reactive, toRefs,
+} from 'vue';
 
 import { ACCOUNT_TYPE, ACCOUNT_TYPE_BADGE_OPTION } from '@/services/asset-inventory/service-account/config';
 import type { AccountType } from '@/services/asset-inventory/service-account/type';
 
-export default {
+interface Props {
+    accountType: AccountType;
+    isManaged: boolean;
+}
+
+export default defineComponent<Props>({
     name: 'ServiceAccountBadge',
     components: { PBadge },
     props: {
@@ -22,11 +30,23 @@ export default {
                 return Object.values(ACCOUNT_TYPE).includes(value);
             },
         },
+        isManaged: {
+            type: Boolean,
+            default: false,
+        },
     },
-    setup() {
+    setup(props) {
+        const state = reactive({
+            badgeOption: computed(() => {
+                if (props.accountType === ACCOUNT_TYPE.GENERAL) return ACCOUNT_TYPE_BADGE_OPTION[props.accountType];
+                const trustAccountType = props.isManaged ? 'TRUST-MANAGED' : ACCOUNT_TYPE.TRUSTED;
+                return ACCOUNT_TYPE_BADGE_OPTION[trustAccountType];
+            }),
+        });
         return {
+            ...toRefs(state),
             ACCOUNT_TYPE_BADGE_OPTION,
         };
     },
-};
+});
 </script>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- isManaged props 가 추가되었습니다.
    Trusted인 계정 중 isManaged인 경우의 배지 옵션이 달라 추가하였습니다. 
    isManaged는 accountType이 Trusted일 때만 작동합니다.

![image](https://user-images.githubusercontent.com/50662170/191434818-970f47d1-e10f-45c6-8290-c6013dc9e9e8.png)


### 생각해볼 문제
