### PR TITLE
fix(space-connector): use `unsetRefreshingState` in `setToken`

### DIFF
--- a/packages/cloudforet/core-lib/src/space-connector/api.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/api.ts
@@ -64,6 +64,7 @@ class API {
         this.refreshToken = refreshToken;
         window.localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
         window.localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+        API.unsetRefreshingState();
     }
 
     getRefreshToken(): string|undefined {

--- a/src/services/auth/authenticator/index.ts
+++ b/src/services/auth/authenticator/index.ts
@@ -1,5 +1,3 @@
-import API from '@cloudforet/core-lib/space-connector/api';
-
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { setI18nLocale } from '@/translations';
@@ -24,8 +22,6 @@ abstract class Authenticator {
             ]);
         } catch (e: unknown) {
             throw e;
-        } finally {
-            API.unsetRefreshingState();
         }
     }
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
버그를 해결하기 위해 SignIn 시 `API.unsetRefreshingState()` 하는 코드를 추가했는데, 사전 지식 없이는 코드를 이해하기 어렵다는 의견이 있었습니다.
이해의 장벽을 낮추기 위해 해당 코드를 좀더 관련성 있는 파일로 옮겼습니다.