### PR TITLE
fix(cost-explorer-filter-item): fix dropdown key word break issue

### DIFF
--- a/src/services/cost-explorer/modules/CostExplorerFilterItem.vue
+++ b/src/services/cost-explorer/modules/CostExplorerFilterItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="cost-explorer-filter-item">
         <project-select-dropdown v-if="category === FILTER.PROJECT"
                                  multi-selectable
                                  project-selectable
@@ -22,6 +22,7 @@
         />
         <p-query-search-dropdown
             v-else-if="category === FILTER.TAGS || category === FILTER.ADDITIONAL_INFO"
+            class="query-search-dropdown"
             :key-item-sets="querySearchHandlerState.keyItemSets"
             :value-handler-map="querySearchHandlerState.valueHandlerMap"
             :selected="querySearchHandlerState.selectedQueryItems"
@@ -265,3 +266,14 @@ export default {
     },
 };
 </script>
+
+<style lang="postcss" scoped>
+.cost-explorer-filter-item {
+    /* custom p-query-search-dropdown */
+    :deep(.query-search-dropdown) {
+        .input-wrapper {
+            word-break: initial;
+        }
+    }
+}
+</style>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [ ] `Error / Warning / Lint / Type`

### 작업 내용
- `query-search-dropdown` 이 `collapsible-pannel`의 css를 상속받는 문제 ([QA-310-1](https://pyengine.atlassian.net/jira/software/projects/QA/boards/23?selectedIssue=QA-310))
-  `v-deep`으로 `word-beak` 초기화로 해결하였읍니다

before
<img width="363" alt="스크린샷 2022-10-20 오후 3 03 17" src="https://user-images.githubusercontent.com/83635051/196868444-cc00f4a3-f57b-4ef2-87f8-96c1644b837b.png">

after
<img width="363" alt="스크린샷 2022-10-20 오후 3 03 41" src="https://user-images.githubusercontent.com/83635051/196868502-10a319cd-e68e-4025-86c9-0ff571d46a9b.png">

