### PR TITLE
fix(asset-inventory): fix permission bug in LNB

### DIFF
--- a/src/services/asset-inventory/AssetInventoryLNB.vue
+++ b/src/services/asset-inventory/AssetInventoryLNB.vue
@@ -70,34 +70,37 @@ export default defineComponent({
                     favoriteType: FAVORITE_TYPE.CLOUD_SERVICE,
                 }
             )), { type: 'divider' }]),
-            menuSet: computed<LNBMenu[]>(() => [
-                (state.isCloudServiceDetailPage ? state.cloudServiceDetailMenuSet : {
+            menuSet: computed<LNBMenu[]>(() => {
+                const menu: LNBMenu[] = (state.isCloudServiceDetailPage ? [] : [{
                     type: 'item',
                     id: MENU_ID.ASSET_INVENTORY_CLOUD_SERVICE,
                     label: i18n.t(MENU_INFO_MAP[MENU_ID.ASSET_INVENTORY_CLOUD_SERVICE].translationId),
                     to: { name: ASSET_INVENTORY_ROUTE.CLOUD_SERVICE._NAME },
-                }),
-                ...filterLNBMenuByPermission([
-                    {
-                        type: 'item',
-                        id: MENU_ID.ASSET_INVENTORY_SERVER,
-                        label: i18n.t(MENU_INFO_MAP[MENU_ID.ASSET_INVENTORY_SERVER].translationId),
-                        to: { name: ASSET_INVENTORY_ROUTE.SERVER._NAME },
-                    },
-                    {
-                        type: 'item',
-                        id: MENU_ID.ASSET_INVENTORY_COLLECTOR,
-                        label: i18n.t(MENU_INFO_MAP[MENU_ID.ASSET_INVENTORY_COLLECTOR].translationId),
-                        to: { name: ASSET_INVENTORY_ROUTE.COLLECTOR._NAME },
-                    },
-                    {
-                        type: 'item',
-                        id: MENU_ID.ASSET_INVENTORY_SERVICE_ACCOUNT,
-                        label: i18n.t(MENU_INFO_MAP[MENU_ID.ASSET_INVENTORY_SERVICE_ACCOUNT].translationId),
-                        to: { name: ASSET_INVENTORY_ROUTE.SERVICE_ACCOUNT._NAME },
-                    },
-                ], store.getters['user/pagePermissionList']),
-            ]),
+                }]);
+                return [
+                    (state.isCloudServiceDetailPage ? state.cloudServiceDetailMenuSet : []),
+                    ...filterLNBMenuByPermission(menu.concat([
+                        {
+                            type: 'item',
+                            id: MENU_ID.ASSET_INVENTORY_SERVER,
+                            label: i18n.t(MENU_INFO_MAP[MENU_ID.ASSET_INVENTORY_SERVER].translationId),
+                            to: { name: ASSET_INVENTORY_ROUTE.SERVER._NAME },
+                        },
+                        {
+                            type: 'item',
+                            id: MENU_ID.ASSET_INVENTORY_COLLECTOR,
+                            label: i18n.t(MENU_INFO_MAP[MENU_ID.ASSET_INVENTORY_COLLECTOR].translationId),
+                            to: { name: ASSET_INVENTORY_ROUTE.COLLECTOR._NAME },
+                        },
+                        {
+                            type: 'item',
+                            id: MENU_ID.ASSET_INVENTORY_SERVICE_ACCOUNT,
+                            label: i18n.t(MENU_INFO_MAP[MENU_ID.ASSET_INVENTORY_SERVICE_ACCOUNT].translationId),
+                            to: { name: ASSET_INVENTORY_ROUTE.SERVICE_ACCOUNT._NAME },
+                        },
+                    ]), store.getters['user/pagePermissionList']),
+                ];
+            }),
         });
 
         const initCloudServiceDetailLNB = async (params: CloudServiceDetailPageParams) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
문제: Role에서 asset inventory -> cloudService에 따로 권한을 주지 않았는데, lnb에서 노출되고 있었음. (lnb컴포넌트에서 권한 체크 함수를 타지 않고있었음)

asset inventory의 LNB에서 menuSet 설정 시, cloudService만 따로 `filterLNBMenuByPermission` 을 타지 않고 computed되고 있었습니다. 
cloudService의 경우 디테일 페이지를 위한 lnb의 추가적인 뎁스가 존재했는데 이 부분에서 누락되었던 것 같습니다.


![image](https://user-images.githubusercontent.com/50662170/196601361-6484d174-c203-4fe9-9c2b-40b8ca98c859.png)

### 생각해볼 문제
