### PR TITLE
refactor(store): change init data of projectGroup from {} to undefined

### DIFF
--- a/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBFavorite.vue
@@ -163,7 +163,7 @@ export default {
             //
             cloudServiceTypes: computed<CloudServiceTypeReferenceMap>(() => store.state.reference.cloudServiceType.items),
             projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
-            projectGroups: computed<ProjectGroupReferenceMap>(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             //
             favoriteMenuItems: computed<FavoriteItem[]>(() => convertMenuConfigToReferenceData(
                 store.state.favorite.menuItems,

--- a/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBRecent.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBRecent.vue
@@ -80,7 +80,7 @@ export default defineComponent({
         const storeState = reactive({
             menuItems: computed<DisplayMenu[]>(() => store.getters['display/allMenuList']),
             projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
-            projectGroups: computed<ProjectGroupReferenceMap>(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             cloudServiceTypes: computed<CloudServiceTypeReferenceMap>(() => store.state.reference.cloudServiceType.items),
             recents: computed<RecentConfig[]>(() => store.state.recent.allItems),
         });

--- a/src/services/administration/iam/role/modules/role-managemnet-table/modules/RoleDeleteModal.vue
+++ b/src/services/administration/iam/role/modules/role-managemnet-table/modules/RoleDeleteModal.vue
@@ -55,7 +55,6 @@
 </template>
 
 <script lang="ts">
-
 import {
     computed, reactive, toRefs, watch,
 } from 'vue';
@@ -69,6 +68,8 @@ import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { i18n } from '@/translations';
+
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 
 import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 import { referenceRouter } from '@/lib/reference/referenceRouter';
@@ -116,7 +117,7 @@ export default {
         const state = reactive({
             users: computed(() => store.state.reference.user.items),
             projects: computed(() => store.getters['reference/projectItems']),
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             loading: true,
             proxyVisible: useProxyValue('visible', props, emit),
             fields: [

--- a/src/services/administration/iam/user/modules/user-management-tab/UserAssignedRole.vue
+++ b/src/services/administration/iam/user/modules/user-management-tab/UserAssignedRole.vue
@@ -52,7 +52,7 @@ import type { Tags } from '@/models';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
-import type { ProjectGroupReferenceItem } from '@/store/modules/reference/project-group/type';
+import type { ProjectGroupReferenceItem, ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceItem } from '@/store/modules/reference/project/type';
 
 import { referenceRouter } from '@/lib/reference/referenceRouter';
@@ -99,7 +99,7 @@ export default {
                 { name: 'labels', label: 'Labels' },
             ]),
             items: [] as UserRoleItem[],
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             projects: computed(() => store.getters['reference/projectItems']),
         });
 

--- a/src/services/asset-inventory/cloud-service/CloudServicePage.vue
+++ b/src/services/asset-inventory/cloud-service/CloudServicePage.vue
@@ -55,7 +55,6 @@
 </template>
 
 <script lang="ts">
-
 import {
     computed, onUnmounted, reactive, toRefs, watch,
 } from 'vue';
@@ -81,6 +80,8 @@ import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
+
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 
 import { assetUrlConverter } from '@/lib/helper/asset-helper';
 import {
@@ -124,7 +125,7 @@ export default {
     setup() {
         const storeState = reactive({
             projects: computed(() => store.getters['reference/projectItems']),
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             serviceAccounts: computed(() => store.state.reference.serviceAccount.items),
         });
         const handlerState = reactive({

--- a/src/services/cost-explorer/budget/budget-detail/modules/budget-info/BudgetDetailInfo.vue
+++ b/src/services/cost-explorer/budget/budget-detail/modules/budget-info/BudgetDetailInfo.vue
@@ -50,10 +50,10 @@ import { computed, reactive, toRefs } from 'vue';
 
 import { PPaneLayout, PAnchor } from '@spaceone/design-system';
 
-
 import { store } from '@/store';
 
 import { CURRENCY } from '@/store/modules/display/config';
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
 
 import { currencyMoneyFormatter } from '@/lib/helper/currency-helper';
@@ -68,6 +68,7 @@ import {
     BUDGET_TIME_UNIT,
 } from '@/services/cost-explorer/budget/type';
 import { costExplorerStore } from '@/services/cost-explorer/store';
+
 
 const getKeyOfCostType = (costType: Record<CostType, string[]|null>) => Object.keys(costType).filter(k => (costType[k] !== null))[0];
 const getValueOfCostType = (costType: Record<CostType, string[]|null>, costTypeKey: string) => costType[costTypeKey];
@@ -100,7 +101,7 @@ export default {
     setup() {
         const state = reactive({
             projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             budgetData: computed<Partial<BudgetData>|null>(() => costExplorerStore.state.budget.budgetData),
             costTypeKey: computed(() => (state.budgetData ? getKeyOfCostType(state.budgetData.cost_types ?? {}) : '')),
             costTypeValue: computed(() => (state.budgetData ? getValueOfCostType(state.budgetData.cost_types ?? {}, state.costTypeKey) : [])),

--- a/src/services/cost-explorer/budget/modules/budget-list/BudgetListCard.vue
+++ b/src/services/cost-explorer/budget/modules/budget-list/BudgetListCard.vue
@@ -83,10 +83,9 @@ import {
     PDivider, PI, PSkeleton,
 } from '@spaceone/design-system';
 
-
 import { store } from '@/store';
 
-import type { ProjectGroupReferenceItem } from '@/store/modules/reference/project-group/type';
+import type { ProjectGroupReferenceItem, ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceItem } from '@/store/modules/reference/project/type';
 import type { ReferenceMap } from '@/store/modules/reference/type';
 
@@ -136,7 +135,7 @@ export default {
     setup(props: Props) {
         const storeState = reactive({
             projects: computed(() => store.getters['reference/projectItems']),
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             providers: computed(() => store.state.reference.provider.items),
             serviceAccounts: computed(() => store.state.reference.serviceAccount.items),
             regions: computed(() => store.state.reference.region.items),

--- a/src/services/cost-explorer/budget/modules/budget-toolbox/BudgetToolbox.vue
+++ b/src/services/cost-explorer/budget/modules/budget-toolbox/BudgetToolbox.vue
@@ -53,8 +53,6 @@
 </template>
 
 <script lang="ts">
-
-
 import {
     computed, reactive, toRefs, watch,
 } from 'vue';
@@ -78,6 +76,7 @@ import { QueryHelper } from '@cloudforet/core-lib/query';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
 
 import BudgetToolboxUsageRange
@@ -85,6 +84,7 @@ import BudgetToolboxUsageRange
 import type { BudgetUsageAnalyzeRequestParam, BudgetUsageRange } from '@/services/cost-explorer/budget/type';
 import CurrencySelectDropdown from '@/services/cost-explorer/modules/CurrencySelectDropdown.vue';
 import type { Period } from '@/services/cost-explorer/type';
+
 
 export interface Pagination {
     pageStart: number;
@@ -119,7 +119,7 @@ export default {
 
         const storeState = reactive({
             projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             serviceAccounts: computed(() => store.state.reference.serviceAccount.items),
         });
 

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisDataTable.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisDataTable.vue
@@ -69,19 +69,17 @@ import dayjs from 'dayjs';
 import { get } from 'lodash';
 import type { Table } from 'pdfmake/interfaces';
 
-
 import { setApiQueryWithToolboxOptions } from '@cloudforet/core-lib/component-util/toolbox';
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import type { QueryStoreFilter } from '@cloudforet/core-lib/query/type';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 
-// eslint-disable-next-line import/extensions,import/no-unresolved
-
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
 import type { ExcelDataField } from '@/store/modules/file/type';
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
 import type { ReferenceMap } from '@/store/modules/reference/type';
 
@@ -100,6 +98,7 @@ import { GRANULARITY, GROUP_BY, GROUP_BY_ITEM_MAP } from '@/services/cost-explor
 import { costExplorerStore } from '@/services/cost-explorer/store';
 import type { GroupByItem } from '@/services/cost-explorer/store/cost-analysis/type';
 import type { CostAnalyzeModel, UsdCost } from '@/services/cost-explorer/widgets/type';
+
 
 interface PrintModeFieldSet {
     widths?: Table['widths'];
@@ -131,7 +130,7 @@ export default {
                 return 'YYYY-MM-DD';
             }),
             //
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
             providers: computed(() => store.state.reference.provider.items),
             regions: computed(() => store.state.reference.region.items),

--- a/src/services/cost-explorer/widgets/BudgetUsageWithForecast.vue
+++ b/src/services/cost-explorer/widgets/BudgetUsageWithForecast.vue
@@ -59,6 +59,7 @@ import { store } from '@/store';
 import { i18n } from '@/translations';
 
 import { CURRENCY } from '@/store/modules/display/config';
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
 
 import { currencyMoneyFormatter } from '@/lib/helper/currency-helper';
@@ -141,7 +142,7 @@ export default {
                 },
             ])),
             items: [] as BudgetItem[],
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
             widgetLink: computed(() => {
                 if (props.printMode) return undefined;

--- a/src/services/dashboard/modules/FavoritesWidget.vue
+++ b/src/services/dashboard/modules/FavoritesWidget.vue
@@ -72,7 +72,7 @@ export default {
     setup() {
         const state = reactive({
             projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
-            projectGroups: computed<ProjectGroupReferenceMap>(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             cloudServiceTypes: computed<CloudServiceTypeReferenceMap>(() => store.state.reference.cloudServiceType.items),
             favoriteProjects: computed<FavoriteItem[]>(() => {
                 const favoriteProjectItems = convertProjectConfigToReferenceData(store.state.favorite.projectItems, state.projects);

--- a/src/services/project/ProjectPage.vue
+++ b/src/services/project/ProjectPage.vue
@@ -114,7 +114,6 @@
 </template>
 
 <script lang="ts">
-
 import {
     computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
@@ -134,6 +133,7 @@ import { store } from '@/store';
 
 import type { FavoriteItem } from '@/store/modules/favorite/type';
 import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 
 import {
     convertProjectConfigToReferenceData,
@@ -209,7 +209,7 @@ export default {
             projectCount: computed(() => store.state.service.project.projectCount),
             projects: computed(() => store.getters['reference/projectItems']),
             favoriteProjects: computed(() => store.state.favorite.projectItems),
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
             projectGroupFormVisible: computed(() => store.state.service.project.projectGroupFormVisible),
             projectGroupDeleteCheckModalVisible: computed(() => store.state.service.project.projectGroupDeleteCheckModalVisible),
             favoriteProjectGroups: computed(() => store.state.favorite.projectGroupItems),

--- a/src/services/project/project-detail/project-member/modules/ProjectMemberTab.vue
+++ b/src/services/project/project-detail/project-member/modules/ProjectMemberTab.vue
@@ -72,7 +72,6 @@
 </template>
 
 <script lang="ts">
-
 import type { SetupContext } from 'vue';
 import {
     computed, getCurrentInstance, reactive, toRefs, watch,
@@ -99,6 +98,7 @@ import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
 
 import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
@@ -159,7 +159,7 @@ export default {
         const storeState = reactive({
             users: computed(() => store.state.reference.user.items),
             projects: computed(() => store.getters['reference/projectItems']),
-            projectGroups: computed(() => store.state.reference.projectGroup.items),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
         });
         const state = reactive({
             searchText: apiQueryHelper.filters.map(d => d.v).join(' ') || '',

--- a/src/store/modules/reference/getters.ts
+++ b/src/store/modules/reference/getters.ts
@@ -1,5 +1,9 @@
 import type { Getter } from 'vuex';
 
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
 
+
 export const projectItems: Getter<any, any> = (state): ProjectReferenceMap => state.project?.items ?? {};
+
+export const projectGroupItems: Getter<any, any> = (state): ProjectGroupReferenceMap => state.projectGroup?.items ?? {};

--- a/src/store/modules/reference/project-group/actions.ts
+++ b/src/store/modules/reference/project-group/actions.ts
@@ -33,6 +33,7 @@ export const load: Action<ProjectGroupReferenceState, any> = async (
         response.results.forEach((projectGroupInfo: any): void => {
             const parentGroup = projectGroupInfo.parent_project_group_info;
             projectGroups[projectGroupInfo.project_group_id] = {
+                key: projectGroupInfo.project_group_id,
                 label: (parentGroup)
                     ? `${parentGroup.name} > ${projectGroupInfo.name}` : projectGroupInfo.name,
                 name: projectGroupInfo.name,
@@ -56,6 +57,7 @@ export const sync: Action<ProjectGroupReferenceState, any> = ({ state, commit },
     const projectGroups: ProjectGroupReferenceMap = {
         ...state.items,
         [projectGroupInfo.project_group_id]: {
+            key: projectGroupInfo.project_group_id,
             label: (parentGroup)
                 ? `${parentGroup.name} > ${projectGroupInfo.name}` : projectGroupInfo.name,
             name: projectGroupInfo.name,

--- a/src/store/modules/reference/project-group/actions.ts
+++ b/src/store/modules/reference/project-group/actions.ts
@@ -16,8 +16,8 @@ export const load: Action<ProjectGroupReferenceState, any> = async (
     const currentTime = new Date().getTime();
 
     if (
-        ((options?.lazyLoad && Object.keys(state.items).length > 0)
-        || (lastLoadedTime !== 0 && currentTime - lastLoadedTime < REFERENCE_LOAD_TTL)
+        ((lastLoadedTime !== 0 && currentTime - lastLoadedTime < REFERENCE_LOAD_TTL)
+        || (options?.lazyLoad && state.items)
         ) && !options?.force
     ) return;
     lastLoadedTime = currentTime;

--- a/src/store/modules/reference/project-group/index.ts
+++ b/src/store/modules/reference/project-group/index.ts
@@ -5,7 +5,7 @@ import * as getters from './getters';
 import * as mutations from './mutations';
 
 const state: ProjectGroupReferenceState = {
-    items: {},
+    items: undefined,
 };
 
 export default {

--- a/src/store/modules/reference/project-group/type.ts
+++ b/src/store/modules/reference/project-group/type.ts
@@ -1,4 +1,4 @@
-import type { ReferenceItem, ReferenceMap, ReferenceState } from '@/store/modules/reference/type';
+import type { ReferenceItem, ReferenceMap } from '@/store/modules/reference/type';
 
 export interface ProjectGroupResourceItemData {
     parentGroupInfo?: {
@@ -11,4 +11,6 @@ export type ProjectGroupReferenceItem = Required<Pick<ReferenceItem<ProjectGroup
 
 export type ProjectGroupReferenceMap = ReferenceMap<ProjectGroupReferenceItem>;
 
-export type ProjectGroupReferenceState = ReferenceState<ProjectGroupReferenceMap>;
+export interface ProjectGroupReferenceState {
+    items?: ProjectGroupReferenceMap;
+}

--- a/src/store/modules/reference/project-group/type.ts
+++ b/src/store/modules/reference/project-group/type.ts
@@ -7,7 +7,7 @@ export interface ProjectGroupResourceItemData {
     };
 }
 
-export type ProjectGroupReferenceItem = Required<Pick<ReferenceItem<ProjectGroupResourceItemData>, 'label'|'name'|'data'>>;
+export type ProjectGroupReferenceItem = Required<Pick<ReferenceItem<ProjectGroupResourceItemData>, 'key'|'label'|'name'|'data'>>;
 
 export type ProjectGroupReferenceMap = ReferenceMap<ProjectGroupReferenceItem>;
 

--- a/src/store/modules/reference/project/type.ts
+++ b/src/store/modules/reference/project/type.ts
@@ -11,8 +11,6 @@ export type ProjectReferenceItem = Required<Pick<ReferenceItem<ProjectResourceIt
 
 export type ProjectReferenceMap = ReferenceMap<ProjectReferenceItem>;
 
-// export type ProjectReferenceState = ReferenceState<ProjectReferenceMap>
-
 export interface ProjectReferenceState {
     items?: ProjectReferenceMap;
 }

--- a/src/store/modules/reference/provider/actions.ts
+++ b/src/store/modules/reference/provider/actions.ts
@@ -59,6 +59,7 @@ export const sync: Action<ProviderReferenceState, any> = ({ state, commit }, pro
     const providers: ProviderReferenceMap = {
         ...state.items,
         [providerInfo.provider]: {
+            key: providerInfo.provider,
             label: providerInfo.tags.label || providerInfo.name,
             name: providerInfo.name,
             icon: assetUrlConverter(providerInfo.tags.icon),


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- reference store에서 projectGroup의 초기값을 `{}`에서 `undefined`로 변경
- reference 데이터에 `key` property 추가
