### PR TITLE
feat(widget-frame): create widgetFrame (only markup)

### DIFF
--- a/src/common/components/widgets/modules/WidgetFrame.vue
+++ b/src/common/components/widgets/modules/WidgetFrame.vue
@@ -4,15 +4,15 @@
              [size]: true,
          }"
     >
-        <header>
+        <div class="widget-header">
             <h3 class="title">
                 {{ title }}
             </h3> <slot name="header-right" />
-        </header>
+        </div>
         <div class="body">
             <slot />
         </div>
-        <footer>
+        <div class="widget-footer">
             <div class="footer-left">
                 <p-datetime-picker style-type="text" select-mode="range" :selected-dates.sync="selectedDates" />
                 <p-divider :vertical="true" />
@@ -28,13 +28,13 @@
                     </router-link>
                 </slot>
             </div>
-        </footer>
+        </div>
     </div>
 </template>
 
 <script lang="ts">
-import type { SetupContext } from 'vue';
-import { reactive, toRefs } from 'vue';
+import type { PropType, SetupContext } from 'vue';
+import { reactive, toRefs, defineComponent } from 'vue';
 
 import { PDatetimePicker, PDivider, PI } from '@spaceone/design-system';
 import { CARD_SIZE } from '@spaceone/design-system/src/data-display/cards/card/config';
@@ -43,7 +43,7 @@ import { useProxyValue } from '@/common/composables/proxy-state';
 
 import CurrencySelectDropdown from '@/services/cost-explorer/modules/CurrencySelectDropdown.vue';
 
-export default {
+export default defineComponent({
     name: 'WidgetFrame',
     components: {
         CurrencySelectDropdown,
@@ -57,11 +57,8 @@ export default {
             default: 'Title',
         },
         size: {
-            type: String,
+            type: String as PropType<CARD_SIZE>,
             default: CARD_SIZE.md,
-            validator(size: any) {
-                return Object.values(CARD_SIZE).includes(size);
-            },
         },
         widgetLink: {
             type: [Object, String],
@@ -85,7 +82,7 @@ export default {
             ...toRefs(state),
         };
     },
-};
+});
 </script>
 
 <style lang="postcss" scoped>
@@ -97,12 +94,12 @@ export default {
 }
 
 .widget-frame {
+    @apply border rounded-lg bg-white;
     border-color: theme('colors.gray.200');
     display: inline-flex;
     flex-direction: column;
 
-    @apply border rounded-lg bg-white;
-    header {
+    .widget-header {
         @apply flex justify-between items-center;
         .title {
             font-size: 1rem;
@@ -120,7 +117,7 @@ export default {
         flex-grow: 1;
         flex-shrink: 1;
     }
-    footer {
+    .widget-footer {
         @apply border-t rounded-b-lg flex justify-between items-center;
         padding: 0 1rem;
         flex: 0 0;
@@ -134,7 +131,7 @@ export default {
         }
         .footer-right {
             .anchor-button {
-                @apply flex items-center flex-shrink-0 text-sm text-blue-700 font-normal cursor-pointer;
+                @apply flex items-center flex-shrink-0 text-blue-700 font-normal cursor-pointer;
                 font-size: 0.75rem;
                 line-height: 150%;
                 margin-top: 0.1rem;

--- a/src/common/components/widgets/modules/WidgetFrame.vue
+++ b/src/common/components/widgets/modules/WidgetFrame.vue
@@ -1,0 +1,157 @@
+<template>
+    <div class="widget-frame"
+         :class="{
+             [size]: true,
+         }"
+    >
+        <header>
+            <h3 class="title">
+                {{ title }}
+            </h3> <slot name="header-right" />
+        </header>
+        <div class="body">
+            <slot />
+        </div>
+        <footer>
+            <div class="footer-left">
+                <p-datetime-picker style-type="text" select-mode="range" :selected-dates.sync="selectedDates" />
+                <p-divider :vertical="true" />
+                <currency-select-dropdown />
+            </div>
+            <div class="footer-right">
+                <slot name="footer-right">
+                    <router-link v-if="widgetLink && !printMode" :to="widgetLink" class="anchor-button">
+                        {{ $t('BILLING.COST_MANAGEMENT.DASHBOARD.FULL_DATA') }}
+                        <p-i name="ic_arrow_right" width="1rem" height="1rem"
+                             color="inherit transparent"
+                        />
+                    </router-link>
+                </slot>
+            </div>
+        </footer>
+    </div>
+</template>
+
+<script lang="ts">
+import type { SetupContext } from 'vue';
+import { reactive, toRefs } from 'vue';
+
+import { PDatetimePicker, PDivider, PI } from '@spaceone/design-system';
+import { CARD_SIZE } from '@spaceone/design-system/src/data-display/cards/card/config';
+
+import { useProxyValue } from '@/common/composables/proxy-state';
+
+import CurrencySelectDropdown from '@/services/cost-explorer/modules/CurrencySelectDropdown.vue';
+
+export default {
+    name: 'WidgetFrame',
+    components: {
+        CurrencySelectDropdown,
+        PDatetimePicker,
+        PDivider,
+        PI,
+    },
+    props: {
+        title: {
+            type: String,
+            default: 'Title',
+        },
+        size: {
+            type: String,
+            default: CARD_SIZE.md,
+            validator(size: any) {
+                return Object.values(CARD_SIZE).includes(size);
+            },
+        },
+        widgetLink: {
+            type: [Object, String],
+            default: undefined,
+        },
+        noData: {
+            type: Boolean,
+            default: false,
+        },
+        printMode: {
+            type: Boolean,
+            default: false,
+        },
+        // currency
+    },
+    setup(props, { emit }:SetupContext) {
+        const state = reactive({
+            selectedDates: useProxyValue('selectedDates', props, emit),
+        });
+        return {
+            ...toRefs(state),
+        };
+    },
+};
+</script>
+
+<style lang="postcss" scoped>
+@define-mixin widget-size $widget-width {
+    & {
+        height: 29rem;
+        width: $widget-width;
+    }
+}
+
+.widget-frame {
+    border-color: theme('colors.gray.200');
+    display: inline-flex;
+    flex-direction: column;
+
+    @apply border rounded-lg bg-white;
+    header {
+        @apply flex justify-between items-center;
+        .title {
+            font-size: 1rem;
+            font-weight: 700;
+            color: theme('colors.gray.900');
+            line-height: 1.25;
+            margin: 0.25rem 0;
+        }
+        padding: 0.75rem 1.5rem 1rem 1.5rem;
+        border-color: inherit;
+        flex: 0 0;
+    }
+    .body {
+        height: auto;
+        flex-grow: 1;
+        flex-shrink: 1;
+    }
+    footer {
+        @apply border-t rounded-b-lg flex justify-between items-center;
+        padding: 0 1rem;
+        flex: 0 0;
+        .footer-left {
+            @apply flex items-center gap-2;
+            .p-divider {
+                &.vertical {
+                    height: 1rem;
+                }
+            }
+        }
+        .footer-right {
+            .anchor-button {
+                @apply flex items-center flex-shrink-0 text-sm text-blue-700 font-normal cursor-pointer;
+                font-size: 0.75rem;
+                line-height: 150%;
+                margin-top: 0.1rem;
+                &:hover {
+                    @apply text-secondary underline;
+                }
+            }
+        }
+    }
+    &.sm {
+        @mixin widget-size 24rem;
+    }
+    &.md {
+        @mixin widget-size 34.625rem;
+    }
+    &.lg {
+        @mixin widget-size 44rem;
+    }
+}
+</style>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
Widget Frame의 마크업위주의 작업입니다.

![image](https://user-images.githubusercontent.com/50662170/199197516-018d7754-015a-4ba9-9eb9-0ff720a2d8ef.png)

디자인 시스템의 PCard를 사용하지 않고 직접 작성하였습니다.
- header: header right 슬롯이 존재합니다. 아직 디자인 작업 진행중이라 슬롯이 아닌 selectButton(ds 없는 기능으로 추가되어야 함)으로 대체될 수 있습니다. 
- body: 위젯의 **차트**와 **테이블**이 추가 될 **default슬롯**입니다.
- footer: 위젯의 필터입니다. 
    - 오늘 회의하시는거 조금 들었는데, 아마 goupby같은 필터가 추가될 수 있다고 합니다.
    - date는 type이 range로 되어있습니다. (혹시 다른 타입 커스텀이 필요하다면 props를 뚫겠습니다)
    - footer-right 슬롯이 존재합니다.

### 생각해볼 문제
