### PR TITLE
hotfix(service-account): make generate_id editable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@amcharts/amcharts4": "^4.10.10",
         "@amcharts/amcharts4-geodata": "^4.1.18",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.410",
+        "@spaceone/design-system": "^1.1.0-beta.416",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -3829,9 +3829,9 @@
       "dev": true
     },
     "node_modules/@spaceone/design-system": {
-      "version": "1.1.0-beta.410",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.410.tgz",
-      "integrity": "sha512-sBXenGZvzfIQFlV1a7a+h+lzzExAaiHF1eHMYDpEjkx39mAsux+0ms3HHeWc8e3fT6iS9HIFVfU/lenRGp0eCA==",
+      "version": "1.1.0-beta.416",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.416.tgz",
+      "integrity": "sha512-U/NF9vhJJ4kzjl75c+wuLdzlTWlZAJ4Xnn/JKKTOiWh1DYfCVe7oOMwd/JioajkA2b8NrF82Ldftpp5srMTMRg==",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -3840,6 +3840,8 @@
         "@faker-js/faker": "^7.3.0",
         "@juggle/resize-observer": "^3.3.1",
         "@popperjs/core": "^2.10.2",
+        "@vueuse/components": "^9.0.2",
+        "@vueuse/core": "^8.3.1",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "ajv-i18n": "^4.2.0",
@@ -39104,9 +39106,9 @@
       "dev": true
     },
     "@spaceone/design-system": {
-      "version": "1.1.0-beta.410",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.410.tgz",
-      "integrity": "sha512-sBXenGZvzfIQFlV1a7a+h+lzzExAaiHF1eHMYDpEjkx39mAsux+0ms3HHeWc8e3fT6iS9HIFVfU/lenRGp0eCA==",
+      "version": "1.1.0-beta.416",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.416.tgz",
+      "integrity": "sha512-U/NF9vhJJ4kzjl75c+wuLdzlTWlZAJ4Xnn/JKKTOiWh1DYfCVe7oOMwd/JioajkA2b8NrF82Ldftpp5srMTMRg==",
       "requires": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -39115,6 +39117,8 @@
         "@faker-js/faker": "^7.3.0",
         "@juggle/resize-observer": "^3.3.1",
         "@popperjs/core": "^2.10.2",
+        "@vueuse/components": "^9.0.2",
+        "@vueuse/core": "^8.3.1",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "ajv-i18n": "^4.2.0",
@@ -44640,7 +44644,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.410",
+        "@spaceone/design-system": "1.1.0-beta.416",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -47541,9 +47545,9 @@
           "dev": true
         },
         "@spaceone/design-system": {
-          "version": "1.1.0-beta.410",
-          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.410.tgz",
-          "integrity": "sha512-sBXenGZvzfIQFlV1a7a+h+lzzExAaiHF1eHMYDpEjkx39mAsux+0ms3HHeWc8e3fT6iS9HIFVfU/lenRGp0eCA==",
+          "version": "1.1.0-beta.416",
+          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.416.tgz",
+          "integrity": "sha512-U/NF9vhJJ4kzjl75c+wuLdzlTWlZAJ4Xnn/JKKTOiWh1DYfCVe7oOMwd/JioajkA2b8NrF82Ldftpp5srMTMRg==",
           "requires": {
             "@amcharts/amcharts4": "^4.10.10",
             "@babel/runtime": "^7.12.5",
@@ -47552,6 +47556,8 @@
             "@faker-js/faker": "^7.3.0",
             "@juggle/resize-observer": "^3.3.1",
             "@popperjs/core": "^2.10.2",
+            "@vueuse/components": "^9.0.2",
+            "@vueuse/core": "^8.3.1",
             "ajv": "^8.11.0",
             "ajv-formats": "^2.1.1",
             "ajv-i18n": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@amcharts/amcharts4": "^4.10.10",
     "@amcharts/amcharts4-geodata": "^4.1.18",
     "@gtm-support/vue2-gtm": "^1.3.0",
-    "@spaceone/design-system": "^1.1.0-beta.410",
+    "@spaceone/design-system": "^1.1.0-beta.416",
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-color": "^2.0.0-beta.12",
     "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue
@@ -432,6 +432,12 @@ export default defineComponent<Props>({
     }
     .custom-schema-box {
         padding: 2rem 2rem 0 2rem;
+        width: 66%;
+
+        /* custom design-system component - p-text-input */
+        :deep(.p-text-input) {
+            width: 100%;
+        }
     }
 
     /* custom design-system component - p-tab */
@@ -457,24 +463,11 @@ export default defineComponent<Props>({
                 padding: 1rem;
             }
         }
-
-        /* custom design-system component - p-text-input */
-        .p-text-input {
-            width: 66%;
-            .input-container {
-                min-width: 25rem;
-                width: 100%;
-            }
-        }
     }
 
     @screen tablet {
-        /* custom design-system component - p-tab */
-        :deep(.p-tab) {
-            /* custom design-system component - p-text-input */
-            .p-text-input {
-                width: 100%;
-            }
+        .custom-schema-box {
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

- 미리내 버전을 올렸습니다. JsonSchemForm의 genrate_id form이 편집 가능하도록 기획 변경사항에 대응하기 위함입니다.
- 추가적으로 ServiceAccountCredentialsForm.vue 에서 text input 컴포넌트에 width를 66%로 고정하여 generate_id 폼만 더 늘어나는 현상이 있었습니다. 따라서 text input컴포넌트의 width는 100%로 부여하고, 컨테이너(json schema form 컴포넌트의 루트 div)에 width를 66% 고정하는 방식으로 수정하였습니다.

https://user-images.githubusercontent.com/26986739/195279656-b7b4fcad-d986-409f-a168-2a250094eadd.mov



### 생각해볼 문제

- json schema form 은 스키마에 따라 폼을 렌더하는 것이므로 내부의 요소에 css를 부여하는 경우는 신중해야 합니다.
- 내부 요소에 전체적으로 특정한 width, height를 부여해야 하는 경우에는 컨테이너에 값을 부여함으로써 해결할 수 있는 방법이 없는지 먼저 고민해보면 좋을 것 같습니다.
