### PR TITLE
fix(router): check `isTokenAlive` before refreshing token

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -76,9 +76,11 @@ export class SpaceRouter {
                 }
             // When an unauthenticated(or token expired) user tries to access a page that only authenticated users can enter, refresh token
             } else if (routeAccessLevel >= ACCESS_LEVEL.AUTHENTICATED) {
-                const res = await SpaceConnector.refreshAccessToken(false);
-                // When refreshing token is failed, redirect to sign in page
-                if (!res) nextLocation = { name: AUTH_ROUTE.SIGN_OUT._NAME, query: { nextPath: to.fullPath } };
+                if (!isTokenAlive) {
+                    // When refreshing token is failed, redirect to sign in page
+                    const res = await SpaceConnector.refreshAccessToken(false);
+                    if (!res) nextLocation = { name: AUTH_ROUTE.SIGN_OUT._NAME, query: { nextPath: to.fullPath } };
+                }
             }
 
             next(nextLocation);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
router beforeEach에서, `routeAccessLevel`이 `userAccessLevel`보다 높으면
1) 토큰을 refresh하고
2) refresh에 실패하면 signOut 시킵니다.

토큰이 이미 있는 경우에도 이러한 과정을 거치기 때문에 불필요한 refresh라 간주하여 `isTokenAlive`가 false일 때만 실행하도록 수정했습니다.