### PR TITLE
fix(cost-explorer): add `deletable` props to filter tags

### DIFF
--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChart.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChart.vue
@@ -48,6 +48,7 @@
             <div class="filter-wrapper">
                 <cost-explorer-filter-tags :print-mode="printMode"
                                            :filter-items="filters"
+                                           deletable
                                            @update-filter-tags="handleUpdateFilterTags"
                 />
             </div>
@@ -359,6 +360,7 @@ export default {
 
         .filter-wrapper {
             height: 8rem;
+            padding: 0.75rem 1rem;
         }
         .legend-wrapper {
             height: 16.75rem;

--- a/src/services/cost-explorer/modules/CostExplorerFilterTags.vue
+++ b/src/services/cost-explorer/modules/CostExplorerFilterTags.vue
@@ -9,7 +9,7 @@
         </template>
         <template v-else>
             <p-tag v-for="(refinedItem, idx) in refinedFilterItems" :key="`selected-tag-${idx}-${refinedItem.value}`"
-                   :deletable="!printMode"
+                   :deletable="!printMode && deletable"
                    :category-item="categoryItemFormatter(refinedItem)"
                    :key-item="keyItemFormatter(refinedItem)"
                    :value-item="valueItemFormatter(refinedItem)"
@@ -27,6 +27,7 @@ import {
 import {
     PEmpty, PTag,
 } from '@spaceone/design-system';
+import { cloneDeep } from 'lodash';
 
 import { store } from '@/store';
 
@@ -55,6 +56,10 @@ export default defineComponent<Props>({
             type: Array,
             default: () => ([]),
         },
+        deletable: {
+            type: Boolean,
+            default: false,
+        },
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
@@ -82,7 +87,7 @@ export default defineComponent<Props>({
 
         /* Event */
         const handleDeleteFilterTag = (item: RefinedFilterItem) => {
-            const _filters: CostQueryFilterItem[] = [...props.filterItems];
+            const _filters: CostQueryFilterItem[] = cloneDeep(props.filterItems);
             const _index = _filters.findIndex((f) => {
                 if (f.category !== item.category) return false;
                 if (item.key) {
@@ -119,7 +124,6 @@ export default defineComponent<Props>({
 .cost-explorer-filter-tags {
     height: 100%;
     overflow-y: auto;
-    padding: 0.75rem 1rem;
     .p-tag {
         margin-bottom: 0.5rem;
     }

--- a/src/services/cost-explorer/modules/CostExplorerSetFilterModal.vue
+++ b/src/services/cost-explorer/modules/CostExplorerSetFilterModal.vue
@@ -34,6 +34,7 @@
                             {{ $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.SELECTED_FILTER') }} ({{ selectedFilterItems.length }})
                         </div>
                         <cost-explorer-filter-tags :filter-items="selectedFilterItems"
+                                                   deletable
                                                    @update-filter-tags="handleUpdateFilterTags"
                         >
                             <template #no-filter>
@@ -117,7 +118,7 @@ export default defineComponent<Props>({
                 }
             });
             state.unfoldedIndices = _unfoldedIndices;
-            state.selectedFilterItems = [...props.prevFilterItems];
+            state.selectedFilterItems = cloneDeep(props.prevFilterItems);
         };
         const handleFormConfirm = () => {
             emit('confirm', state.selectedFilterItems);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
ViewFilterModal에서는 태그 삭제 버튼을 숨겨야 하기 때문에 `deletable` props를 적용했습니다.