### PR TITLE
feat(file-manager): give domain information when adding file

### DIFF
--- a/src/common/composables/file-uploader/index.ts
+++ b/src/common/composables/file-uploader/index.ts
@@ -1,0 +1,9 @@
+import type { Ref } from 'vue';
+
+import { uploadFileAndGetFileInfo } from '@/lib/file-manager';
+
+export const useFileUploader = (domainId: Ref<string|null>) => ({
+    fileUploader(file: File) {
+        return uploadFileAndGetFileInfo(file, domainId.value);
+    },
+});

--- a/src/lib/file-manager/index.ts
+++ b/src/lib/file-manager/index.ts
@@ -7,10 +7,11 @@ import type { FileInfo } from '@/lib/file-manager/type';
 import type { Attachment } from '@/common/components/editor/extensions/image/type';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
-const getUploadInfo = async (file: File): Promise<[fileId: string, uploadUrl: string, options: object]> => {
+const getUploadInfo = async (file: File, domainId: string|null): Promise<[fileId: string, uploadUrl: string, options: object]> => {
     const result = await SpaceConnector.client.fileManager.file.add({
         name: file.name,
         file_type: file.type,
+        domain_id: domainId,
     });
     if (!result.upload_url || !result.upload_options) throw new Error('[File Manager] No upload info in response of add file api');
     return [result.file_id, result.upload_url, result.upload_options];
@@ -35,9 +36,9 @@ export const getDownloadUrl = async (fileId: string): Promise<string> => {
 };
 
 
-export const uploadFileAndGetFileInfo = async (file: File): Promise<Attachment> => {
+export const uploadFileAndGetFileInfo = async (file: File, domainId: string|null): Promise<Attachment> => {
     try {
-        const [fileId, uploadUrl, options] = await getUploadInfo(file);
+        const [fileId, uploadUrl, options] = await getUploadInfo(file, domainId);
         await uploadFile(uploadUrl, options, file);
         const downloadUrl = await getDownloadUrl(fileId);
         return { downloadUrl, fileId };

--- a/src/services/info/notice/modules/NoticeForm.vue
+++ b/src/services/info/notice/modules/NoticeForm.vue
@@ -45,7 +45,7 @@
                            :invalid-text="invalidTexts.contents"
             >
                 <template #default="{invalid}">
-                    <text-editor :value="contents" :attachments.sync="attachments" :image-uploader="uploadFileAndGetFileInfo"
+                    <text-editor :value="contents" :attachments.sync="attachments" :image-uploader="fileUploader"
                                  :invalid="invalid" @update:value="(d) => setForm('contents', d)"
                     />
                 </template>
@@ -97,13 +97,13 @@ import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
-import { uploadFileAndGetFileInfo } from '@/lib/file-manager';
 import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 
 import { emptyHtmlRegExp } from '@/common/components/editor/extensions/image/helper';
 import type { Attachment } from '@/common/components/editor/extensions/image/type';
 import TextEditor from '@/common/components/editor/TextEditor.vue';
 import ErrorHandler from '@/common/composables/error/errorHandler';
+import { useFileUploader } from '@/common/composables/file-uploader';
 import { useFormValidator } from '@/common/composables/form-validator';
 
 import type { NoticePostModel } from '@/services/info/notice/type';
@@ -150,7 +150,7 @@ export default {
             isPinned: false,
             isPopup: false,
             attachments: [] as Attachment[],
-            isAllDomainSelected: !!store.getters['user/hasSystemRole'],
+            isAllDomainSelected: !!store.getters['user/hasSystemRole'], // It's active only in root domain case
             boardIdState: '',
             domainList: [] as Array<DomainItem>,
             selectedDomain: store.getters['user/hasSystemRole']
@@ -193,6 +193,8 @@ export default {
                 is_popup: state.isPopup,
             },
         }));
+
+        const { fileUploader } = useFileUploader(computed(() => (state.isAllDomainSelected ? null : state.selectedDomain[0].name)));
 
         const handleConfirm = () => {
             if (props.type === 'CREATE') handleCreateNotice();
@@ -311,7 +313,7 @@ export default {
             invalidState,
             invalidTexts,
             isAllValid,
-            uploadFileAndGetFileInfo,
+            fileUploader,
         };
     },
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

- `useFileUploader` 훅 추가
  - file add 시에 `domain_id` 정보를 reactive하게 반영하기 위함

### 생각해볼 문제

- 백엔드 개발이 아직 완료되지 않아서, 테스트 후 머지하겠습니다