### PR TITLE
feat(cost-analysis-filter-item): add filter in tags and additional-info case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@amcharts/amcharts4": "^4.10.10",
         "@amcharts/amcharts4-geodata": "^4.1.18",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.423",
+        "@spaceone/design-system": "^1.1.0-beta.426",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -3855,9 +3855,9 @@
       "dev": true
     },
     "node_modules/@spaceone/design-system": {
-      "version": "1.1.0-beta.423",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.423.tgz",
-      "integrity": "sha512-RX1H2Q87IH4rQfKQoyVWn2uQy2Fr8QkIi6fYgzQfu47Gp19TNUzIg0DiMsvxV+qqSvsHRlWYyquzia4gWEFP1Q==",
+      "version": "1.1.0-beta.426",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.426.tgz",
+      "integrity": "sha512-WZUp/msqsyycvcUv3M27nAMXXGZIxCp2v3r1qHmeu2wTSenArk5AgS3t0BAqM5DREA8rIYpQkR6lEVEVxRjtfg==",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -39702,9 +39702,9 @@
       "dev": true
     },
     "@spaceone/design-system": {
-      "version": "1.1.0-beta.423",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.423.tgz",
-      "integrity": "sha512-RX1H2Q87IH4rQfKQoyVWn2uQy2Fr8QkIi6fYgzQfu47Gp19TNUzIg0DiMsvxV+qqSvsHRlWYyquzia4gWEFP1Q==",
+      "version": "1.1.0-beta.426",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.426.tgz",
+      "integrity": "sha512-WZUp/msqsyycvcUv3M27nAMXXGZIxCp2v3r1qHmeu2wTSenArk5AgS3t0BAqM5DREA8rIYpQkR6lEVEVxRjtfg==",
       "requires": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -45375,7 +45375,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.423",
+        "@spaceone/design-system": "^1.1.0-beta.426",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -48301,9 +48301,9 @@
           "dev": true
         },
         "@spaceone/design-system": {
-          "version": "1.1.0-beta.423",
-          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.423.tgz",
-          "integrity": "sha512-RX1H2Q87IH4rQfKQoyVWn2uQy2Fr8QkIi6fYgzQfu47Gp19TNUzIg0DiMsvxV+qqSvsHRlWYyquzia4gWEFP1Q==",
+          "version": "1.1.0-beta.426",
+          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.426.tgz",
+          "integrity": "sha512-WZUp/msqsyycvcUv3M27nAMXXGZIxCp2v3r1qHmeu2wTSenArk5AgS3t0BAqM5DREA8rIYpQkR6lEVEVxRjtfg==",
           "requires": {
             "@amcharts/amcharts4": "^4.10.10",
             "@babel/runtime": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@amcharts/amcharts4": "^4.10.10",
     "@amcharts/amcharts4-geodata": "^4.1.18",
     "@gtm-support/vue2-gtm": "^1.3.0",
-    "@spaceone/design-system": "^1.1.0-beta.423",
+    "@spaceone/design-system": "^1.1.0-beta.426",
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-color": "^2.0.0-beta.12",
     "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFilterItem.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFilterItem.vue
@@ -72,6 +72,7 @@ import type { ServiceAccountReferenceMap } from '@/store/modules/reference/servi
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import ProjectSelectDropdown from '@/common/modules/project/ProjectSelectDropdown.vue';
 
+import type { QueryItemResource } from '@/services/cost-explorer/cost-analysis/type';
 import { FILTER } from '@/services/cost-explorer/lib/config';
 
 interface Props {
@@ -124,7 +125,7 @@ export default {
             menuLoading: false,
         });
         const querySearchHandlerState = reactive({
-            querySearchResource: undefined,
+            querySearchResource: undefined as QueryItemResource[] | undefined,
             selectedQueryItems: computed<QueryItem[]>(() => state.proxySelected?.map(d => ({
                 key: {
                     label: d.key,
@@ -194,7 +195,7 @@ export default {
             return { results: results ? results.map(d => ({ name: d.key, label: d.name })) : [] };
         };
 
-        const queryItemFormatter = (data: {name: string; key: string}[], distinct: string) => {
+        const queryItemFormatter = (data: QueryItemResource[], distinct: string) => {
             const result: {name: string; label: string}[] = data.map(item => ({
                 name: item.name || item.key,
                 label: item.name || item.key,

--- a/src/services/cost-explorer/cost-analysis/type.ts
+++ b/src/services/cost-explorer/cost-analysis/type.ts
@@ -21,3 +21,8 @@ export const CHART_TYPE = Object.freeze({
     STACKED_COLUMN: 'STACKED_COLUMN',
     DONUT: 'DONUT',
 });
+
+export interface QueryItemResource {
+    key: string;
+    name: string;
+}


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [ ] `Error / Warning / Lint / Type`

### 작업 내용
- cost analysis filter modal에 `tags`와 `additional-info` 필터가 추가되었습니다.
  (새로 개발된 `p-query-search-dropdown`이 적용되었습니다.)
- `p-query-search-dropdown`은 `tags`와 `additional-info` type의 분기가 적용됩니다.
- `tags`와 `additional-info`에 적용되기 위한 `querySearchHandlerState`가 추가되었습니다.
- `tags`와 `additional-info`의 리소스를 받아오기 위한 api요청이 추가되었습니다.

![image](https://user-images.githubusercontent.com/83635051/196375128-eddc5251-d9ea-4c5c-90aa-3aebe05392c1.png)
