### PR TITLE
feat(service-account-table): add preprocessor for is_managed badge

### DIFF
--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -77,6 +77,7 @@ import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 
 import { dynamicFieldsToExcelDataFields } from '@/lib/component-util/dynamic-layout';
+import type { ConsoleSearchSchema } from '@/lib/component-util/dynamic-layout/type';
 import { FILE_NAME_PREFIX } from '@/lib/excel-export';
 import { assetUrlConverter } from '@/lib/helper/asset-helper';
 import { referenceFieldFormatter } from '@/lib/reference/referenceFieldFormatter';
@@ -92,6 +93,7 @@ import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
 import { ACCOUNT_TYPE, ACCOUNT_TYPE_BADGE_OPTION } from '@/services/asset-inventory/service-account/config';
 import ServiceAccountProviderList
     from '@/services/asset-inventory/service-account/modules/ServiceAccountProviderList.vue';
+import type { ServiceAccountModel } from '@/services/asset-inventory/service-account/type';
 
 export default {
     name: 'ServiceAccountPage',
@@ -137,8 +139,7 @@ export default {
 
         const tableState = reactive({
             hasManagePermission: useManagePermissionState(),
-            items: [],
-            selectedAccountIds: computed(() => tableState.selectedItems.map(d => d?.service_account_id)),
+            items: [] as ServiceAccountModel[],
             schema: null as null|DynamicLayout,
             visibleCustomFieldModal: false,
             accountTypeList: computed(() => [
@@ -147,13 +148,14 @@ export default {
                 { name: ACCOUNT_TYPE.GENERAL, label: ACCOUNT_TYPE_BADGE_OPTION[ACCOUNT_TYPE.GENERAL].label },
             ]),
             selectedAccountType: 'all',
-            searchFilters: computed<QueryStoreFilter[]>(() => queryHelper.setFiltersAsQueryTag(fetchOptionState.queryTags).filters),
+            searchFilters: computed<QueryStoreFilter[]>(() => [
+                ...queryHelper.setFiltersAsQueryTag(fetchOptionState.queryTags).filters,
+            ]),
         });
 
         const { keyItemSets, valueHandlerMap, isAllLoaded } = useQuerySearchPropsWithSearchSchema(
-            computed(() => tableState.schema?.options?.search ?? []),
+            computed(() => tableState.schema?.options?.search as unknown as ConsoleSearchSchema[] ?? []),
             'identity.ServiceAccount',
-            // computed(() => )
         );
         /** Handling API with SpaceConnector * */
 
@@ -172,12 +174,23 @@ export default {
             return apiQuery.data;
         };
 
+        // add TRUSTED MANAGED directly
+        const serviceAccountPreprocessor = (serviceAccount: ServiceAccountModel[]): ServiceAccountModel[] => serviceAccount.map((sa) => {
+            if (sa.service_account_type === ACCOUNT_TYPE.TRUSTED && sa.tags?.is_managed) {
+                return {
+                    ...sa,
+                    service_account_type: 'TRUSTED-MANAGED',
+                };
+            }
+            return sa;
+        });
+
         const listServiceAccountData = async () => {
             typeOptionState.loading = true;
             try {
                 const res = await SpaceConnector.client.identity.serviceAccount.list({ query: getQuery() });
 
-                tableState.items = res.results;
+                tableState.items = serviceAccountPreprocessor(res.results);
                 typeOptionState.totalCount = res.total_count;
             } catch (e) {
                 ErrorHandler.handleError(e);
@@ -211,7 +224,7 @@ export default {
             await store.dispatch('file/downloadExcel', {
                 url: '/identity/service-account/list',
                 param: { query: getQuery() },
-                fields: dynamicFieldsToExcelDataFields(tableState.schema.options.fields),
+                fields: dynamicFieldsToExcelDataFields(tableState.schema?.options?.fields ?? []),
                 file_name_prefix: FILE_NAME_PREFIX.serviceAccount,
             });
         };

--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -45,9 +45,6 @@
                     </p-select-status>
                 </div>
             </template>
-            <!--            <template #col-service_account_type-format="{data}">-->
-            <!--                <service-account-badge v-if="data" :account-type="data" />-->
-            <!--            </template>-->
         </p-dynamic-layout>
         <custom-field-modal v-model="tableState.visibleCustomFieldModal"
                             resource-type="identity.ServiceAccount"
@@ -133,7 +130,6 @@ export default {
             loading: true,
             totalCount: 0,
             timezone: computed(() => store.state.user.timezone || 'UTC'),
-            selectIndex: [] as number[],
             selectable: false,
             colCopy: false,
             settingsVisible: true,
@@ -142,7 +138,6 @@ export default {
         const tableState = reactive({
             hasManagePermission: useManagePermissionState(),
             items: [],
-            selectedItems: computed(() => typeOptionState.selectIndex.map(d => tableState.items[d])),
             selectedAccountIds: computed(() => tableState.selectedItems.map(d => d?.service_account_id)),
             schema: null as null|DynamicLayout,
             visibleCustomFieldModal: false,
@@ -177,14 +172,10 @@ export default {
             return apiQuery.data;
         };
 
-        const serviceAccountListApi = SpaceConnector.client.identity.serviceAccount.list;
         const listServiceAccountData = async () => {
             typeOptionState.loading = true;
             try {
-                const res = await serviceAccountListApi({ query: getQuery() });
-
-                // filtering select index
-                typeOptionState.selectIndex = typeOptionState.selectIndex.filter(d => !!res.results[d]);
+                const res = await SpaceConnector.client.identity.serviceAccount.list({ query: getQuery() });
 
                 tableState.items = res.results;
                 typeOptionState.totalCount = res.total_count;
@@ -292,7 +283,6 @@ export default {
                     replaceUrlQuery('provider', after);
                     await getTableSchema();
                     await listServiceAccountData();
-                    typeOptionState.selectIndex = [];
                 }
             }, { immediate: true });
         };

--- a/src/services/asset-inventory/service-account/config.ts
+++ b/src/services/asset-inventory/service-account/config.ts
@@ -5,8 +5,9 @@ export const ACCOUNT_TYPE = Object.freeze({
     TRUSTED: 'TRUSTED',
 });
 
+// TRUSTED-MANAGED is not added as a constant because it is used only as a style option.
 export const ACCOUNT_TYPE_BADGE_OPTION = Object.freeze({
     [ACCOUNT_TYPE.GENERAL]: { label: 'General Account', styleType: 'gray200' },
     [ACCOUNT_TYPE.TRUSTED]: { label: 'Trusted Account', styleType: 'blue200' },
-    'TRUST-MANAGED': { label: 'Trusted Account - Managed', styleType: 'primary3' },
+    'TRUSTED-MANAGED': { label: 'Trusted Account - Managed', styleType: 'primary3' },
 });

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountBadge.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountBadge.vue
@@ -39,7 +39,7 @@ export default defineComponent<Props>({
         const state = reactive({
             badgeOption: computed(() => {
                 if (props.accountType === ACCOUNT_TYPE.GENERAL) return ACCOUNT_TYPE_BADGE_OPTION[props.accountType];
-                const trustAccountType = props.isManaged ? 'TRUST-MANAGED' : ACCOUNT_TYPE.TRUSTED;
+                const trustAccountType = props.isManaged ? 'TRUSTED-MANAGED' : ACCOUNT_TYPE.TRUSTED;
                 return ACCOUNT_TYPE_BADGE_OPTION[trustAccountType];
             }),
         });

--- a/src/services/asset-inventory/service-account/type.ts
+++ b/src/services/asset-inventory/service-account/type.ts
@@ -41,10 +41,11 @@ export interface ServiceAccountModel {
     name: string;
     provider: string;
     service_account_id: string;
-    service_account_type?: AccountType;
+    service_account_type?: AccountType | 'TRUSTED-MANAGED';
     data: {
         [key: string]: string;
-    }
+    },
+    tags: {[key: string]: unknown; };
 }
 export type AccountType = typeof ACCOUNT_TYPE[keyof typeof ACCOUNT_TYPE];
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- 사용되지 않는 상태 제거
- is_managed를 위해 받아온 데이터 전처리

-> accountType이 TRUSTED 이며 tags.is_managed가 true 일 때 managed가 추가됩니다.
### 생각해볼 문제
