### PR TITLE
fix(service-account): allow to access detail page with view permission (QA-276)

### DIFF
--- a/src/services/asset-inventory/routes.ts
+++ b/src/services/asset-inventory/routes.ts
@@ -160,7 +160,7 @@ const assetInventoryRoute: RouteConfig = {
                 {
                     path: ':serviceAccountId',
                     name: ASSET_INVENTORY_ROUTE.SERVICE_ACCOUNT.DETAIL._NAME,
-                    meta: { lnbVisible: true, label: ({ params }) => params.serviceAccountId, accessLevel: ACCESS_LEVEL.MANAGE_PERMISSION },
+                    meta: { lnbVisible: true, label: ({ params }) => params.serviceAccountId },
                     props: true,
                     component: ServiceAccountDetailPage,
                 },


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

- fix [QA-276](https://pyengine.atlassian.net/browse/QA-276) [RC1][Asset Inventory > Service Account] Page Permission을 가진 project Viewer 유저가 service Account detail에 접속 불가
  

### 생각해볼 문제
