### PR TITLE
fix(cost-analysis): fix 'cost-analysis-query-filter' vertical spacing

### DIFF
--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
@@ -318,6 +318,11 @@ export default {
         }
     }
 
+    /* custom design-system component - p-button-modal */
+    :deep(.p-button-modal) {
+        display: block;
+    }
+
     /* custom design-system component - p-select-dropdown */
     :deep(.list-button) {
         @apply bg-transparent;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [X] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [X] `Error / Warning / Lint / Type`

### 작업 내용
`<cost-analysis-query-filter />` 컴포넌트의 상하 간격이 디자인과 상이하였습니다. 해당 컴포넌트 상하에 `<p-button-modal />` 컴포넌트가 `display:inline-block;`으로 스타일링 되고 있어 default spacing을 가지고 있었습니다. 하여 `display:block;`으로 수정하여 간격을 조정했습니다. [(QA-269)](https://pyengine.atlassian.net/browse/QA-269)

### 생각해볼 문제