### PR TITLE
fix(cost-analysis): add more group-by buttons

### DIFF
--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilter.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilter.vue
@@ -13,7 +13,7 @@
             {{ groupByItem.label }}
         </p-select-button>
         <p-divider :vertical="true" />
-        <cost-analysis-group-by-more-button />
+        <cost-analysis-group-by-filter-more />
     </div>
 </template>
 
@@ -24,7 +24,7 @@ import {
     PSelectButton, PDivider,
 } from '@spaceone/design-system';
 
-import CostAnalysisGroupByMoreButton from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByMoreButton.vue';
+import CostAnalysisGroupByFilterMore from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMore.vue';
 import { GROUP_BY_ITEM_MAP } from '@/services/cost-explorer/lib/config';
 import { costExplorerStore } from '@/services/cost-explorer/store';
 import type { GroupByItem } from '@/services/cost-explorer/store/cost-analysis/type';
@@ -33,7 +33,7 @@ import type { GroupByItem } from '@/services/cost-explorer/store/cost-analysis/t
 export default {
     name: 'CostAnalysisGroupByFilter',
     components: {
-        CostAnalysisGroupByMoreButton,
+        CostAnalysisGroupByFilterMore,
         PSelectButton,
         PDivider,
     },
@@ -85,7 +85,7 @@ export default {
     .p-divider {
         @apply bg-gray-300;
         height: 1rem;
-        margin-left: 0.375rem;
+        margin: 0 0.375rem;
     }
 }
 </style>

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMore.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMore.vue
@@ -1,5 +1,16 @@
 <template>
-    <div class="cost-analysis-group-by-more-button">
+    <div class="cost-analysis-group-by-filter-more">
+        <p-select-button v-for="moreGroupByItem in moreGroupByItems"
+                         :key="moreGroupByItem.name"
+                         :value="moreGroupByItem"
+                         :selected="selectedMoreGroupByItems"
+                         multi-selectable
+                         size="sm"
+                         :predicate="predicate"
+                         @change="handleSelectGroupByItems"
+        >
+            {{ moreGroupByItem.label }}
+        </p-select-button>
         <p-popover position="bottom-end" :is-visible.sync="popoverVisible">
             <p-icon-button name="ic_setting" size="sm" style-type="transparent"
                            @click="handleClickSettingButton"
@@ -30,32 +41,56 @@
                 </div>
             </template>
         </p-popover>
-        <cost-analysis-set-more-modal :visible.sync="addMoreModalVisible" />
+        <cost-analysis-group-by-filter-more-modal :visible.sync="addMoreModalVisible" />
     </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, toRefs } from 'vue';
+import {
+    computed, defineComponent, reactive, toRefs,
+} from 'vue';
 
-import { PIconButton, PPopover, PButton } from '@spaceone/design-system';
+import {
+    PIconButton, PPopover, PButton, PSelectButton,
+} from '@spaceone/design-system';
 
-import CostAnalysisSetMoreModal from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisSetMoreModal.vue';
+import CostAnalysisGroupByFilterMoreModal from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMoreModal.vue';
 import { GROUP_BY } from '@/services/cost-explorer/lib/config';
+import type { GroupByItem } from '@/services/cost-explorer/store/cost-analysis/type';
+import type { CostQueryFilters } from '@/services/cost-explorer/type';
 
 
+const SAMPLE_FILTERS: CostQueryFilters = {
+    tags: [
+        { name: 'name', label: 'Sample Tag' },
+        { name: 'team', label: 'Team', disabled: true },
+    ],
+    additional_info: [
+        { name: 'raw_usage_type', label: 'sample_sample' },
+    ],
+};
 export default defineComponent({
-    name: 'CostAnalysisGroupByMoreButton',
+    name: 'CostAnalysisGroupByFilterMore',
     components: {
-        CostAnalysisSetMoreModal,
+        CostAnalysisGroupByFilterMoreModal,
         PIconButton,
         PPopover,
         PButton,
+        PSelectButton,
     },
     props: {
     },
     setup() {
         const state = reactive({
             popoverVisible: false,
+            moreGroupByItems: computed<GroupByItem[]>(() => {
+                const results: GroupByItem[] = [];
+                Object.values(SAMPLE_FILTERS).forEach((v: any) => {
+                    results.push(...v.filter(d => !d?.disabled));
+                });
+                return results;
+            }),
+            selectedMoreGroupByItems: [] as GroupByItem[],
             count: {
                 default: Object.keys(GROUP_BY).length,
                 tags: 0,
@@ -63,6 +98,9 @@ export default defineComponent({
             },
             addMoreModalVisible: false,
         });
+
+        /* Util */
+        const predicate = (current, data) => Object.keys(current).every(key => data && current[key] === data[key]);
 
         /* Event */
         const handleClickSettingButton = () => {
@@ -74,18 +112,26 @@ export default defineComponent({
         const handleClickAddMoreButton = () => {
             state.addMoreModalVisible = true;
         };
+        const handleSelectGroupByItems = (items: GroupByItem[]) => {
+            state.selectedMoreGroupByItems = items;
+        };
 
         return {
             ...toRefs(state),
+            predicate,
             handleClickSettingButton,
             handleClose,
             handleClickAddMoreButton,
+            handleSelectGroupByItems,
         };
     },
 });
 </script>
 <style lang="postcss">
-.cost-analysis-group-by-more-button {
+.cost-analysis-group-by-filter-more {
+    display: flex;
+    column-gap: 0.375rem;
+
     /* custom design-system component - p-popover */
     :deep(.p-popover) {
         > .popper {

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMore.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMore.vue
@@ -62,11 +62,13 @@ import type { CostQueryFilters } from '@/services/cost-explorer/type';
 
 const SAMPLE_FILTERS: CostQueryFilters = {
     tags: [
-        { name: 'name', label: 'Sample Tag' },
-        { name: 'team', label: 'Team', disabled: true },
+        'name', 'team',
+        // { name: 'name', label: 'Sample Tag' },
+        // { name: 'team', label: 'Team', disabled: true },
     ],
     additional_info: [
-        { name: 'raw_usage_type', label: 'sample_sample' },
+        'raw_usage_type',
+        // { name: 'raw_usage_type', label: 'sample_sample' },
     ],
 };
 export default defineComponent({
@@ -85,8 +87,8 @@ export default defineComponent({
             popoverVisible: false,
             moreGroupByItems: computed<GroupByItem[]>(() => {
                 const results: GroupByItem[] = [];
-                Object.values(SAMPLE_FILTERS).forEach((v: any) => {
-                    results.push(...v.filter(d => !d?.disabled));
+                Object.values(SAMPLE_FILTERS).forEach((v) => {
+                    results.push(...v.map(d => ({ name: d, label: d })));
                 });
                 return results;
             }),
@@ -134,13 +136,14 @@ export default defineComponent({
 
     /* custom design-system component - p-popover */
     :deep(.p-popover) {
-        > .popper {
+        .popper {
             padding: 0;
         }
     }
     .popover-content-wrapper {
         display: grid;
         gap: 1.25rem;
+        padding: 0.875rem 1rem;
         .count-text {
             padding-left: 0.25rem;
         }

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMoreModal.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMoreModal.vue
@@ -1,11 +1,11 @@
 <template>
     <!--    song-lang-->
     <p-button-modal
-        class="cost-analysis-add-more-modal"
+        class="cost-analysis-group-by-filter-more-modal"
         :header-title="$t('Add More')"
         :visible.sync="proxyVisible"
         size="sm"
-        @confirm="handleFormConfirm"
+        @confirm="handleConfirm"
     >
         <template #body>
             <p-field-group :label="$t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.LABEL_TAG')" required>
@@ -50,7 +50,7 @@ import { useProxyValue } from '@/common/composables/proxy-state';
 
 
 export default {
-    name: 'CostAnalysisSetMoreModal',
+    name: 'CostAnalysisGroupByFilterMoreModal',
     components: {
         PFieldGroup,
         PButtonModal,
@@ -82,15 +82,15 @@ export default {
             ],
         });
 
-        const handleFormConfirm = () => {
+        /* Event */
+        const handleConfirm = () => {
             state.proxyVisible = false;
         };
 
         return {
             ...toRefs(state),
-            handleFormConfirm,
+            handleConfirm,
         };
     },
 };
-
 </script>

--- a/src/services/cost-explorer/type.ts
+++ b/src/services/cost-explorer/type.ts
@@ -1,3 +1,5 @@
+import type { Tags } from '@/models';
+
 import type { FILTER, GRANULARITY, GROUP_BY } from '@/services/cost-explorer/lib/config';
 
 
@@ -9,13 +11,14 @@ export interface Period {
 interface FilterItem {
     name: string;
     label: string;
+    disabled?: boolean;
 }
 
 export type Granularity = typeof GRANULARITY[keyof typeof GRANULARITY];
 export type GroupBy = typeof GROUP_BY[keyof typeof GROUP_BY];
 export type Filter = typeof FILTER[keyof typeof FILTER];
 
-export type CostQueryFilters = Partial<Record<Filter, string[]>>;
+export type CostQueryFilters = Partial<Record<Filter, Array<string | Tags>>>;
 export type CostQueryFilterItemsMap = Partial<Record<Filter, FilterItem[]>>;
 
 export interface CostQuerySetOption {

--- a/src/services/cost-explorer/type.ts
+++ b/src/services/cost-explorer/type.ts
@@ -1,5 +1,3 @@
-import type { Tags } from '@/models';
-
 import type { FILTER, GRANULARITY, GROUP_BY } from '@/services/cost-explorer/lib/config';
 
 
@@ -18,7 +16,7 @@ export type Granularity = typeof GRANULARITY[keyof typeof GRANULARITY];
 export type GroupBy = typeof GROUP_BY[keyof typeof GROUP_BY];
 export type Filter = typeof FILTER[keyof typeof FILTER];
 
-export type CostQueryFilters = Partial<Record<Filter, Array<string | Tags>>>;
+export type CostQueryFilters = Partial<Record<Filter, string[]>>;
 export type CostQueryFilterItemsMap = Partial<Record<Filter, FilterItem[]>>;
 
 export interface CostQuerySetOption {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
more groupby 버튼 생성 (mock 데이터임)
![스크린샷 2022-10-11 오후 2 48 22](https://user-images.githubusercontent.com/18563857/195007007-4a420d6a-863a-415a-8c4e-6379ebaff4f7.png)

### 생각해볼 점
기존 filter는 string[]로 저장되었는데, 태그는 object입니다.
기존
```typescript
{ regions: ['ap-north2'], projects: ['p-sdfsf', 'p-12313'] }
```
```typescript
{ tags: [{name: 'team', label: 'Team' }] }
```
타입 에러로 지금은 태그도 일단 name만 string[]로 저장하도록 했는데...고민중