### PR TITLE
fix(cost-analysis-page): initializes store when approaching url without queryString

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@amcharts/amcharts4": "^4.10.10",
         "@amcharts/amcharts4-geodata": "^4.1.18",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.407",
+        "@spaceone/design-system": "^1.1.0-beta.408",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -3829,9 +3829,9 @@
       "dev": true
     },
     "node_modules/@spaceone/design-system": {
-      "version": "1.1.0-beta.407",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.407.tgz",
-      "integrity": "sha512-/7EI4RrkDb15qcOEoLoFj8uj9RkBBFFyhYq/JAF4X2/mXvqx3EakPsQeCEAM5DQrUMnT51a9gI6UKJV6bMEc0w==",
+      "version": "1.1.0-beta.408",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.408.tgz",
+      "integrity": "sha512-Ito3Pwx+azTZ2ssmlklafIi47v+G/meQdtz9FkKTnhIhPJbQKpwtITU+7JJYeFIiv/xQJ9+e+AHOT5NSNzcHAg==",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -39104,9 +39104,9 @@
       "dev": true
     },
     "@spaceone/design-system": {
-      "version": "1.1.0-beta.407",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.407.tgz",
-      "integrity": "sha512-/7EI4RrkDb15qcOEoLoFj8uj9RkBBFFyhYq/JAF4X2/mXvqx3EakPsQeCEAM5DQrUMnT51a9gI6UKJV6bMEc0w==",
+      "version": "1.1.0-beta.408",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.408.tgz",
+      "integrity": "sha512-Ito3Pwx+azTZ2ssmlklafIi47v+G/meQdtz9FkKTnhIhPJbQKpwtITU+7JJYeFIiv/xQJ9+e+AHOT5NSNzcHAg==",
       "requires": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -44640,7 +44640,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "1.1.0-beta.407",
+        "@spaceone/design-system": "^1.1.0-beta.408",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -47541,9 +47541,9 @@
           "dev": true
         },
         "@spaceone/design-system": {
-          "version": "1.1.0-beta.407",
-          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.407.tgz",
-          "integrity": "sha512-/7EI4RrkDb15qcOEoLoFj8uj9RkBBFFyhYq/JAF4X2/mXvqx3EakPsQeCEAM5DQrUMnT51a9gI6UKJV6bMEc0w==",
+          "version": "1.1.0-beta.408",
+          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.408.tgz",
+          "integrity": "sha512-Ito3Pwx+azTZ2ssmlklafIi47v+G/meQdtz9FkKTnhIhPJbQKpwtITU+7JJYeFIiv/xQJ9+e+AHOT5NSNzcHAg==",
           "requires": {
             "@amcharts/amcharts4": "^4.10.10",
             "@babel/runtime": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@amcharts/amcharts4": "^4.10.10",
     "@amcharts/amcharts4-geodata": "^4.1.18",
     "@gtm-support/vue2-gtm": "^1.3.0",
-    "@spaceone/design-system": "^1.1.0-beta.407",
+    "@spaceone/design-system": "^1.1.0-beta.408",
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-color": "^2.0.0-beta.12",
     "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
+++ b/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
@@ -61,8 +61,6 @@ export default {
         },
     },
     setup(props) {
-        const currentQuery = SpaceRouter.router.currentRoute.query;
-
         const state = reactive({
             costQueryList: computed<CostQuerySetModel[]>(() => costExplorerStore.state.costAnalysis.costQueryList),
             selectedQueryId: computed<string|undefined>(() => costExplorerStore.state.costAnalysis.selectedQueryId),
@@ -103,7 +101,7 @@ export default {
         });
 
         let unregisterStoreWatch;
-        const registerStoreWatch = () => {
+        const registerStoreWatch = (currentQuery) => {
             unregisterStoreWatch = watch(() => costExplorerStore.getters['costAnalysis/currentQuerySetOptions'], (options) => {
                 if (props.querySetId) return;
 
@@ -130,6 +128,7 @@ export default {
 
         /* Page Init */
         (async () => {
+            const currentQuery = SpaceRouter.router.currentRoute.query;
             // list cost query sets
             await costExplorerStore.dispatch('costAnalysis/listCostQueryList');
 
@@ -150,7 +149,7 @@ export default {
             }
 
             // register store watch
-            registerStoreWatch();
+            registerStoreWatch(currentQuery);
         })();
 
         return {

--- a/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
+++ b/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
@@ -61,6 +61,8 @@ export default {
         },
     },
     setup(props) {
+        const currentQuery = SpaceRouter.router.currentRoute.query;
+
         const state = reactive({
             costQueryList: computed<CostQuerySetModel[]>(() => costExplorerStore.state.costAnalysis.costQueryList),
             selectedQueryId: computed<string|undefined>(() => costExplorerStore.state.costAnalysis.selectedQueryId),
@@ -114,7 +116,6 @@ export default {
                     filters: objectToQueryString(options.filters),
                 };
 
-                const currentQuery = SpaceRouter.router.currentRoute.query;
                 if (JSON.stringify(newQuery) !== JSON.stringify(currentQuery)) {
                     SpaceRouter.router.replace({ query: newQuery });
                 }
@@ -141,9 +142,11 @@ export default {
                 } else {
                     setSelectedQueryId();
                 }
-            } else {
-                const options = getQueryOptionsFromUrlQuery(SpaceRouter.router.currentRoute.query);
+            } else if (Object.keys(currentQuery).length) {
+                const options = getQueryOptionsFromUrlQuery(currentQuery);
                 setQueryOptions(options);
+            } else {
+                await costExplorerStore.dispatch('costAnalysis/initCostAnalysisStoreState');
             }
 
             // register store watch


### PR DESCRIPTION

### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
costExplorer에서 라우트 이동 시, cost Analysis의 필터들이 store에 남아있어 init과정에 추가적인 조건을 부여하였습니다.

기존엔 queryString이 존재하거나 저장된 쿼리에대해 초기화를 진행하는 두가지 분기만 있었고,
이번 PR에서 queryString과 queryId 둘다 없을땐 store를 초기화하도록 수정하였습니다.
### 생각해볼 문제
