### PR TITLE
feat(account-type-filter): add a filter for query to api & add sa type

### DIFF
--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -167,6 +167,9 @@ export default {
                     { k: 'provider', v: state.selectedProvider, o: '=' },
                     ...tableState.searchFilters,
                 ]);
+            if (tableState.selectedAccountType !== 'all') {
+                apiQuery.addFilter({ k: 'service_account_type', v: tableState.selectedAccountType, o: '=' });
+            }
             const fields = tableState.schema?.options?.fields;
             if (fields) {
                 apiQuery.setOnly(...fields.map(d => d.key).filter(d => !d.startsWith('tags.')), 'service_account_id', 'tags');
@@ -308,6 +311,9 @@ export default {
             if (replaceQueryHelper.rawQueryString !== JSON.stringify(filterQueryString)) {
                 replaceUrlQuery('filters', replaceQueryHelper.rawQueryStrings);
             }
+        });
+        watch(() => tableState.selectedAccountType, () => {
+            listServiceAccountData();
         });
 
         return {

--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -93,7 +93,7 @@ import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
 import { ACCOUNT_TYPE, ACCOUNT_TYPE_BADGE_OPTION } from '@/services/asset-inventory/service-account/config';
 import ServiceAccountProviderList
     from '@/services/asset-inventory/service-account/modules/ServiceAccountProviderList.vue';
-import type { ServiceAccountModel } from '@/services/asset-inventory/service-account/type';
+import type { ServiceAccountModelForBinding } from '@/services/asset-inventory/service-account/type';
 
 export default {
     name: 'ServiceAccountPage',
@@ -139,7 +139,7 @@ export default {
 
         const tableState = reactive({
             hasManagePermission: useManagePermissionState(),
-            items: [] as ServiceAccountModel[],
+            items: [] as ServiceAccountModelForBinding[],
             schema: null as null|DynamicLayout,
             visibleCustomFieldModal: false,
             accountTypeList: computed(() => [
@@ -175,7 +175,7 @@ export default {
         };
 
         // add TRUSTED MANAGED directly
-        const serviceAccountPreprocessor = (serviceAccount: ServiceAccountModel[]): ServiceAccountModel[] => serviceAccount.map((sa) => {
+        const serviceAccountPreprocessor = (serviceAccount: ServiceAccountModelForBinding[]): ServiceAccountModelForBinding[] => serviceAccount.map((sa) => {
             if (sa.service_account_type === ACCOUNT_TYPE.TRUSTED && sa.tags?.is_managed) {
                 return {
                     ...sa,

--- a/src/services/asset-inventory/service-account/type.ts
+++ b/src/services/asset-inventory/service-account/type.ts
@@ -41,12 +41,16 @@ export interface ServiceAccountModel {
     name: string;
     provider: string;
     service_account_id: string;
-    service_account_type?: AccountType | 'TRUSTED-MANAGED';
+    service_account_type?: AccountType;
     data: {
         [key: string]: string;
     },
     tags: {[key: string]: unknown; };
 }
+export interface ServiceAccountModelForBinding extends Omit<ServiceAccountModel, 'service_account_type'> {
+    service_account_type?: AccountType | 'TRUSTED-MANAGED';
+}
+
 export type AccountType = typeof ACCOUNT_TYPE[keyof typeof ACCOUNT_TYPE];
 
 export type ActiveDataType = 'input' | 'json';


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- account type에서 manage의 추가로 binding을 위한 모델이 클라이언트에서 사용되고 있어 따로 분리하였습니다. (ServiceAccountModelForBinding 라는 타입)
- account type 필터를 api에 연결하였습니다.
    - 검색에서의 account type은 종민님께서 빼주신다고 하셨습니다.

### 생각해볼 문제
