### PR TITLE
fix(space-connector): fix return value of refreshAccessToken function

### DIFF
--- a/packages/cloudforet/core-lib/src/space-connector/api.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/api.ts
@@ -84,7 +84,7 @@ class API {
 
     async refreshAccessToken(executeSessionTimeoutCallback = true): Promise<boolean|undefined> {
         if (!this.refreshToken) {
-            return undefined;
+            return false;
         }
         if (API.checkRefreshingState() !== 'true') {
             try {
@@ -100,7 +100,7 @@ class API {
                 API.unsetRefreshingState();
             }
         } else {
-            return undefined;
+            return true;
         }
     }
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
access token 만료 시, 401이 뜨는경우에 refreshAccessToken 함수가 실행되는데 이때 리턴하는 값에 따라 던져지는 Error타입이 다릅니다.
이 때, 리턴 타입에 false, true, undefined가 있었는데 이로인해 분기문이 잘못 타져 undefined를 제거하였습니다.

토큰 재발급을
했으면 true
하고있어도 true
못헀으면 false
실패했어도 false

### 생각해볼 문제
