### PR TITLE
fix(cost-explorer): fix cost-explore-lnb rendering

### DIFF
--- a/src/services/cost-explorer/CostExplorerLNB.vue
+++ b/src/services/cost-explorer/CostExplorerLNB.vue
@@ -99,7 +99,7 @@ export default {
             }),
             menuSet: computed<LNBMenu[]>(() => [
                 ...state.dashboardMenuSet,
-                filterLNBMenuByPermission([
+                ...filterLNBMenuByPermission([
                     {
                         type: 'item',
                         id: MENU_ID.COST_EXPLORER_COST_ANALYSIS,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [X] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [X] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [X] `Error / Warning / Lint / Type`

### 작업 내용
lnb의 Cost Analysis와 Budget 메뉴가 2depth로 렌더되어, `padding-left`간격이 벌어진 것으로 파악했습니다. 1depth로 렌더 되도록 수정하였습니다 [(QA-265)](https://pyengine.atlassian.net/browse/QA-265)

**전**
![image](https://user-images.githubusercontent.com/19162140/192935605-3d77bde2-02ed-4fc4-87b1-6021d1f71f56.png)

**후**
![image](https://user-images.githubusercontent.com/19162140/192936053-31e0b443-06e5-41f2-9b70-1273bd5abbe0.png)

### 생각해볼 문제
