### PR TITLE
chore(budget): change props name from `filters` to `queryStoreFilters`

### DIFF
--- a/src/services/cost-explorer/budget/modules/budget-list/BudgetList.vue
+++ b/src/services/cost-explorer/budget/modules/budget-list/BudgetList.vue
@@ -9,7 +9,7 @@
                         @export="handleExport"
                         @update-sort="handleUpdateSort"
         />
-        <budget-stat :filters="queryStoreFilters" :period="period" :usage-range="range"
+        <budget-stat :query-store-filters="queryStoreFilters" :period="period" :usage-range="range"
                      class="budget-stat"
         />
         <div class="budget-list-card-box">
@@ -24,7 +24,7 @@
 <script lang="ts">
 
 import {
-    computed, reactive, toRefs,
+    computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
 import dayjs from 'dayjs';
@@ -56,7 +56,7 @@ interface Props {
     filters: QueryStoreFilter[];
 }
 
-export default {
+export default defineComponent<Props>({
     name: 'BudgetList',
     components: { BudgetListCard, BudgetToolbox, BudgetStat },
     props: {
@@ -199,7 +199,7 @@ export default {
             handleUpdateSort,
         };
     },
-};
+});
 </script>
 <style lang="postcss" scoped>
 .budget-list {

--- a/src/services/cost-explorer/budget/modules/budget-stat/BudgetStat.vue
+++ b/src/services/cost-explorer/budget/modules/budget-stat/BudgetStat.vue
@@ -27,10 +27,8 @@
 </template>
 
 <script lang="ts">
-
-
 import {
-    computed, getCurrentInstance,
+    computed, defineComponent, getCurrentInstance,
     reactive, toRefs, watch,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
@@ -62,7 +60,7 @@ import type { Period } from '@/services/cost-explorer/type';
 
 
 interface Props {
-    filters: QueryStoreFilter[];
+    queryStoreFilters: QueryStoreFilter[];
     period: Period;
     usageRange: BudgetUsageRange;
     printMode?: boolean;
@@ -80,10 +78,10 @@ interface Card {
     unit: Unit;
 }
 
-export default {
+export default defineComponent<Props>({
     name: 'BudgetStat',
     props: {
-        filters: {
+        queryStoreFilters: {
             type: Array,
             default: () => ([]),
         },
@@ -164,7 +162,7 @@ export default {
                     include_budget_count: true,
                 };
 
-                const { filter, keyword } = budgetUsageApiQueryHelper.setFilters(props.filters).data;
+                const { filter, keyword } = budgetUsageApiQueryHelper.setFilters(props.queryStoreFilters).data;
                 if (keyword) param.keyword = keyword;
                 if (filter?.length) param.filter = filter;
                 if (isNotEmpty(props.usageRange)) param.usage_range = props.usageRange;
@@ -187,7 +185,7 @@ export default {
         };
 
         /* Watchers */
-        watch([() => props.filters, () => props.period, () => props.usageRange], async () => {
+        watch([() => props.queryStoreFilters, () => props.period, () => props.usageRange], async () => {
             await fetchBudgetUsage();
             await vm.$nextTick();
             emit('rendered');
@@ -201,7 +199,7 @@ export default {
             UNIT,
         };
     },
-};
+});
 </script>
 <style lang="postcss" scoped>
 .budget-stat {

--- a/src/services/cost-explorer/widgets/BudgetUsageSummary.vue
+++ b/src/services/cost-explorer/widgets/BudgetUsageSummary.vue
@@ -4,15 +4,16 @@
                                        :show-top-text="false"
                                        :print-mode="printMode"
     >
-        <budget-stat :filters="queryStoreFilters" :period="period" :print-mode="printMode"
+        <budget-stat :query-store-filters="queryStoreFilters" :period="period" :print-mode="printMode"
                      @rendered="handleRendered"
         />
     </cost-dashboard-card-widget-layout>
 </template>
 
 <script lang="ts">
-
-import { computed, reactive, toRefs } from 'vue';
+import {
+    computed, defineComponent, reactive, toRefs,
+} from 'vue';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import type { QueryStoreFilter } from '@cloudforet/core-lib/query/type';
@@ -30,7 +31,7 @@ import CostDashboardCardWidgetLayout
 import type { WidgetProps } from '@/services/cost-explorer/widgets/type';
 
 
-export default {
+export default defineComponent<WidgetProps>({
     name: 'BudgetUsageSummary',
     components: {
         CostDashboardCardWidgetLayout,
@@ -70,7 +71,7 @@ export default {
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }) {
         const budgetQueryHelper = new QueryHelper();
         const state = reactive({
             widgetOptions: getWidgetOption(props.options, props.widgetId),
@@ -96,5 +97,5 @@ export default {
             handleRendered,
         };
     },
-};
+});
 </script>


### PR DESCRIPTION
### To Reviewers
- [x] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
상위/하위 컴포넌트에서 모두 `filters`라는 변수가 쓰이는데 둘의 타입이 달라 구분하기 위해 하위 props 이름을 바꾸었습니다.