### PR TITLE
fix(cost-dashboard): change type of filters from `object` to `object[]`

### DIFF
--- a/src/services/cost-explorer/budget/modules/budget-form/budget-form-amount-plan/BudgetFormAmountPlanLastMonthsCost.vue
+++ b/src/services/cost-explorer/budget/modules/budget-form/budget-form-amount-plan/BudgetFormAmountPlanLastMonthsCost.vue
@@ -29,9 +29,6 @@ import { useI18nDayjs } from '@/common/composables/i18n-dayjs';
 
 import type { BudgetData, BudgetTimeUnit } from '@/services/cost-explorer/budget/type';
 import { BUDGET_TIME_UNIT } from '@/services/cost-explorer/budget/type';
-import {
-    getConvertedFilter,
-} from '@/services/cost-explorer/cost-analysis/lib/helper';
 import type { CostQueryFilters, Granularity } from '@/services/cost-explorer/type';
 
 
@@ -114,6 +111,22 @@ export default {
             }),
         });
 
+        /* Util */
+        const getConvertedFilter = (filters: CostQueryFilters): QueryStoreFilter[] => {
+            const result: QueryStoreFilter[] = [];
+            Object.entries(filters).forEach(([key, data]) => {
+                if (data?.length) {
+                    result.push({
+                        k: key,
+                        v: data,
+                        o: '=',
+                    });
+                }
+            });
+            return result;
+        };
+
+        /* Api */
         const getRecentBudgets = async () => {
             try {
                 const { results } = await SpaceConnector.client.costAnalysis.cost.analyze(state.budgetListParams);
@@ -135,7 +148,6 @@ export default {
         return {
             ...toRefs(state),
             currencyMoneyFormatter,
-
         };
     },
 

--- a/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
+++ b/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
@@ -82,7 +82,7 @@ export default {
             group_by: queryStringToArray(urlQuery.groupBy),
             primary_group_by: queryStringToString(urlQuery.primaryGroupBy) as GroupBy,
             period: queryStringToObject(urlQuery.period),
-            filters: queryStringToObject(urlQuery.filters),
+            filters: queryStringToArray(urlQuery.filters),
         });
 
         const getQueryWithKey = (queryItemKey: string): Partial<CostQuerySetModel> => (state.costQueryList.find(item => item.cost_query_set_id === queryItemKey)) || {};
@@ -111,7 +111,7 @@ export default {
                     groupBy: arrayToQueryString(options.groupBy),
                     primaryGroupBy: primitiveToQueryString(options.primaryGroupBy),
                     period: objectToQueryString(options.period),
-                    filters: objectToQueryString(options.filters),
+                    filters: arrayToQueryString(options.filters),
                 };
 
                 if (JSON.stringify(newQuery) !== JSON.stringify(currentQuery)) {

--- a/src/services/cost-explorer/cost-analysis/lib/helper.ts
+++ b/src/services/cost-explorer/cost-analysis/lib/helper.ts
@@ -45,13 +45,13 @@ export const getRefinedFilterItems = (resourceMap: Record<string, any>, filterIt
 export const getConvertedBudgetFilter = (filters: CostQueryFilterItem[]): QueryStoreFilter[] => {
     const result: QueryStoreFilter[] = [];
 
-    const projectCategories: Filter[] = [FILTER.PROJECT, FILTER.PROJECT_GROUP];
-    const projectFilterItems = filters.filter(d => projectCategories.includes(d.category));
+    const PROJECT_CATEGORIES: Filter[] = [FILTER.PROJECT, FILTER.PROJECT_GROUP];
+    const projectFilterItems = filters.filter(d => PROJECT_CATEGORIES.includes(d.category));
     projectFilterItems.forEach((d) => {
         result.push({ k: d.category, v: d.value, o: '=' });
     });
 
-    const extraCategories: Filter[] = [...new Set(filters.filter(d => !projectCategories.includes(d.category)).map(d => d.category))];
+    const extraCategories: Filter[] = [...new Set(filters.filter(d => !PROJECT_CATEGORIES.includes(d.category)).map(d => d.category))];
     extraCategories.forEach((category) => {
         const filterItems = filters.filter(d => d.category === category);
         const filterKey = filterItems.length ? filterItems[0]?.key : undefined;

--- a/src/services/cost-explorer/cost-analysis/lib/helper.ts
+++ b/src/services/cost-explorer/cost-analysis/lib/helper.ts
@@ -11,11 +11,20 @@ import type {
 } from '@/services/cost-explorer/type';
 
 
-export const convertFilterItemToQueryStoreFilter = (filterItems: CostQueryFilterItem[]): QueryStoreFilter[] => filterItems.map(f => ({
-    k: f.key ? `${f.category}.${f.key}` : f.category,
-    v: f.value,
-    o: '=',
-}));
+export const convertFilterItemToQueryStoreFilter = (filters: CostQueryFilterItem[]): QueryStoreFilter[] => {
+    const results: QueryStoreFilter[] = [];
+    const categories: Filter[] = [...new Set(filters.map(d => d.category))];
+    categories.forEach((category) => {
+        const filterItems = filters.filter(d => d.category === category);
+        const filterKey = filterItems.length ? filterItems[0]?.key : undefined;
+        results.push({
+            k: filterKey ? `${category}.${filterKey}` : category,
+            v: filterItems.map(d => d.value),
+            o: '=',
+        });
+    });
+    return results;
+};
 
 export const getRefinedFilterItems = (resourceMap: Record<string, any>, filterItems: CostQueryFilterItem[]): RefinedFilterItem[] => {
     const results: RefinedFilterItem[] = [];

--- a/src/services/cost-explorer/cost-analysis/lib/helper.ts
+++ b/src/services/cost-explorer/cost-analysis/lib/helper.ts
@@ -7,7 +7,7 @@ import type { QueryStoreFilter } from '@cloudforet/core-lib/query/type';
 
 import { FILTER, GRANULARITY } from '@/services/cost-explorer/lib/config';
 import type {
-    CostQueryFilters, Period, Granularity, CostQueryFilterItem, RefinedFilterItem,
+    Period, Granularity, CostQueryFilterItem, RefinedFilterItem, Filter,
 } from '@/services/cost-explorer/type';
 
 
@@ -16,21 +16,6 @@ export const convertFilterItemToQueryStoreFilter = (filterItems: CostQueryFilter
     v: f.value,
     o: '=',
 }));
-
-// TODO: will be deprecated soon
-export const getConvertedFilter = (filters: CostQueryFilters): QueryStoreFilter[] => {
-    const result: QueryStoreFilter[] = [];
-    Object.entries(filters).forEach(([key, data]) => {
-        if (data?.length) {
-            result.push({
-                k: key,
-                v: data,
-                o: '=',
-            });
-        }
-    });
-    return result;
-};
 
 export const getRefinedFilterItems = (resourceMap: Record<string, any>, filterItems: CostQueryFilterItem[]): RefinedFilterItem[] => {
     const results: RefinedFilterItem[] = [];
@@ -48,28 +33,26 @@ export const getRefinedFilterItems = (resourceMap: Record<string, any>, filterIt
     return results;
 };
 
-export const getConvertedBudgetFilter = (filters: CostQueryFilters): QueryStoreFilter[] => {
+export const getConvertedBudgetFilter = (filters: CostQueryFilterItem[]): QueryStoreFilter[] => {
     const result: QueryStoreFilter[] = [];
-    Object.entries(filters).forEach(([key, data]) => {
-        if ((key === 'project_id' || key === 'project_group_id') && data?.length) {
-            result.push({
-                k: key,
-                v: data,
-                o: '=',
-            });
-        } else {
-            const values = [] as Array<string|null>;
-            if (data?.length) {
-                data.forEach((value) => {
-                    values.push(value);
-                });
-                result.push({
-                    k: `cost_types.${key}`,
-                    v: [null, ...values],
-                    o: '=',
-                });
-            }
-        }
+
+    const projectCategories: Filter[] = [FILTER.PROJECT, FILTER.PROJECT_GROUP];
+    const projectFilterItems = filters.filter(d => projectCategories.includes(d.category));
+    projectFilterItems.forEach((d) => {
+        result.push({ k: d.category, v: d.value, o: '=' });
+    });
+
+    const extraCategories: Filter[] = [...new Set(filters.filter(d => !projectCategories.includes(d.category)).map(d => d.category))];
+    extraCategories.forEach((category) => {
+        const filterItems = filters.filter(d => d.category === category);
+        const filterKey = filterItems.length ? filterItems[0]?.key : undefined;
+        const k = filterKey ? `${category}.${filterKey}` : category;
+        const values = filterItems.map(d => d.value);
+        result.push({
+            k: `cost_types.${k}`,
+            v: [null, ...values],
+            o: '=',
+        });
     });
     return result;
 };

--- a/src/services/cost-explorer/cost-dashboard/CostDashboardPage.vue
+++ b/src/services/cost-explorer/cost-dashboard/CostDashboardPage.vue
@@ -80,7 +80,6 @@
 </template>
 
 <script lang="ts">
-
 import {
     computed, reactive, toRefs, watch,
 } from 'vue';
@@ -118,7 +117,7 @@ import DashboardLayouts from '@/services/cost-explorer/cost-dashboard/modules/Da
 import type { DashboardInfo } from '@/services/cost-explorer/cost-dashboard/type';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 import { costExplorerStore } from '@/services/cost-explorer/store';
-import type { CostQueryFilters, Period } from '@/services/cost-explorer/type';
+import type { CostQueryFilterItem, Period } from '@/services/cost-explorer/type';
 
 const PUBLIC_ICON_COLOR = gray[500];
 
@@ -171,7 +170,7 @@ export default {
             layout: [] as any[],
             period: {} as Period,
             periodType: '',
-            filters: {} as CostQueryFilters,
+            filters: [] as CostQueryFilterItem[],
             currency: computed(() => store.state.display.currency),
             currencyRates: computed(() => store.state.display.currencyRates),
             homeDashboardId: computed<string|undefined>(() => costExplorerStore.getters.homeDashboardId),
@@ -233,7 +232,9 @@ export default {
             const dashboard = await fetchDashboard(dashboardId);
             state.dashboard = dashboard;
             state.layout = await getDashboardLayout(dashboard);
-            state.filters = dashboard.default_filter;
+            // TODO: default_filter will be changed from `object` to `object[]`
+            // state.filters = dashboard.default_filter;
+            state.filters = [];
             state.period = dashboard.period ?? {};
             state.periodType = dashboard.period_type;
 

--- a/src/services/cost-explorer/cost-dashboard/cost-dashboard-create/modules/CostDashboardCreateDefaultFilter.vue
+++ b/src/services/cost-explorer/cost-dashboard/cost-dashboard-create/modules/CostDashboardCreateDefaultFilter.vue
@@ -12,7 +12,7 @@
             {{ $t('BILLING.COST_MANAGEMENT.DASHBOARD.CREATE.TEMPLATE.VIEW_FILTER') }}
         </p-button>
         <view-filter-modal :visible.sync="defaultFilterModalVisible"
-                           :selected-filters="defaultFilter"
+                           :selected-filters="defaultFilters"
         />
     </fragment>
 </template>
@@ -48,7 +48,9 @@ export default {
                 },
             }),
             defaultFilterModalVisible: false,
-            defaultFilter: computed(() => costExplorerStore.state.dashboard.defaultFilter ?? {}),
+            // TODO: default_filter will be changed from `object` to `object[]`
+            // defaultFilter: computed(() => costExplorerStore.state.dashboard.defaultFilter ?? {}),
+            defaultFilters: computed(() => []),
             isDashboardTemplate: computed(() => has(costExplorerStore.state.dashboard.selectedTemplate, 'public_dashboard_id')
                 || has(costExplorerStore.state.dashboard.selectedTemplate, 'user_dashboard_id')),
         });

--- a/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/CostDashboardCustomizePage.vue
+++ b/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/CostDashboardCustomizePage.vue
@@ -56,7 +56,7 @@ import type {
 } from '@/services/cost-explorer/cost-dashboard/type';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 import { costExplorerStore } from '@/services/cost-explorer/store';
-import type { CostQueryFilters, Period } from '@/services/cost-explorer/type';
+import type { CostQueryFilterItem, Period } from '@/services/cost-explorer/type';
 
 
 export default {
@@ -92,7 +92,7 @@ export default {
             defaultFilter: computed<Record<string, string[]>>(() => costExplorerStore.state.dashboard.defaultFilter),
             period: {} as Period,
             periodType: '',
-            filters: {} as CostQueryFilters,
+            filters: [] as CostQueryFilterItem[],
             widgetPosition: computed(() => costExplorerStore.state.dashboard.widgetPosition),
             layoutOfSpace: computed(() => costExplorerStore.state.dashboard.layoutOfSpace),
         });
@@ -176,7 +176,9 @@ export default {
                 }
                 state.dashboardTitle = state.dashboardData?.name || '';
                 state.layout = await getDashboardLayout(state.dashboardData);
-                state.filters = state.dashboardData.default_filter ?? {};
+                // TODO: default_filter will be changed from `object` to `object[]`
+                // state.filters = state.dashboardData.default_filter ?? {};
+                state.filters = [];
                 state.period = state.dashboardData.period ?? {};
                 state.periodType = state.dashboardData.period_type ?? 'AUTO';
                 state.loading = false;

--- a/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CustomWidgetPreview.vue
+++ b/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CustomWidgetPreview.vue
@@ -19,7 +19,7 @@
             </div>
             <div>
                 <p-label>{{ $t('BILLING.COST_MANAGEMENT.DASHBOARD.CUSTOMIZE.ADD_WIDGET_MODAL.LABEL_FILTERS') }}</p-label>
-                <span :class="{'text-gray-500': noFilters }">{{ filterLabel }}</span>
+                <span :class="{'text-gray-500': !filters.length }">{{ filterLabel }}</span>
             </div>
         </template>
         <template #extra>
@@ -31,7 +31,6 @@
 </template>
 
 <script lang="ts">
-
 import { computed, reactive, toRefs } from 'vue';
 import type { Location } from 'vue-router/types/router';
 
@@ -51,7 +50,7 @@ import { getCostDashboardFilterLabel } from '@/services/cost-explorer/cost-dashb
 import type { WidgetInfo } from '@/services/cost-explorer/cost-dashboard/type';
 import { GRANULARITY, GROUP_BY_ITEM_MAP } from '@/services/cost-explorer/lib/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
-import type { CostQuerySetModel } from '@/services/cost-explorer/type';
+import type { CostQueryFilterItem, CostQuerySetModel } from '@/services/cost-explorer/type';
 
 
 const LAYOUT = 100;
@@ -86,8 +85,9 @@ export default {
                 if (state.granularity === GRANULARITY.MONTHLY) return i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.MONTHLY');
                 return i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.DAILY');
             }),
-            filters: computed(() => props.selectedItem?.options.filters),
-            noFilters: computed(() => !state.filters || !Object.keys(state.filters).length),
+            // TODO: should be changed to object[] type
+            filters: computed<CostQueryFilterItem[]>(() => []),
+            // filters: computed(() => props.selectedItem?.options.filters ?? []),
             filterLabel: computed(() => {
                 const label = getCostDashboardFilterLabel(state.filters);
                 return label ?? i18n.t('BILLING.COST_MANAGEMENT.MAIN.FILTER_NONE');

--- a/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CustomWidgetPreview.vue
+++ b/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CustomWidgetPreview.vue
@@ -42,7 +42,7 @@ import { capitalize } from 'lodash';
 import { SpaceRouter } from '@/router';
 import { i18n } from '@/translations';
 
-import { arrayToQueryString, objectToQueryString, primitiveToQueryString } from '@/lib/router-query-string';
+import { arrayToQueryString, primitiveToQueryString } from '@/lib/router-query-string';
 
 import CostDashboardCustomizeWidgetPreview
     from '@/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CostDashboardCustomizeWidgetPreview.vue';
@@ -115,7 +115,7 @@ export default {
                 query: {
                     granularity: primitiveToQueryString(state.granularity),
                     groupBy: arrayToQueryString([state.groupBy]),
-                    filters: objectToQueryString(state.filters),
+                    filters: arrayToQueryString(state.filters),
                     stack: primitiveToQueryString(state.stack),
                 },
             };

--- a/src/services/cost-explorer/cost-dashboard/lib/helper.ts
+++ b/src/services/cost-explorer/cost-dashboard/lib/helper.ts
@@ -3,7 +3,7 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 import type { CustomLayout, DashboardInfo } from '@/services/cost-explorer/cost-dashboard/type';
 import { FILTER_ITEM_MAP } from '@/services/cost-explorer/lib/config';
 import { costExplorerStore } from '@/services/cost-explorer/store';
-import type { CostQueryFilters } from '@/services/cost-explorer/type';
+import type { CostQueryFilterItem } from '@/services/cost-explorer/type';
 
 export const fetchDefaultLayoutData = async (layoutId: string) => {
     try {
@@ -25,14 +25,14 @@ export const getDashboardLayout = async (dashboard: DashboardInfo): Promise<Cust
     return layout;
 };
 
-export const getCostDashboardFilterLabel = (filters?: CostQueryFilters): string|undefined => {
-    if (!filters) return undefined;
+export const getCostDashboardFilterLabel = (filters: CostQueryFilterItem[]): string|undefined => {
+    if (!filters.length) return undefined;
     const desc: string[] = [];
-    Object.entries(FILTER_ITEM_MAP).forEach(([k, v]) => {
-        if (filters[k]?.length) {
-            const filterLength = filters[k]?.length ?? 0;
-            const suffix = filterLength > 1 ? `${v.label}s` : v.label;
-            desc.push(`${filterLength} ${suffix}`);
+    Object.entries(FILTER_ITEM_MAP).forEach(([filterName, v]) => {
+        const categoryFilters = filters.filter(d => d.category === filterName);
+        if (categoryFilters.length) {
+            const suffix = categoryFilters.length > 1 ? `${v.label}s` : v.label;
+            desc.push(`${categoryFilters.length} ${suffix}`);
         }
     });
     if (desc.length) return desc.join(' & ');

--- a/src/services/cost-explorer/cost-dashboard/modules/CostDashboardPreview.vue
+++ b/src/services/cost-explorer/cost-dashboard/modules/CostDashboardPreview.vue
@@ -31,9 +31,8 @@
 </template>
 
 <script lang="ts">
-
 import {
-    computed, onMounted, reactive, toRefs, watch,
+    computed, defineComponent, onMounted, reactive, toRefs, watch,
 } from 'vue';
 
 import {
@@ -53,11 +52,19 @@ import CostDashboardPeriodSelectDropdown
 import DashboardLayouts from '@/services/cost-explorer/cost-dashboard/modules/DashboardLayouts.vue';
 import type { CustomLayout, DashboardInfo } from '@/services/cost-explorer/cost-dashboard/type';
 import { costExplorerStore } from '@/services/cost-explorer/store';
+import type { CostQueryFilterItem, Period } from '@/services/cost-explorer/type';
+
+
+interface Props {
+    dashboardId: string;
+    period: Period;
+    filters: CostQueryFilterItem[];
+}
 
 const HEADER_ELEMENT = 1;
 const DASHBOARD_LAYOUT = 1;
 
-export default {
+export default defineComponent<Props>({
     name: 'CostDashboardPreview',
     components: {
         CostDashboardPeriodSelectDropdown,
@@ -75,8 +82,8 @@ export default {
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
     },
     setup(props, { emit }) {
@@ -138,7 +145,9 @@ export default {
             const dashboard = await fetchDashboard(dashboardId);
             state.dashboard = dashboard;
             state.layout = await getDashboardLayout(dashboard);
-            state.filters = dashboard.default_filter;
+            // TODO: default_filter will be changed from `object` to `object[]`
+            // state.filters = dashboard.default_filter;
+            state.filters = [];
             state.period = dashboard.period ?? {};
             state.periodType = dashboard.period_type;
 
@@ -167,7 +176,7 @@ export default {
             handleAllRenderedWidgets,
         };
     },
-};
+});
 </script>
 
 <style lang="postcss" scoped>

--- a/src/services/cost-explorer/cost-dashboard/modules/DashboardLayouts.vue
+++ b/src/services/cost-explorer/cost-dashboard/modules/DashboardLayouts.vue
@@ -12,10 +12,10 @@
             <template #loader>
                 <div />
             </template>
-            <div v-for="(row, rowIdx) in layout" :key="`row-${row[0].name}-${contextId}`" ref="dynamicWidgetRows"
+            <div v-for="(row, rowIdx) in layout" :key="`row-${row[0].name}-${contextId}-${rowIdx}`" ref="dynamicWidgetRows"
                  class="row" :class="{'customize':customizeMode}"
             >
-                <div v-for="(widget, colIdx) in row" :key="`widget-${widget.widget_id}-${contextId}`"
+                <div v-for="(widget, colIdx) in row" :key="`widget-${widget.widget_id}-${contextId}-${colIdx}`"
                      :class="`col-${widget.options.layout}`"
                 >
                     <div v-if="customizeMode" class="btn-group">
@@ -119,8 +119,8 @@ export default {
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         currency: {
             type: String,

--- a/src/services/cost-explorer/cost-dashboard/modules/DynamicWidget.vue
+++ b/src/services/cost-explorer/cost-dashboard/modules/DynamicWidget.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts">
 import {
-    computed, reactive, toRefs,
+    computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
 import { CURRENCY } from '@/store/modules/display/config';
@@ -30,7 +30,7 @@ interface Props extends WidgetProps {
     widgetFileName: string;
 }
 
-export default {
+export default defineComponent<Props>({
     name: 'DynamicWidget',
     props: {
         widgetId: {
@@ -54,8 +54,8 @@ export default {
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         currency: {
             type: String,
@@ -70,7 +70,7 @@ export default {
             default: false,
         },
     },
-    setup(props: Props) {
+    setup(props) {
         // noinspection TypeScriptCheckImport
         const state = reactive({
             component: null as any,
@@ -95,5 +95,5 @@ export default {
             getComponent,
         };
     },
-};
+});
 </script>

--- a/src/services/cost-explorer/cost-dashboard/modules/ViewFilterModal.vue
+++ b/src/services/cost-explorer/cost-dashboard/modules/ViewFilterModal.vue
@@ -2,31 +2,22 @@
     <p-button-modal
         class="view-filter-modal"
         :header-title="$t('BILLING.COST_MANAGEMENT.MAIN.APPLIED_FILTER')"
-        size="md"
         fade
         backdrop
+        hide-footer-confirm-button
         :visible.sync="proxyVisible"
-        @confirm="handleClickConfirm"
     >
         <template #body>
             <div v-for="filterName in filterNames" :key="`filter-wrapper-${filterName}`" class="filter-wrapper">
                 <p class="title">
-                    {{ FILTER_ITEM_MAP[filterName].label }} ({{ items[filterName] ? items[filterName].length : 0 }})
+                    {{ FILTER_ITEM_MAP[filterName].label }} ({{ refinedItemsByCategory(filterName).length }})
                 </p>
-                <p-empty v-if="!items[filterName] || !items[filterName].length">
-                    {{ $t('BILLING.COST_MANAGEMENT.MAIN.NO_SELECTED_FILTER') }}
-                </p-empty>
-                <div v-else class="filters">
-                    <p-tag v-for="(item, idx) in items[filterName]" :key="`filter-${item.name}-${idx}`"
-                           :deletable="false"
-                    >
-                        {{ item.label }}
-                    </p-tag>
-                </div>
+                <cost-explorer-filter-tags :filter-items="refinedItemsByCategory(filterName)">
+                    <template #no-filter>
+                        <p-empty>{{ $t('BILLING.COST_MANAGEMENT.MAIN.NO_SELECTED_FILTER') }}</p-empty>
+                    </template>
+                </cost-explorer-filter-tags>
             </div>
-        </template>
-        <template #confirm-button>
-            {{ $t('BILLING.COST_MANAGEMENT.MAIN.CLOSE') }}
         </template>
     </p-button-modal>
 </template>
@@ -35,18 +26,17 @@
 import { computed, reactive, toRefs } from 'vue';
 
 import {
-    PButtonModal, PEmpty, PTag,
+    PButtonModal, PEmpty,
 } from '@spaceone/design-system';
-
 
 import { store } from '@/store';
 
-import type { ReferenceItem } from '@/store/modules/reference/type';
-
 import { useProxyValue } from '@/common/composables/proxy-state';
 
+import { getRefinedFilterItems } from '@/services/cost-explorer/cost-analysis/lib/helper';
 import { FILTER, FILTER_ITEM_MAP } from '@/services/cost-explorer/lib/config';
-import type { CostQueryFilterItemsMap, CostQueryFilters } from '@/services/cost-explorer/type';
+import CostExplorerFilterTags from '@/services/cost-explorer/modules/CostExplorerFilterTags.vue';
+import type { CostQueryFilterItem, RefinedFilterItem } from '@/services/cost-explorer/type';
 
 
 const DASHBOARD_FILTERS = [FILTER.PROJECT_GROUP, FILTER.PROJECT, FILTER.SERVICE_ACCOUNT, FILTER.PROVIDER];
@@ -54,16 +44,16 @@ const CUSTOM_DASHBOARD_FILTERS = Object.values(FILTER);
 
 interface Props {
     visible: boolean;
-    selectedFilters: CostQueryFilters;
+    selectedFilters: CostQueryFilterItem[];
     isCustom?: boolean;
 }
 
 export default {
     name: 'ViewFilterModal',
     components: {
+        CostExplorerFilterTags,
         PButtonModal,
         PEmpty,
-        PTag,
     },
     props: {
         visible: {
@@ -71,8 +61,8 @@ export default {
             default: false,
         },
         selectedFilters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         isCustom: {
             type: Boolean,
@@ -83,27 +73,18 @@ export default {
         const state = reactive({
             proxyVisible: useProxyValue('visible', props, emit),
             filterNames: computed(() => (props.isCustom ? CUSTOM_DASHBOARD_FILTERS : DASHBOARD_FILTERS)),
-            items: computed(() => {
-                const resourceItemsMap = {
-                    [FILTER.PROJECT_GROUP]: store.getters['reference/projectGroupItems'],
-                    [FILTER.PROJECT]: store.getters['reference/projectItems'],
-                    [FILTER.PROVIDER]: store.getters['reference/providerItems'],
-                    [FILTER.SERVICE_ACCOUNT]: store.getters['reference/serviceAccountItems'],
-                    [FILTER.REGION]: store.getters['reference/regionItems'],
-                };
-                const itemsMap: CostQueryFilterItemsMap = {};
-                Object.entries(props.selectedFilters as CostQueryFilters).forEach(([key, data]) => {
-                    const resourceItems = resourceItemsMap[key];
-                    if (resourceItems) {
-                        itemsMap[key] = data?.map((d) => {
-                            const resourceItem: ReferenceItem = resourceItems[d];
-                            return { name: d, label: resourceItem?.label ?? d };
-                        });
-                    } else itemsMap[key] = data?.map(d => ({ name: d, label: d }));
-                });
-                return itemsMap;
-            }),
+            resourceMap: computed(() => ({
+                project_id: store.getters['reference/projectItems'],
+                project_group_id: store.getters['reference/projectGroupItems'],
+                service_account_id: store.getters['reference/serviceAccountItems'],
+                provider: store.getters['reference/providerItems'],
+                region_code: store.getters['reference/regionItems'],
+            })),
+            refinedItems: computed<RefinedFilterItem[]>(() => getRefinedFilterItems(state.resourceMap, props.selectedFilters)),
         });
+
+        /* Util */
+        const refinedItemsByCategory = (category: string) => state.refinedItems.filter(d => d.category === category);
 
         /* event */
         const handleClickConfirm = () => {
@@ -126,6 +107,7 @@ export default {
             FILTER,
             FILTER_ITEM_MAP,
             handleClickConfirm,
+            refinedItemsByCategory,
         };
     },
 };
@@ -136,14 +118,6 @@ export default {
 .view-filter-modal {
     :deep(.modal-body) {
         max-height: 20rem;
-    }
-    :deep(.modal-footer) {
-        .cancel-button {
-            display: none;
-        }
-        .modal-button {
-            margin-left: auto;
-        }
     }
 }
 

--- a/src/services/cost-explorer/cost-dashboard/type.ts
+++ b/src/services/cost-explorer/cost-dashboard/type.ts
@@ -1,7 +1,7 @@
 import type { Tags, TimeStamp } from '@/models';
 
 import type {
-    CostQueryFilters, Period, Granularity, GroupBy,
+    Period, Granularity, GroupBy, CostQueryFilterItem,
 } from '@/services/cost-explorer/type';
 
 const DASHBOARD_SCOPE = {
@@ -11,12 +11,12 @@ const DASHBOARD_SCOPE = {
 
 export type DashboardScope = typeof DASHBOARD_SCOPE[keyof typeof DASHBOARD_SCOPE];
 
-interface DefaultFilter {
-    projects?: string[];
-    project_groups?: string[];
-    service_accounts?: string[];
-    provider?: string[];
-}
+// export interface DefaultFilter {
+//     projects?: string[];
+//     project_groups?: string[];
+//     service_accounts?: string[];
+//     provider?: string[];
+// }
 
 
 export const CHART_TYPE = Object.freeze({
@@ -35,7 +35,7 @@ export type ChartType = typeof CHART_TYPE[keyof typeof CHART_TYPE];
 export interface WidgetOptions {
     stack?: boolean;
     granularity?: Granularity;
-    filters?: CostQueryFilters;
+    filters?: CostQueryFilterItem[];
     period?: Period;
     group_by?: string | GroupBy;
     chart_type?: ChartType;
@@ -52,11 +52,11 @@ export interface WidgetInfo {
 
 export type CustomLayout = WidgetInfo[];
 
-export interface DashboardItem {
+export interface DashboardModel {
     created_at: TimeStamp;
     updated_at: TimeStamp;
     custom_layouts: CustomLayout[];
-    default_filter: DefaultFilter;
+    default_filter: CostQueryFilterItem[];
     default_layout_id: string;
     domain_id?: string;
     name: string;
@@ -67,11 +67,11 @@ export interface DashboardItem {
     period?: Period;
 }
 
-export interface PublicDashboardInfo extends DashboardItem {
+export interface PublicDashboardInfo extends DashboardModel {
     public_dashboard_id: string;
 }
 
-export interface UserDashboardInfo extends DashboardItem {
+export interface UserDashboardInfo extends DashboardModel {
     user_dashboard_id: string;
 }
 
@@ -100,7 +100,7 @@ export interface DashboardCreateParam {
     name: string;
     default_layout_id?: string;
     custom_layouts?: CustomLayout[];
-    default_filter?: DefaultFilter;
+    default_filter?: CostQueryFilterItem[];
     period_type: PeriodType;
     period?: Period;
     tags?: Tags;

--- a/src/services/cost-explorer/widgets/BudgetStatus.vue
+++ b/src/services/cost-explorer/widgets/BudgetStatus.vue
@@ -35,8 +35,7 @@
 </template>
 
 <script lang="ts">
-
-
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
@@ -65,6 +64,7 @@ import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 import CostDashboardCardWidgetLayout
     from '@/services/cost-explorer/widgets/modules/CostDashboardCardWidgetLayout.vue';
 import type { WidgetProps } from '@/services/cost-explorer/widgets/type';
+
 
 interface ChartData {
     budgetId: string;
@@ -101,15 +101,15 @@ export default defineComponent<WidgetProps>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         printMode: {
             type: Boolean,
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const budgetQueryHelper = new QueryHelper();
         const state = reactive({

--- a/src/services/cost-explorer/widgets/BudgetUsage.vue
+++ b/src/services/cost-explorer/widgets/BudgetUsage.vue
@@ -29,9 +29,9 @@
 </template>
 
 <script lang="ts">
-
+import type { SetupContext } from 'vue';
 import {
-    computed, getCurrentInstance, reactive, toRefs, watch,
+    computed, defineComponent, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
 import type { Vue } from 'vue/types/vue';
 
@@ -60,8 +60,10 @@ import BudgetUsageProgressBar
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 import CostDashboardSimpleCardWidget
     from '@/services/cost-explorer/widgets/modules/CostDashboardSimpleCardWidget.vue';
+import type { WidgetProps } from '@/services/cost-explorer/widgets/type';
 
-export default {
+
+export default defineComponent<WidgetProps>({
     name: 'BudgetUsage',
     components: {
         CostDashboardSimpleCardWidget,
@@ -78,8 +80,8 @@ export default {
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         period: {
             type: Object,
@@ -101,7 +103,7 @@ export default {
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             loading: true,
@@ -175,7 +177,7 @@ export default {
             getUsageCostColor,
         };
     },
-};
+});
 </script>
 <style lang="postcss" scoped>
 /* custom progress-bar */

--- a/src/services/cost-explorer/widgets/BudgetUsageSummary.vue
+++ b/src/services/cost-explorer/widgets/BudgetUsageSummary.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script lang="ts">
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
@@ -55,8 +56,8 @@ export default defineComponent<WidgetProps>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         currency: {
             type: String,
@@ -71,7 +72,7 @@ export default defineComponent<WidgetProps>({
             default: false,
         },
     },
-    setup(props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const budgetQueryHelper = new QueryHelper();
         const state = reactive({
             widgetOptions: getWidgetOption(props.options, props.widgetId),

--- a/src/services/cost-explorer/widgets/BudgetUsageWithForecast.vue
+++ b/src/services/cost-explorer/widgets/BudgetUsageWithForecast.vue
@@ -37,9 +37,9 @@
 </template>
 
 <script lang="ts">
-
+import type { SetupContext } from 'vue';
 import {
-    computed, getCurrentInstance, reactive, toRefs, watch,
+    computed, defineComponent, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 import type { Vue } from 'vue/types/vue';
@@ -86,7 +86,7 @@ interface BudgetItem {
 type I18nDataTableField = DataTableField | {
     label: string | TranslateResult;
 };
-export default {
+export default defineComponent<WidgetProps>({
     name: 'BudgetUsageWithForecast',
     components: {
         CostDashboardCardWidgetLayout,
@@ -108,8 +108,8 @@ export default {
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         currency: {
             type: String,
@@ -124,7 +124,7 @@ export default {
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const budgetQueryHelper = new QueryHelper();
 
@@ -240,7 +240,7 @@ export default {
             projectGroupNameFormatter,
         };
     },
-};
+});
 </script>
 
 <style lang="postcss" scoped>

--- a/src/services/cost-explorer/widgets/CostByRegion.vue
+++ b/src/services/cost-explorer/widgets/CostByRegion.vue
@@ -46,6 +46,7 @@
 </template>
 
 <script lang="ts">
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, onUnmounted, reactive, toRefs, watch,
 } from 'vue';
@@ -78,7 +79,9 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 
 import { gray } from '@/styles/colors';
 
-import { getConvertedFilter } from '@/services/cost-explorer/cost-analysis/lib/helper';
+import {
+    convertFilterItemToQueryStoreFilter,
+} from '@/services/cost-explorer/cost-analysis/lib/helper';
 import { GRANULARITY, GROUP_BY } from '@/services/cost-explorer/lib/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 import { RegionMap } from '@/services/cost-explorer/widgets/lib/config';
@@ -140,8 +143,8 @@ export default defineComponent<WidgetProps>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         currency: {
             type: String,
@@ -156,7 +159,7 @@ export default defineComponent<WidgetProps>({
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             chartRef: null as HTMLElement | null,
             chart: null as MapChart | null,
@@ -174,7 +177,7 @@ export default defineComponent<WidgetProps>({
                         granularity: primitiveToQueryString(GRANULARITY.ACCUMULATED),
                         groupBy: arrayToQueryString([GROUP_BY.REGION]),
                         period: objectToQueryString(props.period),
-                        filters: objectToQueryString(props.filters),
+                        filters: arrayToQueryString(props.filters),
                     },
                 };
             }),
@@ -313,7 +316,7 @@ export default defineComponent<WidgetProps>({
 
         const costQueryHelper = new QueryHelper();
         const fetchData = async (): Promise<OriginData[]> => {
-            costQueryHelper.setFilters(getConvertedFilter(props.filters));
+            costQueryHelper.setFilters(convertFilterItemToQueryStoreFilter(props.filters));
             try {
                 const { results } = await SpaceConnector.client.costAnalysis.cost.analyze({
                     include_usage_quantity: false,

--- a/src/services/cost-explorer/widgets/CostDonut.vue
+++ b/src/services/cost-explorer/widgets/CostDonut.vue
@@ -33,8 +33,7 @@
 </template>
 
 <script lang="ts">
-
-
+import type { SetupContext } from 'vue';
 import {
     computed, reactive, toRefs, watch, onUnmounted, defineComponent,
 } from 'vue';
@@ -63,7 +62,9 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 
 import { gray } from '@/styles/colors';
 
-import { getConvertedFilter } from '@/services/cost-explorer/cost-analysis/lib/helper';
+import {
+    convertFilterItemToQueryStoreFilter,
+} from '@/services/cost-explorer/cost-analysis/lib/helper';
 import type { WidgetOptions } from '@/services/cost-explorer/cost-dashboard/type';
 import { GRANULARITY, GROUP_BY_ITEM_MAP } from '@/services/cost-explorer/lib/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
@@ -101,8 +102,8 @@ export default defineComponent<WidgetProps>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         currency: {
             type: String,
@@ -117,7 +118,7 @@ export default defineComponent<WidgetProps>({
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             chartRef: null as HTMLElement | null,
             chartRegistry: {},
@@ -136,7 +137,7 @@ export default defineComponent<WidgetProps>({
                         granularity: primitiveToQueryString(GRANULARITY.ACCUMULATED),
                         groupBy: arrayToQueryString([state.groupBy]),
                         period: objectToQueryString(props.period),
-                        filters: objectToQueryString(props.filters),
+                        filters: arrayToQueryString(props.filters),
                     },
                 };
             }),
@@ -229,7 +230,7 @@ export default defineComponent<WidgetProps>({
         const costQueryHelper = new QueryHelper();
         const getData = async () => {
             state.loading = true;
-            costQueryHelper.setFilters(getConvertedFilter(props.filters));
+            costQueryHelper.setFilters(convertFilterItemToQueryStoreFilter(props.filters));
             try {
                 const { results } = await SpaceConnector.client.costAnalysis.cost.analyze({
                     granularity: GRANULARITY.ACCUMULATED,

--- a/src/services/cost-explorer/widgets/CostPie.vue
+++ b/src/services/cost-explorer/widgets/CostPie.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script lang="ts">
-
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, onUnmounted, reactive, toRefs, watch,
 } from 'vue';
@@ -70,7 +70,9 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 
 import { gray } from '@/styles/colors';
 
-import { getConvertedFilter } from '@/services/cost-explorer/cost-analysis/lib/helper';
+import {
+    convertFilterItemToQueryStoreFilter,
+} from '@/services/cost-explorer/cost-analysis/lib/helper';
 import { CHART_TYPE } from '@/services/cost-explorer/cost-analysis/type';
 import { GRANULARITY, GROUP_BY_ITEM_MAP } from '@/services/cost-explorer/lib/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
@@ -111,8 +113,8 @@ export default defineComponent<WidgetProps>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         currency: {
             type: String,
@@ -127,7 +129,7 @@ export default defineComponent<WidgetProps>({
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             chartRef: null as HTMLElement | null,
             chart: null as PieChart | null,
@@ -146,7 +148,7 @@ export default defineComponent<WidgetProps>({
                         granularity: primitiveToQueryString(GRANULARITY.ACCUMULATED),
                         groupBy: arrayToQueryString([state.groupBy]),
                         period: objectToQueryString(props.period),
-                        filters: objectToQueryString(props.filters),
+                        filters: arrayToQueryString(props.filters),
                     },
                 };
             }),
@@ -217,7 +219,7 @@ export default defineComponent<WidgetProps>({
 
         const costQueryHelper = new QueryHelper();
         const fetchData = async () => {
-            costQueryHelper.setFilters(getConvertedFilter(props.filters));
+            costQueryHelper.setFilters(convertFilterItemToQueryStoreFilter(props.filters));
             try {
                 const { results } = await SpaceConnector.client.costAnalysis.cost.analyze({
                     include_usage_quantity: false,

--- a/src/services/cost-explorer/widgets/CostTrendStackedColumnA.vue
+++ b/src/services/cost-explorer/widgets/CostTrendStackedColumnA.vue
@@ -16,12 +16,12 @@
 </template>
 
 <script lang="ts">
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
 import dayjs from 'dayjs';
-
 
 import { CURRENCY } from '@/store/modules/display/config';
 
@@ -65,15 +65,15 @@ export default defineComponent<WidgetProps>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         printMode: {
             type: Boolean,
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             groupBy: computed(() => props.options?.group_by),
             widgetLink: computed(() => {
@@ -88,7 +88,7 @@ export default defineComponent<WidgetProps>({
                         granularity: primitiveToQueryString(GRANULARITY.MONTHLY),
                         groupBy: arrayToQueryString([state.groupBy]),
                         period: objectToQueryString(_period),
-                        filters: objectToQueryString(props.filters),
+                        filters: arrayToQueryString(props.filters),
                     },
                 };
             }),

--- a/src/services/cost-explorer/widgets/CostTrendStackedColumnB.vue
+++ b/src/services/cost-explorer/widgets/CostTrendStackedColumnB.vue
@@ -17,6 +17,7 @@
 </template>
 
 <script lang="ts">
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
@@ -66,15 +67,15 @@ export default defineComponent<WidgetProps>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         printMode: {
             type: Boolean,
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             groupBy: computed(() => props.options?.group_by),
             widgetLink: computed(() => {
@@ -89,7 +90,7 @@ export default defineComponent<WidgetProps>({
                         granularity: primitiveToQueryString(GRANULARITY.MONTHLY),
                         groupBy: arrayToQueryString([state.groupBy]),
                         period: objectToQueryString(_period),
-                        filters: objectToQueryString(props.filters),
+                        filters: arrayToQueryString(props.filters),
                     },
                 };
             }),

--- a/src/services/cost-explorer/widgets/LastMonthTotalSpend.vue
+++ b/src/services/cost-explorer/widgets/LastMonthTotalSpend.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-
+import type { SetupContext } from 'vue';
 import {
     onUnmounted, computed, reactive, toRefs, watch, defineComponent,
 } from 'vue';
@@ -43,7 +43,9 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 
 import { gray, violet } from '@/styles/colors';
 
-import { getConvertedFilter } from '@/services/cost-explorer/cost-analysis/lib/helper';
+import {
+    convertFilterItemToQueryStoreFilter,
+} from '@/services/cost-explorer/cost-analysis/lib/helper';
 import { GRANULARITY } from '@/services/cost-explorer/lib/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 import { getXYChartData } from '@/services/cost-explorer/widgets/lib/widget-data-helper';
@@ -87,15 +89,15 @@ export default defineComponent<WidgetProps>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         printMode: {
             type: Boolean,
             default: false,
         },
     },
-    setup(props: WidgetProps, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             chartRef: null as HTMLElement | null,
             chart: null as XYChart | null,
@@ -192,7 +194,7 @@ export default defineComponent<WidgetProps>({
 
         const costQueryHelper = new QueryHelper();
         const fetchData = async () => {
-            costQueryHelper.setFilters(getConvertedFilter(props.filters));
+            costQueryHelper.setFilters(convertFilterItemToQueryStoreFilter(props.filters));
             try {
                 const { results } = await SpaceConnector.client.costAnalysis.cost.analyze({
                     granularity: GRANULARITY.MONTHLY,

--- a/src/services/cost-explorer/widgets/lib/widget-data-helper.ts
+++ b/src/services/cost-explorer/widgets/lib/widget-data-helper.ts
@@ -11,8 +11,10 @@ import { convertUSDToCurrency } from '@/lib/helper/currency-helper';
 
 import { getTimeUnitByPeriod } from '@/services/cost-explorer/cost-analysis/lib/helper';
 import type { WidgetOptions } from '@/services/cost-explorer/cost-dashboard/type';
-import { GRANULARITY, GROUP_BY } from '@/services/cost-explorer/lib/config';
-import type { Period, Granularity, GroupBy } from '@/services/cost-explorer/type';
+import { FILTER, GRANULARITY, GROUP_BY } from '@/services/cost-explorer/lib/config';
+import type {
+    Period, Granularity, GroupBy, CostQueryFilterItem,
+} from '@/services/cost-explorer/type';
 import { DATE_FORMAT } from '@/services/cost-explorer/widgets/lib/config';
 import type {
     ChartData,
@@ -264,11 +266,29 @@ export const getCurrencyAppliedChartData = (
 });
 
 
+/**
+ * @name getTooltipText
+ * @description Get formatted tooltip text for charts.
+ */
 export const getTooltipText = (categoryKey, valueKey, money, disablePercentage = true) => {
     if (disablePercentage) {
         return `{${categoryKey}}: [bold]${money}[/]`;
     }
     return `{${categoryKey}}: [bold]${money}[/] ({${valueKey}.percent.formatNumber('#.00')}%)`;
+};
+
+
+/**
+ * @name getAWSFilters
+ * @description Get filters for aws widgets only.
+ */
+export const getAWSFilters = (filters: CostQueryFilterItem[], productName: string): CostQueryFilterItem[] => {
+    const results = filters.filter(d => d.category !== FILTER.PROVIDER && d.category !== FILTER.PRODUCT);
+    results.concat([
+        { category: FILTER.PROVIDER, value: 'aws' },
+        { category: FILTER.PRODUCT, value: productName },
+    ]);
+    return results;
 };
 
 

--- a/src/services/cost-explorer/widgets/modules/CostDashboardStackedColumnWidget.vue
+++ b/src/services/cost-explorer/widgets/modules/CostDashboardStackedColumnWidget.vue
@@ -59,9 +59,11 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 
 import { gray } from '@/styles/colors';
 
-import { getConvertedFilter } from '@/services/cost-explorer/cost-analysis/lib/helper';
+import {
+    convertFilterItemToQueryStoreFilter,
+} from '@/services/cost-explorer/cost-analysis/lib/helper';
 import { GRANULARITY, GROUP_BY_ITEM_MAP } from '@/services/cost-explorer/lib/config';
-import type { GroupBy, Period } from '@/services/cost-explorer/type';
+import type { CostQueryFilterItem, GroupBy, Period } from '@/services/cost-explorer/type';
 import {
     getCurrencyAppliedChartData, getLegends, getTooltipText, getXYChartData,
 } from '@/services/cost-explorer/widgets/lib/widget-data-helper';
@@ -117,8 +119,8 @@ export default defineComponent<Props>({
             default: () => ({}),
         },
         filters: {
-            type: Object,
-            default: () => ({}),
+            type: Array,
+            default: () => ([]),
         },
         printMode: {
             type: Boolean,
@@ -264,8 +266,8 @@ export default defineComponent<Props>({
 
         /* api */
         const costQueryHelper = new QueryHelper();
-        const listCostAnalysisData = async (period: Period, filters): Promise<CostAnalyzeModel[]> => {
-            costQueryHelper.setFilters(getConvertedFilter(filters));
+        const listCostAnalysisData = async (period: Period, filters: CostQueryFilterItem[]): Promise<CostAnalyzeModel[]> => {
+            costQueryHelper.setFilters(convertFilterItemToQueryStoreFilter(filters));
             try {
                 const start = props.widgetType === 'SHORT' ? dayjs.utc(props.period.end).subtract(SHORT_TYPE_RANGE - 1, 'month') : dayjs.utc(props.period.start);
                 const { results, total_count } = await SpaceConnector.client.costAnalysis.cost.analyze({

--- a/src/services/cost-explorer/widgets/type.ts
+++ b/src/services/cost-explorer/widgets/type.ts
@@ -3,7 +3,7 @@ import type { TranslateResult } from 'vue-i18n';
 import type { Currency } from '@/store/modules/display/config';
 import type { CurrencyRates } from '@/store/modules/display/type';
 
-import type { Period } from '@/services/cost-explorer/type';
+import type { CostQueryFilterItem, Period } from '@/services/cost-explorer/type';
 
 /* widget spec */
 export interface ChartData {
@@ -48,7 +48,7 @@ export interface WidgetProps<Options = any> {
     name?: string;
     options: Options;
     period: Period;
-    filters: Record<string, string[]>;
+    filters: CostQueryFilterItem[];
     currency: Currency;
     currencyRates: CurrencyRates;
     printMode?: boolean;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
cost dashboard의 filters 타입 또한 `object`에서 `object[]`로 모두 바꾸었습니다.
현재 DB에는 대시보드의 default_filters 항목이 `object`로 저장되고 있기 때문에 임시로 빈 array를 넣었습니다. (화요일에 쫑님이 변경해주실 예정)