### PR TITLE
feat(cloud-service-tags-panel): apply badge ui to table value

### DIFF
--- a/src/common/modules/tags/tags-panel/TagsPanel.vue
+++ b/src/common/modules/tags/tags-panel/TagsPanel.vue
@@ -23,7 +23,11 @@
                       :loading="loading"
                       :col-copy="true"
                       beautify-text
-        />
+        >
+            <template v-for="(_, slot) of $scopedSlots" #[slot]="scope">
+                <slot :name="slot" v-bind="scope" />
+            </template>
+        </p-data-table>
         <transition name="slide-up">
             <tags-overlay v-if="tagEditPageVisible"
                           :title="overlayTitle"

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue
@@ -25,17 +25,30 @@
                 </p-select-status>
             </div>
         </template>
+        <template #col-type-format="{ value }">
+            <p-badge :style-type="getTagTypeBadgeOption(value).styleType"
+                     outline
+            >
+                {{ getTagTypeBadgeOption(value).label }}
+            </p-badge>
+        </template>
+        <template #col-provider-format="{ value }">
+            <p-badge v-if="value" :background-color="getProviderBadgeOption(value).color">
+                {{ getProviderBadgeOption(value)?.label }}
+            </p-badge>
+        </template>
     </tags-panel>
 </template>
 
 <script lang="ts">
 import { computed, reactive, toRefs } from 'vue';
 
-import { PSelectStatus } from '@spaceone/design-system';
+import { PBadge, PSelectStatus } from '@spaceone/design-system';
 
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
+import { store } from '@/store';
 import { i18n } from '@/translations';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
@@ -50,6 +63,7 @@ export default {
     name: 'CloudServiceTagsPanel',
     components: {
         PSelectStatus,
+        PBadge,
         TagsPanel,
     },
     props: {
@@ -70,6 +84,7 @@ export default {
                 { name: CLOUD_SERVICE_TAG_TYPE.CUSTOM, label: CLOUD_SERVICE_TAG_TYPE_BADGE_OPTION[CLOUD_SERVICE_TAG_TYPE.CUSTOM].label },
                 { name: CLOUD_SERVICE_TAG_TYPE.MANAGED, label: CLOUD_SERVICE_TAG_TYPE_BADGE_OPTION[CLOUD_SERVICE_TAG_TYPE.MANAGED].label },
             ]),
+            providers: computed(() => store.getters['reference/provider/fieldItems']?.options),
             selectedTagType: 'all',
             cloudServiceTagList: [],
             tags: computed(() => {
@@ -111,6 +126,12 @@ export default {
             }
         };
 
+        const getTagTypeBadgeOption = (tagType: keyof typeof CLOUD_SERVICE_TAG_TYPE) => CLOUD_SERVICE_TAG_TYPE_BADGE_OPTION[tagType];
+        const getProviderBadgeOption = provider => ({
+            color: state.providers[provider]?.options.background_color,
+            label: state.providers[provider]?.name,
+        });
+
         (async () => {
             await getCloudServiceTags();
         })();
@@ -118,6 +139,8 @@ export default {
             ...toRefs(state),
             handleSelectTagType,
             handleTagsUpdated,
+            getTagTypeBadgeOption,
+            getProviderBadgeOption,
         };
     },
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
![image](https://user-images.githubusercontent.com/50662170/195517780-000e9064-54f8-4d8c-a55d-d7de9f8cc940.png)
- cloudServiceTagsPanel에서 type, provider 데이터에 badge를 적용하였습니다.
### 생각해볼 문제
