### PR TITLE
fix(cloud-service-tags-panel): add filtered custom tags to Tags panel

### DIFF
--- a/src/common/modules/tags/tags-panel/TagsPanel.vue
+++ b/src/common/modules/tags/tags-panel/TagsPanel.vue
@@ -31,7 +31,7 @@
         <transition name="slide-up">
             <tags-overlay v-if="tagEditPageVisible"
                           :title="overlayTitle"
-                          :tags="tags"
+                          :tags="isCustomMode ? customTags : tags"
                           :resource-id="resourceId"
                           :resource-key="resourceKey" :resource-type="resourceType"
                           :loading="loading"
@@ -109,6 +109,10 @@ export default {
             type: Array,
             default: undefined,
         },
+        customTags: {
+            type: Object,
+            default: undefined,
+        },
     },
     setup(props, { emit }: SetupContext) {
         const apiKeys = computed(() => props.resourceType.split('.').map(d => camelCase(d)));
@@ -182,8 +186,10 @@ export default {
 
         watch([() => props.resourceKey, () => props.resourceId, () => props.resourceType],
             async ([resourceKey, resourceId, resourceType]) => {
-                if (resourceKey && resourceId && resourceType) {
+                if (resourceKey && resourceId && resourceType && !state.isCustomMode) {
                     await getTags();
+                } else {
+                    state.loading = false;
                 }
             }, { immediate: true });
 

--- a/src/common/modules/tags/tags-panel/TagsPanel.vue
+++ b/src/common/modules/tags/tags-panel/TagsPanel.vue
@@ -62,6 +62,7 @@ import { i18n } from '@/translations';
 
 import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 
+import type { Tag } from '@/common/components/forms/tags-input-group/type';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import TagsOverlay from '@/common/modules/tags/tags-panel/modules/TagsOverlay.vue';
 
@@ -110,7 +111,7 @@ export default {
             default: undefined,
         },
         customTags: {
-            type: Object,
+            type: Object as PropType<Tag>,
             default: undefined,
         },
     },

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue
@@ -52,6 +52,7 @@ import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
+import type { Tag } from '@/common/components/forms/tags-input-group/type';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import TagsPanel from '@/common/modules/tags/tags-panel/TagsPanel.vue';
 
@@ -104,7 +105,7 @@ export default {
                 type: k.type,
                 provider: k.provider,
             }))),
-            customTags: computed(() => {
+            customTags: computed<Tag>(() => {
                 const tagObject = {};
                 (state.cloudServiceTagList ?? []).forEach((tag) => {
                     if (tag.type === CLOUD_SERVICE_TAG_TYPE.CUSTOM) {

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue
@@ -7,6 +7,7 @@
                 :overlay-title="$t('INVENTORY.CLOUD_SERVICE.PAGE.CUSTOM_TAGS')"
                 :custom-fields="fields"
                 :custom-items="items"
+                :custom-tags="customTags"
                 @tags-updated="handleTagsUpdated"
     >
         <template #table-top>
@@ -103,6 +104,15 @@ export default {
                 type: k.type,
                 provider: k.provider,
             }))),
+            customTags: computed(() => {
+                const tagObject = {};
+                (state.cloudServiceTagList ?? []).forEach((tag) => {
+                    if (tag.type === CLOUD_SERVICE_TAG_TYPE.CUSTOM) {
+                        tagObject[tag.key] = tag.value;
+                    }
+                });
+                return tagObject;
+            }),
         });
         /* event handler */
         const handleSelectTagType = (tagType) => { state.selectedTagType = tagType; };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
어째서인지.. 오전엔 tagPanel에서 custom tag만 불러오는걸로 확인한 api 가 managed까지 불러와 직접 필터하는 로직을 추가하였습니다.
### 생각해볼 문제
