### PR TITLE
fix(cloud-service-tags): fix so that only custom tags appear in overlay

### DIFF
--- a/src/common/modules/tags/tags-panel/TagsPanel.vue
+++ b/src/common/modules/tags/tags-panel/TagsPanel.vue
@@ -31,7 +31,7 @@
         <transition name="slide-up">
             <tags-overlay v-if="tagEditPageVisible"
                           :title="overlayTitle"
-                          :tags="isCustomMode ? customTags : tags"
+                          :tags="tags"
                           :resource-id="resourceId"
                           :resource-key="resourceKey" :resource-type="resourceType"
                           :loading="loading"
@@ -101,10 +101,6 @@ export default {
             type: String as PropType<TranslateResult|string|undefined>,
             default: undefined,
         },
-        customTags: {
-            type: Object,
-            default: undefined,
-        },
         customFields: {
             type: Array,
             default: undefined,
@@ -121,7 +117,7 @@ export default {
         const state = reactive({
             loading: true,
             tags: {},
-            isCustomMode: computed<boolean>(() => props.customTags && props.customItems && props.customFields),
+            isCustomMode: computed<boolean>(() => props.customItems && props.customFields),
             fields: computed(() => [
                 { name: 'key', label: i18n.t('COMMON.TAGS.KEY'), type: 'item' },
                 { name: 'value', label: i18n.t('COMMON.TAGS.VALUE'), type: 'item' },
@@ -186,10 +182,8 @@ export default {
 
         watch([() => props.resourceKey, () => props.resourceId, () => props.resourceType],
             async ([resourceKey, resourceId, resourceType]) => {
-                if (resourceKey && resourceId && resourceType && !state.isCustomMode) {
+                if (resourceKey && resourceId && resourceType) {
                     await getTags();
-                } else {
-                    state.loading = false;
                 }
             }, { immediate: true });
 

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue
@@ -7,7 +7,6 @@
                 :overlay-title="$t('INVENTORY.CLOUD_SERVICE.PAGE.CUSTOM_TAGS')"
                 :custom-fields="fields"
                 :custom-items="items"
-                :custom-tags="tags"
                 @tags-updated="handleTagsUpdated"
     >
         <template #table-top>
@@ -88,13 +87,6 @@ export default {
             providers: computed(() => store.getters['reference/provider/fieldItems']?.options),
             selectedTagType: 'all',
             cloudServiceTagList: [],
-            tags: computed(() => {
-                const tagObject = {};
-                (state.cloudServiceTagList ?? []).forEach((tag) => {
-                    tagObject[tag.key] = tag.value;
-                });
-                return tagObject;
-            }),
             fields: computed(() => [
                 { name: 'key', label: i18n.t('COMMON.TAGS.KEY'), type: 'item' },
                 { name: 'value', label: i18n.t('COMMON.TAGS.VALUE'), type: 'item' },


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
custom tags만 수정가능 함으로 수정을 위해 overlay에서도 custom tags만 나타나야합니다.
(기존 managed 태그 까지 나타나 저장시 커스텀 태그로 다시 저장되었습니다.)
![image](https://user-images.githubusercontent.com/50662170/197087628-781fb1ee-e237-4e5c-9341-7507f2f5739d.png)

![image](https://user-images.githubusercontent.com/50662170/197087764-a386ef8a-77a9-4fb3-9470-c272ed59a121.png)
현재 태그 리스트 쪽에서 어떤 필터를 지정하여도 custom tag만 나타나도록 수정하였습니다.

### 생각해볼 문제
