### PR TITLE
fix(cost-anlysis): update `more_group_by` to get api data

### DIFF
--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMoreModal.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilterMoreModal.vue
@@ -155,10 +155,6 @@ export default defineComponent<Props>({
             ]);
         };
 
-        (async () => {
-
-        })();
-
         /* Watcher */
         watch(() => props.visible, (visible) => {
             if (visible) {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
more group by api 데이터 적용
![스크린샷 2022-10-19 오후 7 21 23](https://user-images.githubusercontent.com/18563857/196667607-5e7070d4-f84c-4b21-8580-9165eabc091d.png)

### 생각해볼 문제
보낼 땐 'tags.Name' 으로 보내고, 받을 땐 'tags_Name'으로 옵니다. 이에 따른 대응이 되어 있는데, 다른 분들이 볼 때 이게 뭐지 싶을 것 같아 설명을 추가합니다.

api request는 group_by 항목을 **string[]** 로 보내 dot이 들어가도 괜찮지만,
![스크린샷 2022-10-19 오후 7 38 38](https://user-images.githubusercontent.com/18563857/196669119-209e820f-97c5-4541-a0b6-26c878117715.png)

api response는 **object property**여서 dot을 사용하지 못하여 이런 값이 옵니다.
![스크린샷 2022-10-19 오후 7 36 59](https://user-images.githubusercontent.com/18563857/196668628-39f2af48-70ff-456d-a5b8-1cec6f3f7df2.png)