### PR TITLE
fix(service-account): sorting attached general accounts [WIP]

### DIFF
--- a/src/services/asset-inventory/service-account/modules/ServiceAccountAttachedGeneralAccounts.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountAttachedGeneralAccounts.vue
@@ -4,7 +4,7 @@
         <div class="content-wrapper">
             <p-data-table :fields="fields" :items="items"
                           sortable
-                          sort-by:="name"
+                          sort-by="name"
                           :sort-desc="true"
             >
                 <template #col-name-format="{value, item}">

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountAttachedGeneralAccounts.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountAttachedGeneralAccounts.vue
@@ -2,7 +2,11 @@
     <p-pane-layout class="service-account-attached-general-accounts">
         <p-panel-top :title="$t('INVENTORY.SERVICE_ACCOUNT.DETAIL.ATTACHED_GENERAL_ACCOUNTS_TITLE')" />
         <div class="content-wrapper">
-            <p-data-table :fields="fields" :items="items" sortable>
+            <p-data-table :fields="fields" :items="items"
+                          sortable
+                          sort-by:="name"
+                          :sort-desc="true"
+            >
                 <template #col-name-format="{value, item}">
                     <p-anchor
                         :to="{
@@ -61,8 +65,8 @@ export default defineComponent({
             items: [] as any,
         });
         const fields = [
-            { name: 'name', label: 'Name' },
-            { name: 'service_account_id', label: 'Account ID' },
+            { name: 'name', label: 'Name', sortable: true },
+            { name: 'service_account_id', label: 'Account ID', sortable: false },
         ];
 
         const init = async () => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

attached general accounts 에 누락된 sort options 를 추가하였습니다.

### 생각해볼 문제

현재 PDatatable sort 기능에 문제가 있는 것 같습니다. 
해당 컴포넌트 수정 후 재확인이 필요합니다

Collector Page 에서 다수개 Collector 선택 > Selected Data 가 PDatatable 을 참조하는데, sort 가 작동하지 않음
Role Page 에서 한 개 Role 선택  > Details 하단의 API Policy Attachment 가 PDatatable 을 참조하는데, sort 가 작동하지 않음
스토리북에서도 작동하지 않습니다