### PR TITLE
fix(cost-explorer): change filters' type from `object` to `object[]`

### DIFF
--- a/src/services/cost-explorer/cost-analysis/lib/helper.ts
+++ b/src/services/cost-explorer/cost-analysis/lib/helper.ts
@@ -7,7 +7,7 @@ import type { QueryStoreFilter } from '@cloudforet/core-lib/query/type';
 
 import { FILTER, GRANULARITY } from '@/services/cost-explorer/lib/config';
 import type {
-    CostQueryFilters, Period, Granularity, CostQueryFilterItem,
+    CostQueryFilters, Period, Granularity, CostQueryFilterItem, RefinedFilterItem,
 } from '@/services/cost-explorer/type';
 
 
@@ -32,17 +32,17 @@ export const getConvertedFilter = (filters: CostQueryFilters): QueryStoreFilter[
     return result;
 };
 
-export const getRefinedFilterItems = (resourceMap: Record<string, any>, filterItems: CostQueryFilterItem[]): CostQueryFilterItem[] => {
-    const results: CostQueryFilterItem[] = [];
+export const getRefinedFilterItems = (resourceMap: Record<string, any>, filterItems: CostQueryFilterItem[]): RefinedFilterItem[] => {
+    const results: RefinedFilterItem[] = [];
     filterItems.forEach((f) => {
-        const resourceItem = resourceMap[f.category]?.[f.resourceName];
-        let value = f.value;
+        const resourceItem = resourceMap[f.category]?.[f.value];
+        let label = f.value;
         if (resourceItem) {
-            value = f.category === FILTER.REGION ? resourceItem?.name : resourceItem?.label;
+            label = f.category === FILTER.REGION ? resourceItem?.name : resourceItem?.label;
         }
         results.push({
             ...f,
-            value,
+            label,
         });
     });
     return results;

--- a/src/services/cost-explorer/cost-analysis/lib/helper.ts
+++ b/src/services/cost-explorer/cost-analysis/lib/helper.ts
@@ -3,13 +3,21 @@ import type { DataTableFieldType } from '@spaceone/design-system/dist/src/data-d
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 
-
 import type { QueryStoreFilter } from '@cloudforet/core-lib/query/type';
 
-import { GRANULARITY } from '@/services/cost-explorer/lib/config';
-import type { CostQueryFilters, Period, Granularity } from '@/services/cost-explorer/type';
+import { FILTER, GRANULARITY } from '@/services/cost-explorer/lib/config';
+import type {
+    CostQueryFilters, Period, Granularity, CostQueryFilterItem,
+} from '@/services/cost-explorer/type';
 
 
+export const convertFilterItemToQueryStoreFilter = (filterItems: CostQueryFilterItem[]): QueryStoreFilter[] => filterItems.map(f => ({
+    k: f.key ? `${f.category}.${f.key}` : f.category,
+    v: f.value,
+    o: '=',
+}));
+
+// TODO: will be deprecated soon
 export const getConvertedFilter = (filters: CostQueryFilters): QueryStoreFilter[] => {
     const result: QueryStoreFilter[] = [];
     Object.entries(filters).forEach(([key, data]) => {
@@ -22,6 +30,22 @@ export const getConvertedFilter = (filters: CostQueryFilters): QueryStoreFilter[
         }
     });
     return result;
+};
+
+export const getRefinedFilterItems = (resourceMap: Record<string, any>, filterItems: CostQueryFilterItem[]): CostQueryFilterItem[] => {
+    const results: CostQueryFilterItem[] = [];
+    filterItems.forEach((f) => {
+        const resourceItem = resourceMap[f.category]?.[f.resourceName];
+        let value = f.value;
+        if (resourceItem) {
+            value = f.category === FILTER.REGION ? resourceItem?.name : resourceItem?.label;
+        }
+        results.push({
+            ...f,
+            value,
+        });
+    });
+    return results;
 };
 
 export const getConvertedBudgetFilter = (filters: CostQueryFilters): QueryStoreFilter[] => {

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFilterItem.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFilterItem.vue
@@ -15,36 +15,33 @@
         <p-search-dropdown
             v-else-if="type === FILTER.SERVICE_ACCOUNT || type === FILTER.REGION || type === FILTER.PROVIDER"
             :menu="menuItems"
-            :selected="selectedItems"
+            :selected="selectedSearchDropdownItems"
             multi-selectable
             use-fixed-menu-style
             :exact-mode="false"
             @update:selected="handleUpdateSelected"
-            @search="handleSearch"
         />
         <p-search-dropdown
             v-else
             :handler="menuHandler"
-            :selected="selectedItems"
+            :selected="selectedSearchDropdownItems"
             :loading="menuLoading"
             multi-selectable
             use-fixed-menu-style
             :exact-mode="false"
             @update:selected="handleUpdateSelected"
-            @search="handleSearch"
         />
     </div>
 </template>
 
 <script lang="ts">
 import {
-    computed, reactive, toRefs,
+    computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
 import {
     PSearchDropdown,
 } from '@spaceone/design-system';
-import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
 import type {
     AutocompleteHandler, SearchDropdownMenuItem,
 } from '@spaceone/design-system/dist/src/inputs/dropdown/search-dropdown/type';
@@ -60,17 +57,19 @@ import type { RegionReferenceMap } from '@/store/modules/reference/region/type';
 import type { ServiceAccountReferenceMap } from '@/store/modules/reference/service-account/type';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
+import { useProxyValue } from '@/common/composables/proxy-state';
 import ProjectSelectDropdown from '@/common/modules/project/ProjectSelectDropdown.vue';
 
-import { FILTER } from '@/services/cost-explorer/lib/config';
+import { ADDITIONAL_FILTER, FILTER } from '@/services/cost-explorer/lib/config';
+import type { CostQueryFilterItem } from '@/services/cost-explorer/type';
 
 
 interface Props {
     type: string;
-    selected: string[];
+    selected: CostQueryFilterItem[];
 }
 
-export default {
+export default defineComponent<Props>({
     name: 'CostAnalysisFilterItem',
     components: {
         ProjectSelectDropdown,
@@ -86,28 +85,44 @@ export default {
             default: () => ([]),
         },
     },
-    setup(props: Props, { emit }) {
-        const state = reactive({
-            selectedItems: computed<SearchDropdownMenuItem[]>(() => props.selected.map(selectedName => ({
-                name: selectedName,
-                label: state.menuItems.find(d => d.name === selectedName)?.label || selectedName,
-            }))),
+    setup(props, { emit }) {
+        const storeState = reactive({
             serviceAccounts: computed<ServiceAccountReferenceMap>(() => store.getters['reference/serviceAccountItems']),
             providers: computed<ProviderReferenceMap>(() => store.getters['reference/providerItems']),
             regions: computed<RegionReferenceMap>(() => store.getters['reference/regionItems']),
-            menuItems: computed(() => {
+        });
+        const state = reactive({
+            proxySelected: useProxyValue('selected', props, emit),
+            selectedSearchDropdownItems: computed<SearchDropdownMenuItem[]>(() => state.proxySelected?.map(d => ({
+                name: d.resourceName,
+                label: state.menuItems.find(menuItem => menuItem.name === d.resourceName)?.label || d.value,
+            }))),
+            menuItems: computed<SearchDropdownMenuItem[]>(() => {
                 if (props.type === FILTER.SERVICE_ACCOUNT) {
-                    return Object.keys(state.serviceAccounts).map(k => ({
-                        name: k, label: state.serviceAccounts[k].label,
+                    return Object.keys(storeState.serviceAccounts).map(k => ({
+                        name: k, label: storeState.serviceAccounts[k].label,
                     }));
                 } if (props.type === FILTER.PROVIDER) {
-                    return Object.keys(state.providers).map(k => ({
-                        name: k, label: state.providers[k].name,
+                    return Object.keys(storeState.providers).map(k => ({
+                        name: k, label: storeState.providers[k].name,
                     }));
                 } if (props.type === FILTER.REGION) {
-                    return Object.keys(state.regions).map(k => ({
-                        name: k, label: state.regions[k].name,
+                    return Object.keys(storeState.regions).map(k => ({
+                        name: k, label: storeState.regions[k].name,
                     }));
+                }
+                // TODO: tags, additional_info
+                if (props.type === ADDITIONAL_FILTER.TAGS) {
+                    // return [
+                    //     {
+                    //         keyItem: { name: 'tag_key1', label: 'tag_key1' },
+                    //         valueItem: { name: 'tag_value1', label: 'tag_value1' },
+                    //     },
+                    //     {
+                    //         keyItem: { name: 'tag_key2', label: 'tag_key2' },
+                    //         valueItem: { name: 'tag_value2', label: 'tag_value2' },
+                    //     },
+                    // ];
                 }
                 return [];
             }),
@@ -161,14 +176,22 @@ export default {
 
         /* event */
         const handleSelectedProjectIds = (selectedProjectIds) => {
-            emit('update:selected', selectedProjectIds);
+            state.proxySelected = selectedProjectIds.map(d => ({
+                category: props.type,
+                resourceName: d,
+                value: d,
+            }));
         };
-        const handleUpdateSelected = (selectedItem: MenuItem[]) => {
-            emit('update:selected', selectedItem.map(d => d.name));
+        const handleUpdateSelected = (selectedItems: SearchDropdownMenuItem[]) => {
+            state.proxySelected = selectedItems.map(d => ({
+                category: props.type,
+                resourceName: d.name,
+                value: d.name,
+            }));
         };
-        const handleSearch = (val: string) => {
-            emit('update:selected', state.selectedItems.map(d => d.name).concat([val]));
-        };
+        // const handleSearch = (val: string) => {
+        //     emit('update:selected', state.selectedItems.map(d => d.name).concat([val]));
+        // };
 
         // LOAD REFERENCE STORE
         (async () => {
@@ -185,8 +208,7 @@ export default {
             menuHandler,
             handleSelectedProjectIds,
             handleUpdateSelected,
-            handleSearch,
         };
     },
-};
+});
 </script>

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFilterItem.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFilterItem.vue
@@ -94,8 +94,8 @@ export default defineComponent<Props>({
         const state = reactive({
             proxySelected: useProxyValue('selected', props, emit),
             selectedSearchDropdownItems: computed<SearchDropdownMenuItem[]>(() => state.proxySelected?.map(d => ({
-                name: d.resourceName,
-                label: state.menuItems.find(menuItem => menuItem.name === d.resourceName)?.label || d.value,
+                name: d.value,
+                label: state.menuItems.find(menuItem => menuItem.name === d.value)?.label || d.value,
             }))),
             menuItems: computed<SearchDropdownMenuItem[]>(() => {
                 if (props.type === FILTER.SERVICE_ACCOUNT) {
@@ -178,14 +178,12 @@ export default defineComponent<Props>({
         const handleSelectedProjectIds = (selectedProjectIds) => {
             state.proxySelected = selectedProjectIds.map(d => ({
                 category: props.type,
-                resourceName: d,
                 value: d,
             }));
         };
         const handleUpdateSelected = (selectedItems: SearchDropdownMenuItem[]) => {
             state.proxySelected = selectedItems.map(d => ({
                 category: props.type,
-                resourceName: d.name,
                 value: d.name,
             }));
         };

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -149,7 +149,6 @@ export default {
         display: flex;
         justify-content: space-between;
         font-size: 0.875rem;
-        margin-bottom: 1rem;
         .timezone-text {
             @apply text-gray-400;
             font-size: 0.875rem;

--- a/src/services/cost-explorer/cost-analysis/type.ts
+++ b/src/services/cost-explorer/cost-analysis/type.ts
@@ -2,7 +2,7 @@ import type { RouteQueryString } from '@/lib/router-query-string';
 
 import type { CostAnalysisPageUrlQueryKey } from '@/services/cost-explorer/cost-analysis/lib/config';
 import type {
-    CostQueryFilters, Period, Granularity, GroupBy,
+    Period, Granularity, GroupBy, CostQueryFilterItem,
 } from '@/services/cost-explorer/type';
 
 
@@ -12,7 +12,7 @@ export interface CostAnalysisPageQueryValue {
     period?: Period;
     groupBy?: GroupBy[];
     primaryGroupBy?: GroupBy;
-    filters?: CostQueryFilters;
+    filters?: CostQueryFilterItem[];
     stack?: boolean;
     granularity?: Granularity;
 }

--- a/src/services/cost-explorer/cost-dashboard/lib/helper.ts
+++ b/src/services/cost-explorer/cost-dashboard/lib/helper.ts
@@ -30,7 +30,7 @@ export const getCostDashboardFilterLabel = (filters?: CostQueryFilters): string|
     const desc: string[] = [];
     Object.entries(FILTER_ITEM_MAP).forEach(([k, v]) => {
         if (filters[k]?.length) {
-            const filterLength = filters[k].length;
+            const filterLength = filters[k]?.length ?? 0;
             const suffix = filterLength > 1 ? `${v.label}s` : v.label;
             desc.push(`${filterLength} ${suffix}`);
         }

--- a/src/services/cost-explorer/lib/config.ts
+++ b/src/services/cost-explorer/lib/config.ts
@@ -18,6 +18,11 @@ export const GROUP_BY = {
     ACCOUNT: 'account',
 } as const;
 
+export const MORE_GROUP_BY = {
+    TAGS: 'tags',
+    ADDITIONAL_INFO: 'additional_info',
+};
+
 export const GRANULARITY_ITEM_MAP = {
     [GRANULARITY.ACCUMULATED]: { name: GRANULARITY.ACCUMULATED, label: 'Accumulated' },
     [GRANULARITY.DAILY]: { name: GRANULARITY.DAILY, label: 'Daily' },

--- a/src/services/cost-explorer/lib/config.ts
+++ b/src/services/cost-explorer/lib/config.ts
@@ -1,11 +1,11 @@
-export const GRANULARITY = Object.freeze({
+export const GRANULARITY = {
     ACCUMULATED: 'ACCUMULATED',
     DAILY: 'DAILY',
     MONTHLY: 'MONTHLY',
     YEARLY: 'YEARLY',
-});
+} as const;
 
-export const GROUP_BY = Object.freeze({
+export const GROUP_BY = {
     PROJECT_GROUP: 'project_group_id',
     PROJECT: 'project_id',
     PROVIDER: 'provider',
@@ -16,16 +16,16 @@ export const GROUP_BY = Object.freeze({
     REGION: 'region_code',
     TYPE: 'usage_type',
     ACCOUNT: 'account',
-} as const);
+} as const;
 
-export const GRANULARITY_ITEM_MAP = Object.freeze({
+export const GRANULARITY_ITEM_MAP = {
     [GRANULARITY.ACCUMULATED]: { name: GRANULARITY.ACCUMULATED, label: 'Accumulated' },
     [GRANULARITY.DAILY]: { name: GRANULARITY.DAILY, label: 'Daily' },
     [GRANULARITY.MONTHLY]: { name: GRANULARITY.MONTHLY, label: 'Monthly' },
     [GRANULARITY.YEARLY]: { name: GRANULARITY.YEARLY, label: 'Yearly' },
-});
+} as const;
 
-export const GROUP_BY_ITEM_MAP = Object.freeze({
+export const GROUP_BY_ITEM_MAP = {
     [GROUP_BY.PROJECT_GROUP]: { name: GROUP_BY.PROJECT_GROUP, label: 'Project Group' },
     [GROUP_BY.PROJECT]: { name: GROUP_BY.PROJECT, label: 'Project' },
     [GROUP_BY.PROVIDER]: { name: GROUP_BY.PROVIDER, label: 'Provider' },
@@ -36,16 +36,19 @@ export const GROUP_BY_ITEM_MAP = Object.freeze({
     [GROUP_BY.REGION]: { name: GROUP_BY.REGION, label: 'Region' },
     [GROUP_BY.TYPE]: { name: GROUP_BY.TYPE, label: 'Type' },
     [GROUP_BY.ACCOUNT]: { name: GROUP_BY.ACCOUNT, label: 'Account ID' },
-});
+} as const;
 
-export const FILTER = Object.freeze({
-    ...GROUP_BY,
+export const ADDITIONAL_FILTER = {
     TAGS: 'tags',
     ADDITIONAL_INFO: 'additional_info',
-} as const);
+};
+export const FILTER = {
+    ...GROUP_BY,
+    ...ADDITIONAL_FILTER,
+} as const;
 
-export const FILTER_ITEM_MAP = Object.freeze({
+export const FILTER_ITEM_MAP = {
     ...GROUP_BY_ITEM_MAP,
-    tags: { name: 'tags', label: 'Tags' },
-    additional_info: { name: 'additional_info', label: 'Additional Info' },
-});
+    [ADDITIONAL_FILTER.TAGS]: { name: ADDITIONAL_FILTER.TAGS, label: 'Tags' },
+    [ADDITIONAL_FILTER.ADDITIONAL_INFO]: { name: ADDITIONAL_FILTER.ADDITIONAL_INFO, label: 'Additional Info' },
+};

--- a/src/services/cost-explorer/store/cost-analysis/actions.ts
+++ b/src/services/cost-explorer/store/cost-analysis/actions.ts
@@ -27,13 +27,12 @@ export const initCostAnalysisStoreState: Action<CostAnalysisStoreState, any> = (
 
 const convertFilterFromObjectToArray = (filters: CostQueryFilters) => {
     const results: CostQueryFilterItem[] = [];
-    Object.entries(filters).forEach(([category, resourceNames]) => {
-        if (resourceNames) {
-            resourceNames.forEach((name) => {
+    Object.entries(filters).forEach(([category, values]) => {
+        if (values) {
+            values.forEach((v) => {
                 results.push({
                     category,
-                    value: name as string,
-                    resourceName: name as string,
+                    value: v as string,
                 });
             });
         }

--- a/src/services/cost-explorer/store/cost-analysis/getters.ts
+++ b/src/services/cost-explorer/store/cost-analysis/getters.ts
@@ -1,38 +1,11 @@
 import type { Getter } from 'vuex';
 
-import { store } from '@/store';
-
-import type { ReferenceItem } from '@/store/modules/reference/type';
-
 import { GROUP_BY_ITEM_MAP } from '@/services/cost-explorer/lib/config';
 import type {
     CostAnalysisStoreState, GroupByItem,
 } from '@/services/cost-explorer/store/cost-analysis/type';
-import type { CostQueryFilterItemsMap, CostQuerySetModel } from '@/services/cost-explorer/type';
+import type { CostQuerySetModel } from '@/services/cost-explorer/type';
 
-
-export const filterItemsMap: Getter<CostAnalysisStoreState, any> = ({ filters }): CostQueryFilterItemsMap => {
-    const itemsMap: CostQueryFilterItemsMap = {};
-    const resourceItemsMap = {
-        project_id: store.getters['reference/projectItems'],
-        project_group_id: store.getters['reference/projectGroupItems'],
-        service_account_id: store.getters['reference/serviceAccountItems'],
-        provider: store.getters['reference/providerItems'],
-        region_code: store.getters['reference/regionItems'],
-    };
-
-    Object.entries(filters).forEach(([key, data]) => {
-        const resourceItems = resourceItemsMap[key];
-        if (resourceItems) {
-            itemsMap[key] = data?.map((d) => {
-                const resourceItem: ReferenceItem = resourceItems[d];
-                const label = key === 'region_code' ? resourceItem?.name : resourceItem?.label;
-                return { name: d, label: label ?? d };
-            });
-        } else itemsMap[key] = data?.map(d => ({ name: d, label: d }));
-    });
-    return itemsMap;
-};
 
 export const groupByItems: Getter<CostAnalysisStoreState, any> = ({ groupBy }): GroupByItem[] => groupBy.map(d => GROUP_BY_ITEM_MAP[d]);
 

--- a/src/services/cost-explorer/store/cost-analysis/index.ts
+++ b/src/services/cost-explorer/store/cost-analysis/index.ts
@@ -12,8 +12,9 @@ const state: CostAnalysisStoreState = {
     stack: false,
     groupBy: [],
     primaryGroupBy: undefined,
+    moreGroupBy: [],
     period: getInitialDates(),
-    filters: {},
+    filters: [],
     selectedQueryId: undefined,
     costQueryList: [],
 };

--- a/src/services/cost-explorer/store/cost-analysis/mutations.ts
+++ b/src/services/cost-explorer/store/cost-analysis/mutations.ts
@@ -4,8 +4,7 @@ import type {
     CostAnalysisStoreState,
 } from '@/services/cost-explorer/store/cost-analysis/type';
 import type {
-    CostQueryFilters, CostQuerySetModel, GroupBy, Period,
-    Granularity,
+    CostQuerySetModel, GroupBy, Period, Granularity, MoreGroupByItem, CostQueryFilterItem,
 } from '@/services/cost-explorer/type';
 
 
@@ -25,11 +24,15 @@ export const setPrimaryGroupBy: Mutation<CostAnalysisStoreState> = (state, prima
     state.primaryGroupBy = primaryGroupBy;
 };
 
+export const setMoreGroupBy: Mutation<CostAnalysisStoreState> = (state, moreGroupBy: MoreGroupByItem[]) => {
+    state.moreGroupBy = moreGroupBy;
+};
+
 export const setPeriod: Mutation<CostAnalysisStoreState> = (state, period: Period) => {
     state.period = period;
 };
 
-export const setFilters: Mutation<CostAnalysisStoreState> = (state, filters: CostQueryFilters) => {
+export const setFilters: Mutation<CostAnalysisStoreState> = (state, filters: CostQueryFilterItem[]) => {
     state.filters = filters;
 };
 

--- a/src/services/cost-explorer/store/cost-analysis/type.ts
+++ b/src/services/cost-explorer/store/cost-analysis/type.ts
@@ -1,5 +1,6 @@
 import type {
-    CostQueryFilters, CostQuerySetModel, Period, Granularity, GroupBy,
+    CostQuerySetModel, Period, Granularity, GroupBy, MoreGroupByItem,
+    CostQueryFilterItem,
 } from '@/services/cost-explorer/type';
 
 export interface GroupByItem {
@@ -12,8 +13,9 @@ export interface CostAnalysisStoreState {
     stack: boolean;
     groupBy: GroupBy[];
     primaryGroupBy?: GroupBy;
+    moreGroupBy: MoreGroupByItem[];
     period: Period;
-    filters: CostQueryFilters;
+    filters: CostQueryFilterItem[];
     selectedQueryId?: string;
     costQueryList: CostQuerySetModel[];
 }

--- a/src/services/cost-explorer/type.ts
+++ b/src/services/cost-explorer/type.ts
@@ -6,9 +6,16 @@ export interface Period {
     end?: string;
 }
 
-interface FilterItem {
-    name: string;
-    label: string;
+export interface CostQueryFilterItem {
+    resourceName: string;
+    key?: string;
+    category: string;
+    value: string;
+}
+
+export interface MoreGroupByItem {
+    category: string;
+    key: string;
     disabled?: boolean;
 }
 
@@ -17,15 +24,15 @@ export type GroupBy = typeof GROUP_BY[keyof typeof GROUP_BY];
 export type Filter = typeof FILTER[keyof typeof FILTER];
 
 export type CostQueryFilters = Partial<Record<Filter, string[]>>;
-export type CostQueryFilterItemsMap = Partial<Record<Filter, FilterItem[]>>;
 
 export interface CostQuerySetOption {
     group_by?: GroupBy[];
     primary_group_by?: GroupBy;
+    more_group_by: MoreGroupByItem[];
     granularity: Granularity;
     stack?: boolean;
     period: Period;
-    filters?: CostQueryFilters;
+    filters?: CostQueryFilterItem[];
 }
 
 export interface CostQuerySetModel {

--- a/src/services/cost-explorer/type.ts
+++ b/src/services/cost-explorer/type.ts
@@ -7,10 +7,13 @@ export interface Period {
 }
 
 export interface CostQueryFilterItem {
-    resourceName: string;
-    key?: string;
     category: string;
+    key?: string;
     value: string;
+}
+
+export interface RefinedFilterItem extends CostQueryFilterItem {
+    label: string;
 }
 
 export interface MoreGroupByItem {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
cost-explorer > cost-analysis 스토어에서 filters의 타입을 `object`에서 `object[]`로 바꾸었습니다.

**바꾸게 된 이유**
기존에 저장되던 데이터는 이렇습니다.
```typescript
{
  region_code: ['ap-north-02', 'ap-south-01'],
  provider: ['aws', 'google_cloud'],
}
```

그러나 tags와 additional_info 등, key:value 타입의 데이터가 들어오게 되면서, 다음과 같이 바꾸게 되었습니다.
```typescript
[
  { category: 'region_code', resourceName: 'ap-north-02', value: 'ap-north-02' },
  { category: 'region_code', resourceName: 'ap-south-01', value: 'ap-south-01' },
  // tags의 경우
  { category: 'tags', resourceName: 'tags.team', key: 'team', value: 'spaceOne' },
]
```

### 생각해볼 점
`object[]`가 그대로 url에 들어가게 되는데 너무 데이터가 커서 좀 걱정입니다;;
url로 보낼 땐 데이터를 다시 이렇게 컨버팅할까 생각중이에요.
```typescript
{
  region_code: ['ap-north-02', 'ap-south-01'],
  provider: ['aws', 'google_cloud'],
  'tags.team': ['spaceOne'],
}
```