### PR TITLE
fix(api, error-handler): do not reject error as promise instance

### DIFF
--- a/packages/cloudforet/core-lib/src/space-connector/api.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/api.ts
@@ -198,9 +198,9 @@ class API {
         // Axios's response interceptor with error handling
         this.instance.interceptors.response.use(
             (response: AxiosResponse) => response,
-            error => new Promise((resolve, reject) => {
-                this.handleRequestError(error).catch((err) => { reject(err); });
-            }),
+            async (error) => {
+                await this.handleRequestError(error);
+            },
         );
     }
 }

--- a/packages/cloudforet/core-lib/src/space-connector/api.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/api.ts
@@ -145,7 +145,7 @@ class API {
         return this.defaultAxiosConfig;
     }
 
-    private handleRequestError = async (error: AxiosError) => {
+    private handleRequestError = async (error: AxiosError): Promise<APIError|void> => {
         switch (error.response?.status) {
         case 400: {
             throw new BadRequestError(error);
@@ -198,7 +198,7 @@ class API {
         // Axios's response interceptor with error handling
         this.instance.interceptors.response.use(
             (response: AxiosResponse) => response,
-            error => Promise.reject(this.handleRequestError(error)),
+            error => this.handleRequestError(error),
         );
     }
 }

--- a/packages/cloudforet/core-lib/src/space-connector/api.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/api.ts
@@ -145,7 +145,7 @@ class API {
         return this.defaultAxiosConfig;
     }
 
-    private handleRequestError = async (error: AxiosError): Promise<APIError|void> => {
+    private handleRequestError = async (error: AxiosError): Promise<void> => {
         switch (error.response?.status) {
         case 400: {
             throw new BadRequestError(error);
@@ -198,7 +198,9 @@ class API {
         // Axios's response interceptor with error handling
         this.instance.interceptors.response.use(
             (response: AxiosResponse) => response,
-            error => this.handleRequestError(error),
+            error => new Promise((resolve, reject) => {
+                this.handleRequestError(error).catch((err) => { reject(err); });
+            }),
         );
     }
 }

--- a/src/common/composables/error/errorHandler.ts
+++ b/src/common/composables/error/errorHandler.ts
@@ -53,21 +53,11 @@ export default class ErrorHandler {
         }
     }
 
-    static handleRequestError(error, errorMessage: TranslateResult) {
-        if (error instanceof Promise) {
-            error.catch((err) => {
-                if (!isInstanceOfAuthorizationError(err)) {
-                    if (isInstanceOfBadRequestError(err) && errorMessage) showErrorMessage(errorMessage, err);
-                    else if (isInstanceOfAPIError(err)) showErrorMessage('Something is Wrong! Please contact the administrator.', err);
-                }
-                this.handleError(err);
-            });
-        } else {
-            if (!isInstanceOfAuthorizationError(error)) {
-                if (isInstanceOfBadRequestError(error) && errorMessage) showErrorMessage(errorMessage, error);
-                else if (isInstanceOfAPIError(error)) showErrorMessage('Something is Wrong! Please contact the administrator.', error);
-            }
-            this.handleError(error);
+    static handleRequestError(error: unknown, errorMessage: TranslateResult) {
+        if (!isInstanceOfAuthorizationError(error)) {
+            if (isInstanceOfBadRequestError(error) && errorMessage) showErrorMessage(errorMessage, error);
+            else if (isInstanceOfAPIError(error)) showErrorMessage('Something is Wrong! Please contact the administrator.', error);
         }
+        this.handleError(error);
     }
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

 - [promise case error handling PR](https://github.com/cloudforet-io/console/pull/154) 의 내용을 일부 revert 했습니다. 해당 PR은 근본 원인을 해결한 것이 아니라 일어나는 현상만 막았기 때문입니다.

- promise error 를 반환하는 root cause 를 찾아 해결했습니다. api.ts 에서 axios response 인터셉터에 프라미스 객체로 감싸서 에러를 리턴해야 합니다. 그런데 `this.handleRequestError` 함수가 Promise 객체를 리턴하는 함수로 바뀌면서, 프라미스 객체가 다시 한 번 프라미스 객체를 감싸는 형태로 리턴하게 되었습니다. 
이 문제를 수정하였습니다.


### 생각해볼 문제
