### PR TITLE
fix(service-account): add provider filter to valueHandlerMap & add queryString for next path

### DIFF
--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -112,7 +112,7 @@ export default {
         const queryHelper = new QueryHelper().setFiltersAsRawQueryString(query.filters);
 
         const state = reactive({
-            selectedProvider: query.provider ?? 'atlassian',
+            selectedProvider: query.provider ?? store.state.reference.provider.items[0],
             provider: computed(() => store.state.reference.provider.items),
             providerList: computed(() => Object.keys(state.provider).map(k => ({
                 ...state.provider[k],
@@ -297,10 +297,10 @@ export default {
                 store.dispatch('reference/provider/load'),
             ]);
             const providerFilter = Array.isArray(query.provider) ? query.provider[0] : query.provider;
-            state.selectedProvider = providerFilter || state.providerList[0].key;
+            state.selectedProvider = providerFilter || state.providerList[0]?.key;
             watch(() => state.selectedProvider, async (after, before) => {
                 if (after !== before) {
-                    await replaceUrlQuery('provider', after);
+                    replaceUrlQuery('provider', after);
                     await getTableSchema();
                     await listServiceAccountData();
                 }
@@ -359,7 +359,7 @@ export default {
         @apply overflow-hidden border border-gray-200 rounded-lg;
     }
 
-    /* custom design-system component - p-horizontal-layout */
+    /* custom design-system component -  p-dynamic-layout */
     :deep(.service-account-table) {
         overflow: unset;
         .p-toolbox-table {

--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -112,7 +112,7 @@ export default {
         const queryHelper = new QueryHelper().setFiltersAsRawQueryString(query.filters);
 
         const state = reactive({
-            selectedProvider: 'atlassian',
+            selectedProvider: query.provider ?? 'atlassian',
             provider: computed(() => store.state.reference.provider.items),
             providerList: computed(() => Object.keys(state.provider).map(k => ({
                 ...state.provider[k],

--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -150,14 +150,16 @@ export default {
                 { name: ACCOUNT_TYPE.GENERAL, label: ACCOUNT_TYPE_BADGE_OPTION[ACCOUNT_TYPE.GENERAL].label },
             ]),
             selectedAccountType: 'all',
-            searchFilters: computed<QueryStoreFilter[]>(() => [
-                ...queryHelper.setFiltersAsQueryTag(fetchOptionState.queryTags).filters,
-            ]),
+            searchFilters: computed<QueryStoreFilter[]>(() => queryHelper.setFiltersAsQueryTag(fetchOptionState.queryTags).filters),
         });
 
+        const searchFilter = new ApiQueryHelper();
         const { keyItemSets, valueHandlerMap, isAllLoaded } = useQuerySearchPropsWithSearchSchema(
             computed(() => tableState.schema?.options?.search as unknown as ConsoleSearchSchema[] ?? []),
             'identity.ServiceAccount',
+            computed(() => searchFilter.setFilters([
+                { k: 'provider', v: state.selectedProvider, o: '=' },
+            ]).apiQuery.filter),
         );
         /** Handling API with SpaceConnector * */
 
@@ -298,7 +300,7 @@ export default {
             state.selectedProvider = providerFilter || state.providerList[0].key;
             watch(() => state.selectedProvider, async (after, before) => {
                 if (after !== before) {
-                    replaceUrlQuery('provider', after);
+                    await replaceUrlQuery('provider', after);
                     await getTableSchema();
                     await listServiceAccountData();
                 }
@@ -355,6 +357,14 @@ export default {
     }
     .service-account-table {
         @apply overflow-hidden border border-gray-200 rounded-lg;
+    }
+
+    /* custom design-system component - p-horizontal-layout */
+    :deep(.service-account-table) {
+        overflow: unset;
+        .p-toolbox-table {
+            @apply rounded-lg;
+        }
     }
 }
 

--- a/src/services/asset-inventory/service-account/service-account-add/ServiceAccountAddPage.vue
+++ b/src/services/asset-inventory/service-account/service-account-add/ServiceAccountAddPage.vue
@@ -95,6 +95,7 @@ import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import InfoButton from '@/common/modules/portals/InfoButton.vue';
 
+import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
 import { ACCOUNT_TYPE } from '@/services/asset-inventory/service-account/config';
 import ServiceAccountAccountType
     from '@/services/asset-inventory/service-account/modules/ServiceAccountAccountType.vue';
@@ -251,7 +252,7 @@ export default {
                 const isSecretCreationSuccess = await createSecret(serviceAccountId);
                 if (!isSecretCreationSuccess) return;
             }
-            SpaceRouter.router.back();
+            SpaceRouter.router.push({ name: ASSET_INVENTORY_ROUTE.SERVICE_ACCOUNT._NAME, query: { provider: props.provider } });
         };
         const handleGoBack = () => {
             const nextPath = SpaceRouter.router.currentRoute.query.nextPath as string|undefined;

--- a/src/services/asset-inventory/service-account/service-account-detail/ServiceAccountDetailPage.vue
+++ b/src/services/asset-inventory/service-account/service-account-detail/ServiceAccountDetailPage.vue
@@ -62,6 +62,7 @@
                                       :service-account-id="serviceAccountId"
                                       :service-account-name="item.name"
                                       :attached-general-accounts="attachedGeneralAccounts"
+                                      :provider-id="providerId"
         />
     </div>
 </template>
@@ -95,7 +96,6 @@ import ServiceAccountProject from '@/services/asset-inventory/service-account/mo
 import ServiceAccountDeleteModal
     from '@/services/asset-inventory/service-account/service-account-detail/modules/ServiceAccountDeleteModal.vue';
 import type { ProviderModel, ServiceAccountModel } from '@/services/asset-inventory/service-account/type';
-
 
 export default defineComponent({
     name: 'ServiceAccountDetailPage',
@@ -132,9 +132,10 @@ export default defineComponent({
             attachedGeneralAccounts: [] as ServiceAccountModel[],
             attachedTrustedAccountId: computed(() => state.item.trusted_service_account_id),
             providerData: {} as ProviderModel,
+            providerId: computed(() => state.item?.provider),
             provider: computed(() => {
                 if (!storeState.providerLoading && !state.loading) {
-                    return storeState.providers[state.item?.provider] || undefined;
+                    return storeState.providers[state.providerId] || undefined;
                 }
                 return undefined;
             }),
@@ -197,7 +198,7 @@ export default defineComponent({
         watch(() => props.serviceAccountId, async (serviceAccountId) => {
             if (serviceAccountId) {
                 await getServiceAccount(serviceAccountId);
-                await getProviderData(state.item?.provider);
+                await getProviderData(state.providerId);
             }
         }, { immediate: true });
 

--- a/src/services/asset-inventory/service-account/service-account-detail/modules/ServiceAccountDeleteModal.vue
+++ b/src/services/asset-inventory/service-account/service-account-detail/modules/ServiceAccountDeleteModal.vue
@@ -74,6 +74,10 @@ export default {
             type: Array as PropType<ServiceAccountModel[]>,
             default: () => ([]),
         },
+        providerId: {
+            type: String,
+            default: '',
+        },
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
@@ -100,7 +104,7 @@ export default {
         /* Event */
         const handleConfirmDelete = async () => {
             await deleteServiceAccount();
-            await SpaceRouter.router.push({ name: ASSET_INVENTORY_ROUTE.SERVICE_ACCOUNT._NAME });
+            await SpaceRouter.router.push({ name: ASSET_INVENTORY_ROUTE.SERVICE_ACCOUNT._NAME, query: { provider: props.providerId } });
         };
 
         return {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
qa 277 작업에 1, 3번 문제입니다.
query search에서 valueHandlerMap에 따로 분리되어있던 provider 가 필터로 적용되지 않아 모든 검색결과가 나왔었습니다.
어카운트를 삭제 추가 시, 리스트페이지로 다시 돌아가는데 그때 추가/삭제된 provider로 가지 않고 default provider로 넘겨져 수정하였습니다.
### 생각해볼 문제
