### PR TITLE
fix(service-account): add help text to trusted account

### DIFF
--- a/packages/cloudforet/language-pack/console-translation.babel
+++ b/packages/cloudforet/language-pack/console-translation.babel
@@ -22448,6 +22448,27 @@
                                         </translations>
                                     </concept_node>
                                     <concept_node>
+                                        <name>SEE_MORE</name>
+                                        <definition_loaded>false</definition_loaded>
+                                        <description/>
+                                        <comment/>
+                                        <default_text/>
+                                        <translations>
+                                            <translation>
+                                                <language>en-US</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                            <translation>
+                                                <language>ja-JP</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                            <translation>
+                                                <language>ko-KR</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                        </translations>
+                                    </concept_node>
+                                    <concept_node>
                                         <name>SERVICE_ACCOUNT</name>
                                         <definition_loaded>false</definition_loaded>
                                         <description/>
@@ -22612,6 +22633,27 @@
                                             <translation>
                                                 <language>ko-KR</language>
                                                 <approved>true</approved>
+                                            </translation>
+                                        </translations>
+                                    </concept_node>
+                                    <concept_node>
+                                        <name>TRUSTED_ACCOUNT_HELP_TEXT</name>
+                                        <definition_loaded>false</definition_loaded>
+                                        <description/>
+                                        <comment/>
+                                        <default_text/>
+                                        <translations>
+                                            <translation>
+                                                <language>en-US</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                            <translation>
+                                                <language>ja-JP</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                            <translation>
+                                                <language>ko-KR</language>
+                                                <approved>false</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>

--- a/packages/cloudforet/language-pack/en.json
+++ b/packages/cloudforet/language-pack/en.json
@@ -1260,6 +1260,7 @@
 				"PROJECT_TITLE": "Project",
 				"SAVE": "Save",
 				"SECRET_TYPE_LABEL": "Secret Type",
+				"SEE_MORE": "See more",
 				"SERVICE_ACCOUNT": "Service Account",
 				"TAB_INPUT": "Input Form",
 				"TAB_JSON": "Json Code",
@@ -1267,7 +1268,8 @@
 				"TAG_DESC_1": "Set {name}'s tag.",
 				"TAG_DESC_2": "The Key - Value pair is a required field. Only underscores (_), characters, and numbers are allowed. International characters are allowed.",
 				"TAG_LABEL": "Tags",
-				"TITLE": "Add Service Account"
+				"TITLE": "Add Service Account",
+				"TRUSTED_ACCOUNT_HELP_TEXT": "If you choose to attach a Trusted Account, It will have access to the resources from selected account."
 			},
 			"MAIN": {
 				"ACTION": "Action",

--- a/packages/cloudforet/language-pack/ja.json
+++ b/packages/cloudforet/language-pack/ja.json
@@ -1260,6 +1260,7 @@
 				"PROJECT_TITLE": "プロジェクト",
 				"SAVE": "保存",
 				"SECRET_TYPE_LABEL": "暗号化キーのタイプ",
+				"SEE_MORE": "",
 				"SERVICE_ACCOUNT": "サービスアカウント",
 				"TAB_INPUT": "直接入力",
 				"TAB_JSON": "JSONで入力",
@@ -1267,7 +1268,8 @@
 				"TAG_DESC_1": "{name}のタグを設定します",
 				"TAG_DESC_2": "キーは、文字、数字、およびアンダースコアのみ使用できます。",
 				"TAG_LABEL": "タグ",
-				"TITLE": "サービスアカウントの追加"
+				"TITLE": "サービスアカウントの追加",
+				"TRUSTED_ACCOUNT_HELP_TEXT": ""
 			},
 			"MAIN": {
 				"ACTION": "作業",

--- a/packages/cloudforet/language-pack/ko.json
+++ b/packages/cloudforet/language-pack/ko.json
@@ -1260,6 +1260,7 @@
 				"PROJECT_TITLE": "프로젝트",
 				"SAVE": "저장",
 				"SECRET_TYPE_LABEL": "암호화 키 유형",
+				"SEE_MORE": "",
 				"SERVICE_ACCOUNT": "서비스 계정",
 				"TAB_INPUT": "직접 입력",
 				"TAB_JSON": "JSON으로 입력",
@@ -1267,7 +1268,8 @@
 				"TAG_DESC_1": "{name}의 태그를 설정합니다.",
 				"TAG_DESC_2": "키는 문자, 숫자 및 밑줄만 사용할 수 있습니다.",
 				"TAG_LABEL": "태그",
-				"TITLE": "서비스 계정 추가"
+				"TITLE": "서비스 계정 추가",
+				"TRUSTED_ACCOUNT_HELP_TEXT": ""
 			},
 			"MAIN": {
 				"ACTION": "작업",

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue
@@ -18,6 +18,13 @@
                            :label="$t('INVENTORY.SERVICE_ACCOUNT.DETAIL.CREDENTIALS_LABEL')"
                            required
             >
+                <template #help>
+                    <span>{{ $t('IDENTITY.SERVICE_ACCOUNT.ADD.TRUSTED_ACCOUNT_HELP_TEXT') }}</span>
+                    <p-anchor class="see-more-text"
+                              :text="$t('IDENTITY.SERVICE_ACCOUNT.ADD.SEE_MORE')"
+                              :href="trustedAccountInfoLink"
+                    />
+                </template>
                 <div class="radio-wrapper">
                     <p-radio :selected="formState.attachTrustedAccount" :value="false"
                              @change="handleChangeAttachTrustedAccount"
@@ -77,7 +84,7 @@ import {
 } from 'vue';
 
 import {
-    PFieldGroup, PRadio, PTab, PJsonSchemaForm, PTextEditor, PSelectDropdown,
+    PFieldGroup, PRadio, PTab, PJsonSchemaForm, PTextEditor, PSelectDropdown, PAnchor,
 } from '@spaceone/design-system';
 import type { SelectDropdownMenu } from '@spaceone/design-system/dist/src/inputs/dropdown/select-dropdown/type';
 import type { JsonSchema } from '@spaceone/design-system/dist/src/inputs/forms/json-schema-form/type';
@@ -87,6 +94,7 @@ import { isEmpty } from 'lodash';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 
+import { store } from '@/store';
 import { i18n } from '@/translations';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
@@ -109,6 +117,7 @@ interface Props {
 export default defineComponent<Props>({
     name: 'ServiceAccountCredentialsForm',
     components: {
+        PAnchor,
         PSelectDropdown,
         PFieldGroup,
         PRadio,
@@ -139,15 +148,18 @@ export default defineComponent<Props>({
         },
     },
     setup(props, { emit }) {
+        const storeState = reactive({
+            language: computed(() => store.state.user.language),
+        });
         const state = reactive({
             providerData: {} as ProviderModel,
-            showTrustedAccount: computed(() => state.providerData?.capability?.support_trusted_service_account ?? false),
+            showTrustedAccount: computed<boolean>(() => state.providerData?.capability?.support_trusted_service_account ?? false),
             trustedAccounts: [] as ServiceAccountModel[],
             trustedAccountMenuItems: computed<SelectDropdownMenu[]>(() => state.trustedAccounts.map(d => ({
                 name: d.service_account_id,
                 label: d.name,
             }))),
-            secretTypes: computed(() => {
+            secretTypes: computed<string[]>(() => {
                 if (props.serviceAccountType === 'GENERAL') {
                     if (formState.attachTrustedAccount) {
                         return state.providerData?.capability?.general_service_account_schema ?? [];
@@ -157,6 +169,10 @@ export default defineComponent<Props>({
                 return state.providerData?.capability?.trusted_service_account_schema ?? [];
             }),
             credentialSchema: {} as JsonSchema,
+            trustedAccountInfoLink: computed<string>(() => {
+                const lang = storeState.language === 'en' ? '' : `${storeState.language}/`;
+                return `https://spaceone.org/${lang}docs/guides/asset-inventory/service-account/`;
+            }),
         });
         const formState = reactive({
             hasCredentialKey: true,
@@ -369,6 +385,14 @@ export default defineComponent<Props>({
     }
     .custom-schema-box {
         padding: 2rem 2rem 0 2rem;
+    }
+
+    /* custom design-system component - p-tab */
+    :deep(.p-field-group) {
+        .see-more-text {
+            @apply text-blue-700;
+            margin-left: 0.25rem;
+        }
     }
 
     /* custom design-system component - p-tab */


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
Trusted Account 필드그룹에 help-text 추가
![스크린샷 2022-09-27 오후 3 11 08](https://user-images.githubusercontent.com/18563857/192446727-cd09487e-d0a5-45e6-9ffa-7e2c8d3640e5.png)