### PR TITLE
fix(cloud-service): do not get data when filters are the same in overview detail(QA-300)

### DIFF
--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-usage-overview/CloudServiceUsageOverviewDetailModal.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-usage-overview/CloudServiceUsageOverviewDetailModal.vue
@@ -185,6 +185,14 @@ export default defineComponent<Props>({
             });
         };
 
+        const setFilters = (filters: QueryStoreFilter[]) => {
+            const { filter, keyword } = queryHelper.setFilters(filters).apiQuery;
+
+            state.apiQuery.filter = filter;
+            state.apiQuery.keyword = keyword;
+            state.queryTags = queryHelper.queryTags;
+        };
+
         /* Component Props */
         const fieldHandler: DynamicWidgetFieldHandler<Record<'reference', Reference>> = (field) => {
             if (field.extraData?.reference) {
@@ -217,14 +225,8 @@ export default defineComponent<Props>({
 
             // set filters and get data
             if (!state.dataLoading) state.dataLoading = true;
-
-            const { filter, keyword } = queryHelper.setFilters(filters).apiQuery;
-
-            state.apiQuery.filter = filter;
-            state.apiQuery.keyword = keyword;
-            state.queryTags = queryHelper.queryTags;
+            setFilters(filters);
             await getDataListWithSchema();
-
             state.dataLoading = false;
         }, { immediate: true });
 

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-usage-overview/CloudServiceUsageOverviewDetailModal.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-usage-overview/CloudServiceUsageOverviewDetailModal.vue
@@ -203,22 +203,28 @@ export default defineComponent<Props>({
         /* Watchers */
         watch([() => state.proxyVisible, () => props.schemaList, () => props.filters], async ([visible, schemaList, filters], [, prevSchemaList, prevFilters]) => {
             if (!visible) {
+                // If the schema is the same, do not flush the data.
+                // We can reuse the data if the filters are the same.
                 if (schemaList !== prevSchemaList) state.chartDataList = [];
+
+                // Show users loading UI at the first time.
                 state.dataLoading = true;
                 return;
             }
 
-            if (filters === prevFilters) {
-                return;
-            }
+            // Do not get data if filters are the same with the previous one.
+            if (filters === prevFilters) return;
 
+            // set filters and get data
             if (!state.dataLoading) state.dataLoading = true;
+
             const { filter, keyword } = queryHelper.setFilters(filters).apiQuery;
 
             state.apiQuery.filter = filter;
             state.apiQuery.keyword = keyword;
             state.queryTags = queryHelper.queryTags;
             await getDataListWithSchema();
+
             state.dataLoading = false;
         }, { immediate: true });
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

- [QA-300 [RC1][Cloud Service > Service > Show Charts] 차트 깜빡임](https://pyengine.atlassian.net/browse/QA-300) 이슈 해결
  - 필터도 함께 watch 하여 이전 필터와 같으면 데이터를 다시 불러오지 않게 함으로써 차트 깜빡임 이슈 해결
- 그 밖의 UX 개선
  - 모달을 닫을 때 항상 차트 데이터를 비워주던 것을, 모달이 닫혀있을 때 스키마가 이전 스키마와 다른 경우에 비우도록 변경. 이렇게 함으로써 스키마와 필터가 변경되지 않은 경우에, 데이터를 다시 가져오지 않고 재사용 가능하도록 함.
  - 모달을 닫을 때 loading 상태를 true로 바꿔줌으로써, 모달이 뜰 때 일시적으로 loading UI가 아닌 빈 화면이 보이는 어색함을 해소함.


https://user-images.githubusercontent.com/26986739/196943682-088f8142-fc05-4a4e-9082-e86ef542bd50.mov



### 생각해볼 문제
