### PR TITLE
feat(cloud-service-tags-panel): improve TagsPanel for reflect improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@amcharts/amcharts4": "^4.10.10",
         "@amcharts/amcharts4-geodata": "^4.1.18",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.416",
+        "@spaceone/design-system": "^1.1.0-beta.418",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -3829,9 +3829,9 @@
       "dev": true
     },
     "node_modules/@spaceone/design-system": {
-      "version": "1.1.0-beta.416",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.416.tgz",
-      "integrity": "sha512-U/NF9vhJJ4kzjl75c+wuLdzlTWlZAJ4Xnn/JKKTOiWh1DYfCVe7oOMwd/JioajkA2b8NrF82Ldftpp5srMTMRg==",
+      "version": "1.1.0-beta.418",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.418.tgz",
+      "integrity": "sha512-Ge3ofQ8HO072+xkM2jJKXy85YvDQUQ4ZrKcJU6FU+CR3m+UCsPqlFRCBF/wLuu6mYR5gkyWUKORGfs5z4rwPQQ==",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -39106,9 +39106,9 @@
       "dev": true
     },
     "@spaceone/design-system": {
-      "version": "1.1.0-beta.416",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.416.tgz",
-      "integrity": "sha512-U/NF9vhJJ4kzjl75c+wuLdzlTWlZAJ4Xnn/JKKTOiWh1DYfCVe7oOMwd/JioajkA2b8NrF82Ldftpp5srMTMRg==",
+      "version": "1.1.0-beta.418",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.418.tgz",
+      "integrity": "sha512-Ge3ofQ8HO072+xkM2jJKXy85YvDQUQ4ZrKcJU6FU+CR3m+UCsPqlFRCBF/wLuu6mYR5gkyWUKORGfs5z4rwPQQ==",
       "requires": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -44644,7 +44644,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "1.1.0-beta.416",
+        "@spaceone/design-system": "^1.1.0-beta.418",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -47545,9 +47545,9 @@
           "dev": true
         },
         "@spaceone/design-system": {
-          "version": "1.1.0-beta.416",
-          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.416.tgz",
-          "integrity": "sha512-U/NF9vhJJ4kzjl75c+wuLdzlTWlZAJ4Xnn/JKKTOiWh1DYfCVe7oOMwd/JioajkA2b8NrF82Ldftpp5srMTMRg==",
+          "version": "1.1.0-beta.418",
+          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.418.tgz",
+          "integrity": "sha512-Ge3ofQ8HO072+xkM2jJKXy85YvDQUQ4ZrKcJU6FU+CR3m+UCsPqlFRCBF/wLuu6mYR5gkyWUKORGfs5z4rwPQQ==",
           "requires": {
             "@amcharts/amcharts4": "^4.10.10",
             "@babel/runtime": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@amcharts/amcharts4": "^4.10.10",
     "@amcharts/amcharts4-geodata": "^4.1.18",
     "@gtm-support/vue2-gtm": "^1.3.0",
-    "@spaceone/design-system": "^1.1.0-beta.416",
+    "@spaceone/design-system": "^1.1.0-beta.418",
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-color": "^2.0.0-beta.12",
     "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/common/modules/tags/tags-panel/modules/TagsOverlay.vue
+++ b/src/common/modules/tags/tags-panel/modules/TagsOverlay.vue
@@ -55,19 +55,11 @@ import type { TranslateResult } from 'vue-i18n';
 import {
     PIconButton, PPaneLayout, PButton,
 } from '@spaceone/design-system';
-import {
-    camelCase, isEmpty, get,
-} from 'lodash';
+import { isEmpty } from 'lodash';
 
-import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
-
-import { i18n } from '@/translations';
-
-import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 
 import TagsInputGroup from '@/common/components/forms/tags-input-group/TagsInputGroup.vue';
 import type { Tag } from '@/common/components/forms/tags-input-group/type';
-import ErrorHandler from '@/common/composables/error/errorHandler';
 
 
 export default {
@@ -87,25 +79,13 @@ export default {
             type: Object,
             default: () => ({}),
         },
-        resourceKey: {
-            type: String,
-            default: '',
-            required: true,
-        },
-        resourceId: {
-            type: String,
-            default: '',
-            required: true,
-        },
-        resourceType: {
-            type: String,
-            default: '',
-            required: true,
+        loading: {
+            type: Boolean,
+            default: false,
         },
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
-            loading: false,
             showHeader: computed(() => state.newTags.length > 0),
             newTags: { ...props.tags },
             isTagsValid: false,
@@ -115,28 +95,7 @@ export default {
         /* Api */
         const handleSaveTags = async () => {
             if (!state.isTagsValid) return;
-
-            const apiKeys = props.resourceType.split('.').map(d => camelCase(d));
-            const api = get(SpaceConnector.client, apiKeys);
-            if (!api) {
-                ErrorHandler.handleRequestError(new Error(), i18n.t('COMMON.TAGS.ALT_E_UPDATE'));
-                return;
-            }
-
-            try {
-                state.loading = true;
-                await api.update({
-                    [props.resourceKey]: props.resourceId,
-                    tags: state.newTags,
-                });
-                showSuccessMessage(i18n.t('COMMON.TAGS.ALT_S_UPDATE'), '');
-            } catch (e) {
-                ErrorHandler.handleRequestError(e, i18n.t('COMMON.TAGS.ALT_E_UPDATE'));
-            } finally {
-                state.loading = false;
-            }
-
-            emit('update');
+            emit('update', state.newTags);
         };
 
         /* Event */


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

<img width="709" alt="image" src="https://user-images.githubusercontent.com/50662170/195335235-6f9b5c0a-47ef-420d-9d6f-c4198b8507f4.png">

이번 Tag 개선 사항을 반영하기위해 TagsPanel을 조금 수정하였습니다.

목적
- 기존 일관된 tag의 형태와 다른 type과 provider에대한 추가 속성이 부여된 tag들을 보여줘야함 (api도 따로 만들어짐)

개선 방식
- 태그 수정 overlay가 그대로 사용되어야 해서, 새로운 컴포너트를 만들지 않고 기존 TagsPanel을 수정했습니다.
- TagsPanel의 props들([custom-fields, custom-items, custom-tags])을 추가 하였고, 이들이 있을 때 isCustomMode가 `true`입니다.
- custom-xxx props가 추가된 이유는 패널에 보여지는 태그는 기존 패널 내부의 api요청과는 다른 api를 쏴야하기 때문입니다.
(기존에는 custom 태그들만 보여졌고, 개선 후엔 Managed 태그를 포함하여 보여줘야하기 때문에 다른 api가 필요)

### 생각해볼 문제
다음 PR에서 table의 col 관련 slot을 외부에서 반영 가능하도록 TagsPanel의 추가 개선이 진행 되어야합니다.(현재 데이터만 테이블에 보여지고 있으며, 배지 UI가 반영되어있지 않습니다)
혹시, 기존 TagsPanel을 사용하지 않는 방향으로 가야될지 궁굼합니다.