### PR TITLE
fix(referenceRouter): fix empty object when project id is undefined

### DIFF
--- a/src/lib/reference/referenceRouter.ts
+++ b/src/lib/reference/referenceRouter.ts
@@ -29,12 +29,13 @@ const serverLinkFormatter: LinkFormatter = (name, data, reference, query) => {
 };
 
 const projectLinkFormatter: LinkFormatter = (name, data, reference, query) => {
-    const location = {
-        name,
-        query,
-        params: { id: data },
-    };
-    return location;
+    if (data) {
+        return {
+            name,
+            query,
+            params: data ? { id: data } : undefined,
+        };
+    } return {};
 };
 
 const projectGroupLinkFormatter: LinkFormatter = (name, data, reference, query) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
referenceRouter에서 projectLinkFormatter의 id가 없을 시 빈 object를 반환하도록 했습니다. (vue-warning 해결)

### 생각해볼 문제
다른 linkFormatter들도 warning 일어나는 곳이 있는지 확인 필요