### PR TITLE
feat(double-check-modal): create double-check-modal & apply to service-account-detail-page

### DIFF
--- a/src/common/components/modals/DoubleCheckModal.vue
+++ b/src/common/components/modals/DoubleCheckModal.vue
@@ -6,7 +6,7 @@
                     :backdrop="backdrop"
                     :visible.sync="proxyVisible"
                     :theme-color="themeColor"
-                    :disabled="invalid"
+                    :disabled="invalid || inputText.length === 0"
                     @cancel="cancel"
                     @close="close"
                     @confirm="confirm"

--- a/src/common/components/modals/DoubleCheckModal.vue
+++ b/src/common/components/modals/DoubleCheckModal.vue
@@ -1,0 +1,175 @@
+<template>
+    <p-button-modal :header-title="headerTitle"
+                    :scrollable="scrollable"
+                    :size="size"
+                    :fade="fade"
+                    :backdrop="backdrop"
+                    :visible.sync="proxyVisible"
+                    :theme-color="themeColor"
+                    :disabled="invalid"
+                    @cancel="cancel"
+                    @close="close"
+                    @confirm="confirm"
+    >
+        <template #body>
+            <div>
+                <slot v-if="subTitle" name="subTitle" />
+                <!--song-lang-->
+                <!--need to remove square brackets on both sides of the account-->
+                <i18n v-else class="double-check-modal-sub-title" tag="p"
+                      path="IDENTITY.SERVICE_ACCOUNT.MAIN.CHECK_MODAL_DELETE_DESC"
+                >
+                    <template #account>
+                        <strong>{{ verificationText }}</strong>
+                    </template>
+                </i18n>
+
+                <p-field-group
+                    class="field-group"
+                    :required="true"
+                    :invalid-text="$t('COMPONENT.DOUBLE_CHECK_MODAL.INVALID_TEXT', {text: verificationText})"
+                    :invalid="invalid"
+                >
+                    <template #label>
+                        <i18n class="label-text" path="COMPONENT.DOUBLE_CHECK_MODAL.INPUT_DESC">
+                            <template #text>
+                                <strong>{{ verificationText }}</strong>
+                            </template>
+                        </i18n>
+                    </template>
+                    <p-text-input v-model="inputText"
+                                  :invalid="invalid"
+                                  block
+                                  @keyup.enter="confirm()"
+                    />
+                </p-field-group>
+
+                <slot />
+            </div>
+        </template>
+    </p-button-modal>
+</template>
+<script lang="ts">
+import type { SetupContext } from 'vue';
+import {
+    reactive, toRefs, watch, defineComponent,
+} from 'vue';
+
+import { PButtonModal, PFieldGroup, PTextInput } from '@spaceone/design-system';
+
+import type { Size } from '@/common/components/modals/config';
+import { SIZE } from '@/common/components/modals/config';
+import { useProxyValue } from '@/common/composables/proxy-state';
+
+export default defineComponent({
+    name: 'DoubleCheckModal',
+    components: { PButtonModal, PTextInput, PFieldGroup },
+    props: {
+        fade: {
+            type: Boolean,
+            default: false,
+        },
+        scrollable: {
+            type: Boolean,
+            default: false,
+        },
+        size: {
+            type: String,
+            validator(value: Size): boolean {
+                return Object.values(SIZE).includes(value);
+            },
+            default: SIZE.sm,
+        },
+        backdrop: {
+            type: Boolean,
+            default: true,
+        },
+        visible: { // sync
+            type: Boolean,
+            default: false,
+        },
+        themeColor: {
+            type: String,
+            default: 'alert',
+        },
+        headerTitle: {
+            type: String,
+            default: undefined,
+        },
+        subTitle: {
+            type: String,
+            default: undefined,
+        },
+        verificationText: {
+            type: String,
+            required: true,
+        },
+    },
+    setup(props, { emit }: SetupContext) {
+        const state = reactive({
+            proxyVisible: useProxyValue('visible', props, emit),
+        });
+
+        const checkState = reactive({
+            inputText: '',
+            invalid: false,
+        });
+        const reset = () => {
+            checkState.inputText = '';
+            checkState.invalid = false;
+        };
+        const cancel = (...event) => {
+            reset();
+            emit('cancel', ...event);
+        };
+        const close = (...event) => {
+            reset();
+            emit('close', ...event);
+        };
+        const confirm = () => {
+            if (checkState.inputText === props.verificationText) {
+                reset();
+                emit('confirm');
+            } else {
+                checkState.invalid = true;
+            }
+        };
+
+        watch(() => checkState.inputText, (value) => {
+            checkState.invalid = value.length > 0 && props.verificationText !== value;
+        });
+
+        return {
+            ...toRefs(state),
+            ...toRefs(checkState),
+            cancel,
+            close,
+            confirm,
+        };
+    },
+
+
+});
+</script>
+
+<style lang="postcss" scoped>
+.double-check-modal-sub-title {
+    font-style: normal;
+    font-weight: normal;
+    font-size: 1rem;
+    line-height: 1.6rem;
+    margin-bottom: 1.875rem;
+}
+
+.field-group {
+    /* custom design-system component - p-label */
+    :deep(.p-label) {
+        margin-bottom: 1rem;
+    }
+}
+
+.label-text {
+    font-weight: normal !important;
+    font-size: 1rem;
+}
+</style>

--- a/src/common/components/modals/DoubleCheckModal.vue
+++ b/src/common/components/modals/DoubleCheckModal.vue
@@ -7,9 +7,9 @@
                     :visible.sync="proxyVisible"
                     :theme-color="themeColor"
                     :disabled="invalid || inputText.length === 0"
-                    @cancel="cancel"
-                    @close="close"
-                    @confirm="confirm"
+                    @cancel="handleCancel"
+                    @close="hadleClose"
+                    @confirm="handleConfirm"
     >
         <template #body>
             <div>
@@ -43,8 +43,6 @@
                                   @keyup.enter="confirm()"
                     />
                 </p-field-group>
-
-                <slot />
             </div>
         </template>
     </p-button-modal>
@@ -118,15 +116,15 @@ export default defineComponent({
             checkState.inputText = '';
             checkState.invalid = false;
         };
-        const cancel = (...event) => {
+        const handleCancel = (event) => {
             reset();
-            emit('cancel', ...event);
+            emit('cancel', event);
         };
-        const close = (...event) => {
+        const handleClose = (event) => {
             reset();
-            emit('close', ...event);
+            emit('close', event);
         };
-        const confirm = () => {
+        const handleConfirm = () => {
             if (checkState.inputText === props.verificationText) {
                 reset();
                 emit('confirm');
@@ -142,9 +140,9 @@ export default defineComponent({
         return {
             ...toRefs(state),
             ...toRefs(checkState),
-            cancel,
-            close,
-            confirm,
+            handleCancel,
+            handleClose,
+            handleConfirm,
         };
     },
 

--- a/src/services/asset-inventory/service-account/service-account-detail/ServiceAccountDetailPage.vue
+++ b/src/services/asset-inventory/service-account/service-account-detail/ServiceAccountDetailPage.vue
@@ -50,13 +50,12 @@
                                          :editable="!isManagedAccount"
             />
         </div>
-        <p-double-check-modal :visible.sync="deleteModalVisible"
-                              :header-title="$t('IDENTITY.SERVICE_ACCOUNT.MAIN.CHECK_MODAL_DELETE_TITLE')"
-                              :sub-title="$t('IDENTITY.SERVICE_ACCOUNT.MAIN.CHECK_MODAL_DELETE_DESC', { account: item.name })"
-                              :verification-text="item.name ? item.name : ''"
-                              theme-color="alert"
-                              size="sm"
-                              @confirm="handleConfirmDelete"
+        <double-check-modal :visible.sync="deleteModalVisible"
+                            :header-title="$t('IDENTITY.SERVICE_ACCOUNT.MAIN.CHECK_MODAL_DELETE_TITLE')"
+                            :verification-text="item.name ? item.name : ''"
+                            theme-color="alert"
+                            size="sm"
+                            @confirm="handleConfirmDelete"
         />
         <p-button-modal :visible.sync="cannotDeleteModalVisible"
                         :header-title="$t('INVENTORY.SERVICE_ACCOUNT.DELETE_CHECK_MODAL.TITLE')"
@@ -77,7 +76,7 @@ import {
 import type { Vue } from 'vue/types/vue';
 
 import {
-    PAnchor, PButton, PIconButton, PPageTitle, PLazyImg, PDoubleCheckModal, PButtonModal, PPaneLayout, PPanelTop,
+    PAnchor, PButton, PIconButton, PPageTitle, PLazyImg, PButtonModal, PPaneLayout, PPanelTop,
 } from '@spaceone/design-system';
 import { render } from 'ejs';
 
@@ -90,6 +89,7 @@ import { i18n } from '@/translations';
 
 import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 
+import DoubleCheckModal from '@/common/components/modals/DoubleCheckModal.vue';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import { useManagePermissionState } from '@/common/composables/page-manage-permission';
 
@@ -119,10 +119,10 @@ export default defineComponent({
         PButton,
         PAnchor,
         PLazyImg,
-        PDoubleCheckModal,
         PButtonModal,
         PPaneLayout,
         PPanelTop,
+        DoubleCheckModal,
     },
     props: {
         serviceAccountId: {

--- a/src/services/cost-explorer/budget/budget-detail/modules/BudgetDeleteModal.vue
+++ b/src/services/cost-explorer/budget/budget-detail/modules/BudgetDeleteModal.vue
@@ -45,7 +45,8 @@ export default {
     setup(props, { emit }) {
         const state = reactive({
             proxyVisible: false,
-            title: 'Delete Budget' as TranslateResult,
+            // song-lang
+            title: '$t(Delete Budget)' as TranslateResult,
             verificationText: computed(() => props.budgetName),
         });
 

--- a/src/services/cost-explorer/budget/budget-detail/modules/BudgetDeleteModal.vue
+++ b/src/services/cost-explorer/budget/budget-detail/modules/BudgetDeleteModal.vue
@@ -1,11 +1,10 @@
 <template>
-    <p-double-check-modal :visible="proxyVisible"
-                          :header-title="title"
-                          :sub-title="subTitle"
-                          :verification-text="verificationText"
-                          size="sm"
-                          @confirm="handleConfirm"
-                          @update:visible="handleUpdate"
+    <double-check-modal :visible="proxyVisible"
+                        :header-title="title"
+                        :verification-text="verificationText"
+                        size="sm"
+                        @confirm="handleConfirm"
+                        @update:visible="handleUpdate"
     />
 </template>
 
@@ -16,10 +15,9 @@ import {
 } from 'vue';
 import VueI18n from 'vue-i18n';
 
-import { PDoubleCheckModal } from '@spaceone/design-system';
-
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
+import DoubleCheckModal from '@/common/components/modals/DoubleCheckModal.vue';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
 
@@ -28,7 +26,7 @@ import TranslateResult = VueI18n.TranslateResult;
 export default {
     name: 'BudgetDeleteModal',
     components: {
-        PDoubleCheckModal,
+        DoubleCheckModal,
     },
     props: {
         visible: {
@@ -48,7 +46,6 @@ export default {
         const state = reactive({
             proxyVisible: false,
             title: 'Delete Budget' as TranslateResult,
-            subTitle: computed(() => `${props.budgetName} will be deleted permanently`),
             verificationText: computed(() => props.budgetName),
         });
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [ ] `Error / Warning / Lint / Type`

### 작업 내용
- create `double-check-modal` in console
- apply `double-check-modal` to `service-account-detail-page` & `budget-delete-modal`

<img width="520" alt="스크린샷 2022-09-23 오후 12 29 46" src="https://user-images.githubusercontent.com/83635051/191887176-fda8c814-61a8-41cb-95fd-adbcbc0c0718.png">


### 생각해볼 문제
- need to remove square brackets on both sides of the account in babel edit
