### PR TITLE
fix(notice): do not show domain-id when its for all domain

### DIFF
--- a/src/services/info/notice/modules/NoticeForm.vue
+++ b/src/services/info/notice/modules/NoticeForm.vue
@@ -282,11 +282,11 @@ export default {
             state.isPinned = d.options?.is_pinned ?? false;
             state.isPopup = d.options?.is_popup ?? false;
             state.attachments = d.files?.map(file => ({ fileId: file.file_id, downloadUrl: file.download_url ?? '' })) ?? [];
-            state.isAllDomainSelected = !d.domain_id;
+            state.isAllDomainSelected = !d?.domain_id;
             state.boardIdState = d?.board_id ?? '';
             state.selectedDomain = d?.domain_id
                 ? [{ name: d.domain_id, label: state.domainName || d.domain_id }]
-                : [{ name: store.state.domain.domainId, label: store.state.domain.domainId }];
+                : [];
             state.postId = d.post_id ?? '';
             setForm('writerName', d.writer);
             setForm('noticeTitle', d.title);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
전체 도메인 대상의 공지사항일 경우, 수정 시 domain 항목 비우기
[[Info > Notice] For posts created for the all domain, the name is not visible on the notice Edit page](https://github.com/spaceone-dev/feedback/issues/144)
![스크린샷 2022-10-04 오후 8 27 04](https://user-images.githubusercontent.com/18563857/193808248-9250d403-56fe-4f5d-af40-aca647f64a01.png)
