### PR TITLE
fix(cost-analysis): split codes and save `moreGroupBy` to url query

### DIFF
--- a/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
+++ b/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
@@ -36,7 +36,7 @@ import CostAnalysisQueryFilter from '@/services/cost-explorer/cost-analysis/modu
 import type { CostAnalysisPageUrlQuery } from '@/services/cost-explorer/cost-analysis/type';
 import { costExplorerStore } from '@/services/cost-explorer/store';
 import type {
-    CostQuerySetModel, CostQuerySetOption, Granularity, GroupBy,
+    CostQuerySetModel, CostQuerySetOption, Granularity,
 } from '@/services/cost-explorer/type';
 
 
@@ -80,7 +80,8 @@ export default {
             granularity: queryStringToString(urlQuery.granularity) as Granularity,
             stack: queryStringToBoolean(urlQuery.stack),
             group_by: queryStringToArray(urlQuery.groupBy),
-            primary_group_by: queryStringToString(urlQuery.primaryGroupBy) as GroupBy,
+            primary_group_by: queryStringToString(urlQuery.primaryGroupBy) as string,
+            more_group_by: queryStringToArray(urlQuery.moreGroupBy),
             period: queryStringToObject(urlQuery.period),
             filters: queryStringToObject(urlQuery.filters),
         });
@@ -110,6 +111,7 @@ export default {
                     stack: primitiveToQueryString(options.stack),
                     groupBy: arrayToQueryString(options.groupBy),
                     primaryGroupBy: primitiveToQueryString(options.primaryGroupBy),
+                    moreGroupBy: arrayToQueryString(options.moreGroupBy),
                     period: objectToQueryString(options.period),
                     filters: objectToQueryString(options.filters),
                 };

--- a/src/services/cost-explorer/cost-analysis/lib/config.ts
+++ b/src/services/cost-explorer/cost-analysis/lib/config.ts
@@ -5,6 +5,6 @@ export const REQUEST_TYPE = Object.freeze({
 
 export type RequestType = typeof REQUEST_TYPE[keyof typeof REQUEST_TYPE];
 
-export const COST_ANALYSIS_PAGE_URL_QUERY_KEY = ['period', 'groupBy', 'primaryGroupBy', 'filters', 'stack', 'granularity'] as const;
+export const COST_ANALYSIS_PAGE_URL_QUERY_KEY = ['period', 'groupBy', 'primaryGroupBy', 'moreGroupBy', 'filters', 'stack', 'granularity'] as const;
 
 export type CostAnalysisPageUrlQueryKey = typeof COST_ANALYSIS_PAGE_URL_QUERY_KEY[number];

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChartQuerySection.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChartQuerySection.vue
@@ -1,0 +1,329 @@
+<template>
+    <div class="cost-analysis-chart-query-section" :class="{'print-mode': printMode}">
+        <!--filter-->
+        <div class="title-wrapper">
+            <span class="title">{{ $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.FILTER') }}</span>
+            <div v-if="!printMode" class="button-wrapper">
+                <p-button style-type="gray-border"
+                          font-weight="normal" size="sm"
+                          :disabled="!filtersLength"
+                          @click="handleClearAllFilters"
+                >
+                    {{ $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.CLEAR_ALL') }}
+                </p-button>
+                <p-icon-button
+                    name="ic_plus"
+                    style-type="gray900"
+                    size="sm"
+                    @click="handleClickAddFilterButton"
+                />
+            </div>
+        </div>
+        <div class="filter-wrapper">
+            <cost-explorer-filter-tags :print-mode="printMode"
+                                       :filters="filters"
+                                       deletable
+                                       @update-filter-tags="handleUpdateFilterTags"
+            />
+        </div>
+
+        <!--legend-->
+        <div class="title-wrapper">
+            <p-select-dropdown v-if="groupByMenuItems.length"
+                               :items="groupByMenuItems"
+                               :selected="primaryGroupBy"
+                               style-type="transparent"
+                               :read-only="printMode"
+                               @select="handlePrimaryGroupByItem"
+            />
+            <span v-else class="title">Total Cost</span>
+            <div v-if="!printMode" class="button-wrapper">
+                <p-button style-type="gray-border"
+                          size="sm" font-weight="normal"
+                          @click="handleToggleAllLegends"
+                >
+                    {{ showHideAll ? $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.HIDE_ALL') : $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.SHOW_ALL') }}
+                </p-button>
+            </div>
+        </div>
+        <p-data-loader :loading="loading" :data="legends" class="legend-wrapper">
+            <p v-if="legends.length > 15" class="too-many-text">
+                {{ $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.TOO_MANY_ITEMS') }}
+            </p>
+            <div v-for="(legend, idx) in legends" :key="`legend-${legend.name}`"
+                 class="legend"
+                 @click="handleToggleSeries(idx)"
+            >
+                <p-status :text="legend.label"
+                          :icon-color="getLegendIconColor(idx)"
+                          :text-color="getLegendTextColor(idx)"
+                />
+            </div>
+            <template #no-data>
+                {{ $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.NO_ITEMS') }}
+            </template>
+        </p-data-loader>
+        <cost-explorer-set-filter-modal v-if="!printMode"
+                                        :visible.sync="filterModalVisible"
+                                        :prev-selected-filters="filters"
+                                        :categories="CATEGORIES"
+                                        @confirm="handleConfirmFilterModal"
+        />
+    </div>
+</template>
+
+<script lang="ts">
+import type { SetupContext } from 'vue';
+import {
+    computed, defineComponent, reactive, toRefs, watch,
+} from 'vue';
+
+import {
+    PButton, PIconButton, PSelectDropdown, PStatus, PDataLoader,
+} from '@spaceone/design-system';
+import type { SelectDropdownMenu } from '@spaceone/design-system/dist/src/inputs/dropdown/select-dropdown/type';
+import { cloneDeep, sum } from 'lodash';
+
+import { useProxyValue } from '@/common/composables/proxy-state';
+
+import { DEFAULT_CHART_COLORS, DISABLED_LEGEND_COLOR } from '@/styles/colorsets';
+
+import { FILTER, GROUP_BY_ITEM_MAP } from '@/services/cost-explorer/lib/config';
+import CostExplorerFilterTags from '@/services/cost-explorer/modules/CostExplorerFilterTags.vue';
+import CostExplorerSetFilterModal from '@/services/cost-explorer/modules/CostExplorerSetFilterModal.vue';
+import { costExplorerStore } from '@/services/cost-explorer/store';
+import type { CostFiltersMap } from '@/services/cost-explorer/type';
+import type { Legend } from '@/services/cost-explorer/widgets/type';
+
+
+interface Props {
+    printMode: boolean;
+    loading: boolean;
+    legends: Legend[];
+}
+
+const CATEGORIES = Object.values(FILTER);
+
+export default defineComponent<Props>({
+    name: 'CostAnalysisChartQuerySection',
+    components: {
+        CostExplorerFilterTags,
+        CostExplorerSetFilterModal,
+        PSelectDropdown,
+        PIconButton,
+        PDataLoader,
+        PButton,
+        PStatus,
+    },
+    props: {
+        printMode: {
+            type: Boolean,
+            default: false,
+        },
+        loading: {
+            type: Boolean,
+            default: true,
+        },
+        legends: {
+            type: Array,
+            default: () => ([]),
+        },
+    },
+    setup(props, { emit }: SetupContext) {
+        const state = reactive({
+            filters: computed(() => costExplorerStore.state.costAnalysis.filters),
+            groupBy: computed(() => costExplorerStore.state.costAnalysis.groupBy),
+            primaryGroupBy: computed(() => costExplorerStore.state.costAnalysis.primaryGroupBy),
+            moreGroupBy: computed(() => costExplorerStore.state.costAnalysis.moreGroupBy),
+            //
+            filtersLength: computed<number>(() => {
+                const selectedValues = Object.values(state.filters);
+                return sum(selectedValues.map(v => v?.length || 0));
+            }),
+            filterModalVisible: false,
+            //
+            proxyLegends: useProxyValue('legends', props, emit),
+            groupByMenuItems: computed<SelectDropdownMenu[]>(() => {
+                const groupByItems = state.groupBy.map(d => GROUP_BY_ITEM_MAP[d]);
+                const moreGroupByItems = state.moreGroupBy.filter(d => d.selected).map(d => ({
+                    name: `${d.category}.${d.key}`,
+                    label: d.key,
+                }));
+                return [...groupByItems, ...moreGroupByItems];
+            }),
+            showHideAll: computed(() => props.legends.some(legend => !legend.disabled)),
+        });
+
+        /* Util */
+        const getLegendIconColor = (index) => {
+            const legend = props.legends[index];
+            if (legend?.disabled) return DISABLED_LEGEND_COLOR;
+            if (legend?.color) return legend.color;
+            return DEFAULT_CHART_COLORS[index];
+        };
+        const getLegendTextColor = (index) => {
+            const legend = props.legends[index];
+            if (legend?.disabled) return DISABLED_LEGEND_COLOR;
+            return null;
+        };
+
+        /* Event */
+        const handleClearAllFilters = () => {
+            costExplorerStore.commit('costAnalysis/setFilters', {});
+        };
+        const handleClickAddFilterButton = () => {
+            state.filterModalVisible = true;
+        };
+        const handleUpdateFilterTags = (filters: CostFiltersMap) => {
+            costExplorerStore.commit('costAnalysis/setFilters', filters);
+        };
+        const handleToggleSeries = (index) => {
+            const _legends = cloneDeep(props.legends);
+            _legends[index].disabled = !_legends[index]?.disabled;
+            state.proxyLegends = _legends;
+            emit('toggle-series', index);
+        };
+        const handleToggleAllLegends = () => {
+            const _legends = cloneDeep(props.legends);
+            if (state.showHideAll) {
+                _legends.forEach((d) => {
+                    d.disabled = true;
+                });
+                emit('hide-all-series');
+            } else {
+                _legends.forEach((d) => {
+                    d.disabled = false;
+                });
+                emit('show-all-series');
+            }
+            state.proxyLegends = _legends;
+        };
+        const handlePrimaryGroupByItem = (groupBy?: string) => {
+            costExplorerStore.commit('costAnalysis/setPrimaryGroupBy', groupBy);
+        };
+        const handleConfirmFilterModal = (filters) => {
+            costExplorerStore.commit('costAnalysis/setFilters', filters);
+        };
+
+        /* Watcher */
+        watch(() => state.groupByMenuItems, (after) => {
+            if (!after.length) {
+                costExplorerStore.commit('costAnalysis/setPrimaryGroupBy', undefined);
+            } else if (!after.filter(d => d.name === state.primaryGroupBy).length) {
+                costExplorerStore.commit('costAnalysis/setPrimaryGroupBy', after[0].name);
+            }
+        });
+
+        return {
+            ...toRefs(state),
+            CATEGORIES,
+            getLegendIconColor,
+            getLegendTextColor,
+            handleClearAllFilters,
+            handleClickAddFilterButton,
+            handleUpdateFilterTags,
+            handlePrimaryGroupByItem,
+            handleToggleSeries,
+            handleToggleAllLegends,
+            handleConfirmFilterModal,
+        };
+    },
+});
+</script>
+
+<style lang="postcss" scoped>
+.cost-analysis-chart-query-section {
+    @apply col-span-3 bg-white rounded-md border border-gray-200;
+    .title-wrapper {
+        @apply border-b border-gray-200;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        height: 2.5rem;
+        padding: 0.5rem 1rem;
+        .title {
+            font-size: 0.875rem;
+            font-weight: bold;
+        }
+
+        /* custom design-system component - p-select-dropdown */
+        :deep(.p-select-dropdown) {
+            .dropdown-button {
+                font-weight: bold;
+            }
+        }
+        .button-wrapper {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+    }
+    .filter-wrapper {
+        height: 8rem;
+        overflow-y: auto;
+        padding: 0.75rem 1rem;
+        .p-tag {
+            margin-bottom: 0.5rem;
+        }
+    }
+    .legend-wrapper {
+        height: 16.75rem;
+        overflow-y: auto;
+        padding: 0.5rem 0;
+
+        .too-many-text {
+            @apply text-gray-400;
+            font-size: 0.75rem;
+            padding: 0 1rem 0.5rem 1rem;
+        }
+        .legend {
+            height: 25px;
+            display: flex;
+            align-items: center;
+            font-size: 0.875rem;
+            cursor: pointer;
+            padding: 0 1rem;
+
+            &:hover {
+                @apply bg-gray-100;
+            }
+            &.disabled {
+                @apply text-gray-300;
+            }
+
+            /* custom design-system component - p-status */
+            :deep(.p-status) {
+                .text {
+                    white-space: nowrap;
+                }
+            }
+        }
+    }
+
+    @define-mixin row-stack {
+        @apply col-span-12 row-start-1;
+        .legend-wrapper {
+            height: auto;
+            padding: 0.5rem;
+            .legend {
+                display: inline-block;
+                .p-status {
+                    height: 100%;
+                }
+            }
+        }
+    }
+
+    &.print-mode {
+        @mixin row-stack;
+        .title {
+            white-space: nowrap;
+        }
+    }
+    &:not(.print-mode) {
+        @screen tablet {
+            @mixin row-stack;
+        }
+    }
+}
+</style>

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisDataTable.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisDataTable.vue
@@ -386,7 +386,7 @@ export default {
 
         // Link for setting table widths: https://pdfmake.github.io/docs/0.1/document-definition-object/tables/
         const getPrintModeFieldSets = (): PrintModeFieldSet[] => {
-            const groupByLength = state.groupByMenuItems.length;
+            const groupByLength = tableState.groupByFields.length;
             const costFieldLength = tableState.costFields.length;
             const totalLength = costFieldLength + groupByLength;
             const costColumnCount = PRINT_MODE_MAX_COL - groupByLength;

--- a/src/services/cost-explorer/cost-analysis/type.ts
+++ b/src/services/cost-explorer/cost-analysis/type.ts
@@ -2,7 +2,7 @@ import type { RouteQueryString } from '@/lib/router-query-string';
 
 import type { CostAnalysisPageUrlQueryKey } from '@/services/cost-explorer/cost-analysis/lib/config';
 import type {
-    Period, Granularity, GroupBy, CostFiltersMap,
+    Period, Granularity, GroupBy, CostFiltersMap, MoreGroupByItem,
 } from '@/services/cost-explorer/type';
 
 
@@ -11,7 +11,8 @@ export type CostAnalysisPageUrlQuery = Partial<Record<CostAnalysisPageUrlQueryKe
 export interface CostAnalysisPageQueryValue {
     period?: Period;
     groupBy?: GroupBy[];
-    primaryGroupBy?: GroupBy;
+    primaryGroupBy?: GroupBy | string;
+    moreGroupBy?: MoreGroupByItem[];
     filters?: CostFiltersMap;
     stack?: boolean;
     granularity?: Granularity;

--- a/src/services/cost-explorer/store/cost-analysis/actions.ts
+++ b/src/services/cost-explorer/store/cost-analysis/actions.ts
@@ -26,10 +26,8 @@ export const initCostAnalysisStoreState: Action<CostAnalysisStoreState, any> = (
 export const setQueryOptions: Action<CostAnalysisStoreState, any> = ({ commit }, options: Partial<CostQuerySetOption>): void => {
     if (options.granularity) commit('setGranularity', options.granularity);
     if (typeof options.stack === 'boolean') commit('setStack', options.stack);
-    if (options.group_by?.length) {
-        commit('setGroupBy', options.group_by);
-        commit('setPrimaryGroupBy', options.primary_group_by);
-    } else commit('setPrimaryGroupBy', undefined);
+    if (options.group_by?.length) commit('setGroupBy', options.group_by);
+    if (options.primary_group_by) commit('setPrimaryGroupBy', options.primary_group_by);
     if (options.more_group_by?.length) commit('setMoreGroupBy', options.more_group_by);
     if (options.period) commit('setPeriod', { start: options.period.start, end: options.period.end });
     if (options.filters) {
@@ -62,7 +60,7 @@ export const saveQuery: Action<CostAnalysisStoreState, any> = async ({ state, co
             stack,
             period,
             group_by: groupBy,
-            primary_group_by: groupBy?.length ? (primaryGroupBy || groupBy[0]) : undefined,
+            primary_group_by: primaryGroupBy,
             more_group_by: moreGroupBy,
             filters,
         };

--- a/src/services/cost-explorer/store/cost-analysis/getters.ts
+++ b/src/services/cost-explorer/store/cost-analysis/getters.ts
@@ -15,14 +15,15 @@ export const selectedQuerySet: Getter<CostAnalysisStoreState, any> = ({ selected
     return costQueryList.find(item => item.cost_query_set_id === selectedQueryId);
 };
 
-type QuerySetOptions = Pick<CostAnalysisStoreState, 'stack'|'granularity'|'groupBy'|'primaryGroupBy'|'period'|'filters'>;
+type QuerySetOptions = Pick<CostAnalysisStoreState, 'stack'|'granularity'|'groupBy'|'primaryGroupBy'|'moreGroupBy'|'period'|'filters'>;
 export const currentQuerySetOptions: Getter<CostAnalysisStoreState, any> = ({
-    stack, granularity, groupBy, primaryGroupBy, period, filters,
+    stack, granularity, groupBy, primaryGroupBy, moreGroupBy, period, filters,
 }): QuerySetOptions => ({
     stack,
     granularity,
     groupBy,
     primaryGroupBy,
+    moreGroupBy,
     period,
     filters,
 });

--- a/src/services/cost-explorer/store/cost-analysis/mutations.ts
+++ b/src/services/cost-explorer/store/cost-analysis/mutations.ts
@@ -21,7 +21,7 @@ export const setGroupBy: Mutation<CostAnalysisStoreState> = (state, groupBy: Gro
     state.groupBy = groupBy;
 };
 
-export const setPrimaryGroupBy: Mutation<CostAnalysisStoreState> = (state, primaryGroupBy?: GroupBy) => {
+export const setPrimaryGroupBy: Mutation<CostAnalysisStoreState> = (state, primaryGroupBy?: GroupBy | string) => {
     state.primaryGroupBy = primaryGroupBy;
 };
 

--- a/src/services/cost-explorer/store/cost-analysis/type.ts
+++ b/src/services/cost-explorer/store/cost-analysis/type.ts
@@ -11,7 +11,7 @@ export interface CostAnalysisStoreState {
     granularity: Granularity;
     stack: boolean;
     groupBy: GroupBy[];
-    primaryGroupBy?: GroupBy;
+    primaryGroupBy?: GroupBy | string;
     moreGroupBy: MoreGroupByItem[];
     period: Period;
     filters: CostFiltersMap;

--- a/src/services/cost-explorer/type.ts
+++ b/src/services/cost-explorer/type.ts
@@ -22,7 +22,7 @@ export type CostFiltersMap = Record<Filter, FilterItem[]>;
 
 export interface CostQuerySetOption {
     group_by?: GroupBy[];
-    primary_group_by?: GroupBy;
+    primary_group_by?: GroupBy | string;
     more_group_by: MoreGroupByItem[];
     granularity: Granularity;
     stack?: boolean;

--- a/src/services/cost-explorer/widgets/lib/widget-data-helper.ts
+++ b/src/services/cost-explorer/widgets/lib/widget-data-helper.ts
@@ -47,7 +47,7 @@ const _mergePrevChartDataAndCurrChartData = (prevData: ChartData, currData?: Cha
  * @description Extract legends from raw data.
  * @usage CostAnalysisChart, CostTrendByProduct|CostTrendByProject|CostTrendByProvider, SpcProjectWiseUsageSummary
  */
-export const getLegends = (rawData: CostAnalyzeModel[], granularity: Granularity, groupBy?: GroupBy): Legend[] => {
+export const getLegends = (rawData: CostAnalyzeModel[], granularity: Granularity, groupBy?: GroupBy | string): Legend[] => {
     if (groupBy) {
         let _groupBy: string = groupBy;
         // Parsing to match api data (ex. tags.Name -> tags_Name)
@@ -113,7 +113,7 @@ export const getLegends = (rawData: CostAnalyzeModel[], granularity: Granularity
  * @usage AWSCloudFrontCost
  * @example ('project-111111', 'project_id') => 'SpaceOne Dev Project'
  */
-export const getReferenceLabel = (data: string, groupBy: GroupBy): string => {
+export const getReferenceLabel = (data: string, groupBy: GroupBy | string): string => {
     if (!data) return 'Unknown';
     const _providers = store.getters['reference/providerItems'];
     const _serviceAccounts = store.getters['reference/serviceAccountItems'];
@@ -136,7 +136,7 @@ export const getReferenceLabel = (data: string, groupBy: GroupBy): string => {
  *       => [{ category: 'aws', value: 100 }, { category: 'azure', value: 30 }]
  * @usage SpcProjectWiseUsageSummary, CostAnalysisChart
  */
-export const getPieChartData = (rawData: CostAnalyzeModel[], groupBy?: GroupBy): PieChartData[] => {
+export const getPieChartData = (rawData: CostAnalyzeModel[], groupBy?: GroupBy | string): PieChartData[] => {
     let chartData: PieChartData[] = [];
     if (groupBy) {
         let _groupBy: string = groupBy;
@@ -193,7 +193,7 @@ export const getPieChartData = (rawData: CostAnalyzeModel[], groupBy?: GroupBy):
  * @usage CostAnalysisChart, CostTrendByProduct|CostTrendByProject|CostTrendByProvider, SpcProjectWiseUsageSummary, LastMonthTotalSpend, BudgetSummaryChart
  */
 export const getXYChartData = (
-    rawData: CostAnalyzeModel[], granularity: Granularity, period: Period, groupBy?: GroupBy, valueKey = 'usd_cost',
+    rawData: CostAnalyzeModel[], granularity: Granularity, period: Period, groupBy?: GroupBy | string, valueKey = 'usd_cost',
 ): XYChartData[] => {
     const chartData: XYChartData[] = [];
     const timeUnit = getTimeUnitByPeriod(granularity, dayjs.utc(period.start), dayjs.utc(period.end));


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- CostAnalysisChart에서 filter, legend 부분 모듈로 분리
  ![스크린샷 2022-10-21 오전 10 23 37](https://user-images.githubusercontent.com/18563857/197089532-ed9c7d87-01c2-4920-8ad7-148887638f69.png)
- 이번에 새로 추가된 `moreGroupBy`가 url query에 저장되도록 함

> 커밋 별로 보시는 것을 추천합니다. 그리고 첫번째 커밋은 안 보셔도 됨다. 그냥 코드분리라서.