### PR TITLE
fix(service-account): set origin data when edit credentials

### DIFF
--- a/src/services/asset-inventory/service-account/modules/ServiceAccountCredentials.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountCredentials.vue
@@ -32,7 +32,7 @@
                                               :service-account-type="serviceAccountType"
                                               :provider="provider"
                                               :is-valid.sync="isFormValid"
-                                              :origin-form-data="credentialForm"
+                                              :origin-form="originCredentialForm"
                                               @change="handleChangeCredentialForm"
             />
         </div>
@@ -126,6 +126,7 @@ export default defineComponent<Props>({
             isFormValid: undefined,
             credentialData: {} as CredentialModel,
             credentialForm: {} as CredentialForm,
+            originCredentialForm: {} as Partial<CredentialForm>,
         });
 
         /* Api */
@@ -141,16 +142,13 @@ export default defineComponent<Props>({
                     listApi = SpaceConnector.client.secret.trustedSecret.list;
                 }
                 const { results } = await listApi({ query: getQuery().data });
-                if (results.length) {
-                    state.credentialData = results[0];
-                    state.credentialForm.selectedSecretType = results[0].schema;
-                } else {
-                    state.credentialData = {};
-                }
+                if (results.length) state.credentialData = results[0];
+                else state.credentialData = {};
             } catch (e) {
                 ErrorHandler.handleError(e);
                 state.credentialData = {};
             } finally {
+                state.originCredentialForm.hasCredentialKey = !isEmpty(state.credentialData);
                 state.loading = false;
             }
         };
@@ -271,6 +269,9 @@ export default defineComponent<Props>({
         /* Watcher */
         watch([() => props.serviceAccountId, () => props.serviceAccountType], ([serviceAccountId]) => {
             if (serviceAccountId) getCredentialData(serviceAccountId);
+        }, { immediate: true });
+        watch(() => props.attachedTrustedAccountId, (attachedTrustedAccountId) => {
+            state.originCredentialForm.attachedTrustedAccountId = attachedTrustedAccountId;
         }, { immediate: true });
 
         return {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
서비스 어카운트 디테일 페이지에서 credential 수정 시, 기존 데이터가 폼에 적용되도록 개선함
