### PR TITLE
fix(service-account): remove detail infos about account type

### DIFF
--- a/packages/cloudforet/language-pack/console-translation.babel
+++ b/packages/cloudforet/language-pack/console-translation.babel
@@ -30557,27 +30557,6 @@
                                         </translations>
                                     </concept_node>
                                     <concept_node>
-                                        <name>HERE</name>
-                                        <definition_loaded>false</definition_loaded>
-                                        <description/>
-                                        <comment/>
-                                        <default_text/>
-                                        <translations>
-                                            <translation>
-                                                <language>en-US</language>
-                                                <approved>false</approved>
-                                            </translation>
-                                            <translation>
-                                                <language>ja-JP</language>
-                                                <approved>false</approved>
-                                            </translation>
-                                            <translation>
-                                                <language>ko-KR</language>
-                                                <approved>false</approved>
-                                            </translation>
-                                        </translations>
-                                    </concept_node>
-                                    <concept_node>
                                         <name>PROJECT_REQUIRED_HELP_TEXT</name>
                                         <definition_loaded>false</definition_loaded>
                                         <description/>
@@ -30649,15 +30628,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>

--- a/packages/cloudforet/language-pack/en.json
+++ b/packages/cloudforet/language-pack/en.json
@@ -1699,11 +1699,10 @@
 				"CONNECT_TO_CONSOLE": "Connect to Console",
 				"CREDENTIALS_LABEL": "Do you want to attach an existing Trusted Account?",
 				"EDIT": "Edit",
-				"HERE": "here",
 				"PROJECT_REQUIRED_HELP_TEXT": "It's now required to select a specific\nproject for any service account.\n( Note: A randomly generated\nproject will be forcefully added to\nthe accounts with no project soon.)",
 				"REQUIRED": "** required",
 				"SAVE": "Save",
-				"TRUST_ACCOUNT_HELP_TEXT": "Trusted Account can allow entities in other AWS accounts belonging to you. Get more details"
+				"TRUST_ACCOUNT_HELP_TEXT": "Trusted Account can allow entities in other AWS accounts belonging to you."
 			}
 		}
 	},

--- a/packages/cloudforet/language-pack/ja.json
+++ b/packages/cloudforet/language-pack/ja.json
@@ -1699,7 +1699,6 @@
 				"CONNECT_TO_CONSOLE": "",
 				"CREDENTIALS_LABEL": "",
 				"EDIT": "",
-				"HERE": "",
 				"PROJECT_REQUIRED_HELP_TEXT": "",
 				"REQUIRED": "",
 				"SAVE": "",

--- a/packages/cloudforet/language-pack/ko.json
+++ b/packages/cloudforet/language-pack/ko.json
@@ -1699,7 +1699,6 @@
 				"CONNECT_TO_CONSOLE": "",
 				"CREDENTIALS_LABEL": "",
 				"EDIT": "수정",
-				"HERE": "",
 				"PROJECT_REQUIRED_HELP_TEXT": "",
 				"REQUIRED": "",
 				"SAVE": "",

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountAccountType.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountAccountType.vue
@@ -24,9 +24,8 @@
                          color="inherit"
                          class="external-icon"
                     />
-                    <div class="anchor-wrapper">
+                    <div class="help-wrapper">
                         <span>{{ $t('INVENTORY.SERVICE_ACCOUNT.DETAIL.TRUST_ACCOUNT_HELP_TEXT') }}</span>
-                        <p-anchor class="here-anchor" highlight :text="$t('INVENTORY.SERVICE_ACCOUNT.DETAIL.HERE')" />
                     </div>
                 </div>
             </div>
@@ -41,7 +40,7 @@ import {
 } from 'vue';
 
 import {
-    PPaneLayout, PPanelTop, PSelectCard, PI, PAnchor,
+    PPaneLayout, PPanelTop, PSelectCard, PI,
 } from '@spaceone/design-system';
 
 import { TRUSTED_ACCOUNT_ALLOWED } from '@/services/asset-inventory/service-account/config';
@@ -51,7 +50,6 @@ import type { AccountType } from '@/services/asset-inventory/service-account/typ
 export default defineComponent({
     name: 'ServiceAccountAccountType',
     components: {
-        PAnchor,
         PPaneLayout,
         PPanelTop,
         PSelectCard,
@@ -118,11 +116,8 @@ export default defineComponent({
                 gap: 0.3rem;
                 align-content: flex-start;
                 padding-bottom: 1rem;
-                .anchor-wrapper {
+                .help-wrapper {
                     width: calc(100% - 1rem);
-                }
-                .here-anchor {
-                    margin-left: 0.25rem;
                 }
             }
         }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

service account create 시에 있던 info 에서, here 에 대한 링크가 제공되지 않는 것으로 바뀌어, 삭제하였습니다.

### 생각해볼 문제
