### PR TITLE
fix(service-account): set `cursor: pointer` to dataTable row

### DIFF
--- a/src/services/asset-inventory/service-account/ServiceAccountPage.vue
+++ b/src/services/asset-inventory/service-account/ServiceAccountPage.vue
@@ -366,6 +366,11 @@ export default {
         .p-toolbox-table {
             @apply rounded-lg;
         }
+        .p-data-table {
+            .row-height-fixed {
+                cursor: pointer;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
서비스 어카운트 페이지에서, 데이터 테이블 row hover 시 pointer:cursor로 보이도록 수정
(기존 default pointer는 클릭 가능한 아이템인지 유저가 모를 수 있음)
