### PR TITLE
fix(double-check-modal): add trim for service account name space issue

### DIFF
--- a/src/common/components/modals/DoubleCheckModal.vue
+++ b/src/common/components/modals/DoubleCheckModal.vue
@@ -136,7 +136,6 @@ export default defineComponent({
         watch(() => checkState.inputText, (value) => {
             // TODO: Currently, name with space exists. So, further fixes are required later.
             checkState.invalid = value.trim().length > 0 && props.verificationText.trim() !== value;
-            console.log(checkState.inputText, props.verificationText, checkState.invalid);
         });
 
         return {

--- a/src/common/components/modals/DoubleCheckModal.vue
+++ b/src/common/components/modals/DoubleCheckModal.vue
@@ -35,7 +35,7 @@
                             </template>
                         </i18n>
                     </template>
-                    <p-text-input v-model="inputText"
+                    <p-text-input v-model.trim="inputText"
                                   :invalid="invalid"
                                   block
                                   @keyup.enter="confirm()"
@@ -134,7 +134,6 @@ export default defineComponent({
 
         watch(() => checkState.inputText, (value) => {
             // TODO: Here, too.
-            checkState.inputText = checkState.inputText.trim();
             checkState.invalid = value.trim().length > 0 && props.verificationText.trim() !== value;
         });
 

--- a/src/common/components/modals/DoubleCheckModal.vue
+++ b/src/common/components/modals/DoubleCheckModal.vue
@@ -1,4 +1,5 @@
 <template>
+    <!--TODO: Currently, name with space exists. So, further fixes are required later.-->
     <p-button-modal :header-title="headerTitle"
                     :scrollable="scrollable"
                     :size="size"
@@ -6,7 +7,7 @@
                     :backdrop="backdrop"
                     :visible.sync="proxyVisible"
                     :theme-color="themeColor"
-                    :disabled="invalid || inputText.length === 0"
+                    :disabled="invalid || inputText.trim().length === 0"
                     @cancel="handleCancel"
                     @close="handleClose"
                     @confirm="handleConfirm"
@@ -123,7 +124,8 @@ export default defineComponent({
             emit('close', event);
         };
         const handleConfirm = () => {
-            if (checkState.inputText === props.verificationText) {
+            // TODO: Currently, name with space exists. So, further fixes are required later.
+            if (checkState.inputText.trim() === props.verificationText.trim()) {
                 reset();
                 emit('confirm');
             } else {
@@ -132,7 +134,9 @@ export default defineComponent({
         };
 
         watch(() => checkState.inputText, (value) => {
-            checkState.invalid = value.length > 0 && props.verificationText !== value;
+            // TODO: Currently, name with space exists. So, further fixes are required later.
+            checkState.invalid = value.trim().length > 0 && props.verificationText.trim() !== value;
+            console.log(checkState.inputText, props.verificationText, checkState.invalid);
         });
 
         return {

--- a/src/common/components/modals/DoubleCheckModal.vue
+++ b/src/common/components/modals/DoubleCheckModal.vue
@@ -1,5 +1,4 @@
 <template>
-    <!--TODO: Currently, name with space exists. So, further fixes are required later.-->
     <p-button-modal :header-title="headerTitle"
                     :scrollable="scrollable"
                     :size="size"
@@ -7,7 +6,7 @@
                     :backdrop="backdrop"
                     :visible.sync="proxyVisible"
                     :theme-color="themeColor"
-                    :disabled="invalid || inputText.trim().length === 0"
+                    :disabled="invalid || inputText.length === 0"
                     @cancel="handleCancel"
                     @close="handleClose"
                     @confirm="handleConfirm"
@@ -125,7 +124,7 @@ export default defineComponent({
         };
         const handleConfirm = () => {
             // TODO: Currently, name with space exists. So, further fixes are required later.
-            if (checkState.inputText.trim() === props.verificationText.trim()) {
+            if (checkState.inputText === props.verificationText.trim()) {
                 reset();
                 emit('confirm');
             } else {
@@ -134,7 +133,8 @@ export default defineComponent({
         };
 
         watch(() => checkState.inputText, (value) => {
-            // TODO: Currently, name with space exists. So, further fixes are required later.
+            // TODO: Here, too.
+            checkState.inputText = checkState.inputText.trim();
             checkState.invalid = value.trim().length > 0 && props.verificationText.trim() !== value;
         });
 

--- a/src/services/asset-inventory/service-account/service-account-add/ServiceAccountAddPage.vue
+++ b/src/services/asset-inventory/service-account/service-account-add/ServiceAccountAddPage.vue
@@ -188,7 +188,7 @@ export default {
             try {
                 const res = await SpaceConnector.client.identity.serviceAccount.create({
                     provider: props.provider,
-                    name: formState.baseInformationForm.accountName,
+                    name: formState.baseInformationForm.accountName.trim(),
                     data: formState.baseInformationForm.customSchemaForm,
                     tags: formState.baseInformationForm.tags,
                     service_account_type: formState.accountType,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [ ] `Error / Warning / Lint / Type`

### 작업 내용
- QA-291
- 이름 앞뒤에 공백이있는 service account 를 삭제할 때 생기는 이슈 해결
- service account 등록 시 이름에 `trim()` 적용 
- 삭제 시 비교 대상이되는 기존 `verificationText` 및 `inputText` 값에 모두 `trim()` 적용
- 추후 백엔드 측에서도 trim 처리할 예정이지만 현재 만들어진 service account 와 혹시 모를 상황을 위해 `double check modal` 에서 관련된 모든 부분에 `trim()` 처리를 하였음 
(추후 수정 필요  ex. `inputText`에서는 trim을 적용하지만 `verificationText`는 공백이 없는 값만 생성이 될 것이므로 trim 제거)

### 생각해볼 문제
