### PR TITLE
fix(notice-popup): do not show popup when session is expired

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44640,7 +44640,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "1.1.0-beta.410",
+        "@spaceone/design-system": "^1.1.0-beta.410",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/common/modules/popup/notice/NoticePopup.vue
+++ b/src/common/modules/popup/notice/NoticePopup.vue
@@ -2,6 +2,7 @@
     <fragment>
         <notice-popup-item
             v-for="(item, index) in popupList"
+            v-show="!isSessionExpired"
             :key="`notice-item-${index}`"
             :popup-index="index"
             :item="item"
@@ -33,8 +34,8 @@ export default {
     },
     setup() {
         const state = reactive({
-            isSessionExpired: computed(() => store.state.user.isSessionExpired),
-            isNoRoleUser: computed(() => store.getters['user/isNoRoleUser']),
+            isSessionExpired: computed<boolean>(() => store.state.user.isSessionExpired),
+            isNoRoleUser: computed<boolean>(() => store.getters['user/isNoRoleUser']),
             popupList: [] as Array<NoticePostModel>,
         });
 
@@ -54,6 +55,7 @@ export default {
             v: true,
             o: '=',
         }]).setSort('created_at', false).data;
+
 
         // API
         const getUserConfigBoardPostIdList = async (): Promise<Array<string>> => {
@@ -80,7 +82,7 @@ export default {
             }
         };
 
-        const getPostList = async () => {
+        const getPostList = async (): Promise<void> => {
             try {
                 const noticeBoard = await getNoticeBoard();
                 if (!noticeBoard) return;
@@ -97,8 +99,9 @@ export default {
             }
         };
 
+
         watch(() => state.isSessionExpired, async (isSessionExpired) => {
-            if (isSessionExpired === false && !state.isNoRoleUser) await getPostList();
+            if (!isSessionExpired && !state.isNoRoleUser) await getPostList();
         }, { immediate: true });
 
         return {

--- a/src/common/modules/popup/notice/modules/NoticePopupItem.vue
+++ b/src/common/modules/popup/notice/modules/NoticePopupItem.vue
@@ -97,7 +97,7 @@ export default {
         });
         const { attachments } = useFileAttachments(files);
 
-        const handleClose = async (neverShowPopup?: boolean) => {
+        const handleClose = async (neverShowPopup?: boolean): Promise<void> => {
             state.popupVisible = false;
             if (neverShowPopup) {
                 try {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

세션 만료 혹은 로그아웃 등으로 token 이 expired 되었을 때,
notice-popup 에서 don't show me again 클릭 시,
userConfig 가 set 되지 않아, 팝업이 다시 뜨는 버그가 존재하였고,

이에 대한 해결 방법으로 token 이 expired 되었을 때 popup 을 숨기는 것으로 조치하였습니다.

---
토큰 만료 시 다시 로그인하는 케이스가 더 많을 것 같다고 판단하였고, 
app.vue 에 물려있는 파일이라 렌더링에 조금이나마 부하를 방지하고자 
`v-show` 로 작성하였습니다.


### 생각해볼 문제
