### PR TITLE
fix(service-account-credentials): hide attached trusted account when its not aws

### DIFF
--- a/src/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue
@@ -14,7 +14,7 @@
             </div>
         </p-field-group>
         <template v-if="hasCredentialKey">
-            <p-field-group v-if="serviceAccountType !== ACCOUNT_TYPE.TRUSTED"
+            <p-field-group v-if="serviceAccountType !== ACCOUNT_TYPE.TRUSTED && TRUSTED_ACCOUNT_ALLOWED.some((d) => d === provider)"
                            :label="$t('INVENTORY.SERVICE_ACCOUNT.DETAIL.CREDENTIALS_LABEL')"
                            required
             >
@@ -78,7 +78,7 @@ import { i18n } from '@/translations';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
-import { ACCOUNT_TYPE } from '@/services/asset-inventory/service-account/config';
+import { ACCOUNT_TYPE, TRUSTED_ACCOUNT_ALLOWED } from '@/services/asset-inventory/service-account/config';
 import type {
     ActiveDataType, CredentialForm, ProviderModel, PageMode, AccountType,
 } from '@/services/asset-inventory/service-account/type';
@@ -274,6 +274,7 @@ export default defineComponent<Props>({
             ...toRefs(state),
             tabState,
             ACCOUNT_TYPE,
+            TRUSTED_ACCOUNT_ALLOWED,
             handleChangeSecretType,
             handleCredentialValidate,
             handleSelectNoCredentials,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
AWS가 아니면 credentials에서 이 항목 숨기기
![스크린샷 2022-09-22 오후 9 08 26](https://user-images.githubusercontent.com/18563857/191742627-1cf2d4a9-161c-4728-bbaa-c0da5010d286.png)
