### PR TITLE
refactor(core-lib): separate token api and service api

### DIFF
--- a/packages/cloudforet/core-lib/src/space-connector/service-api.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/service-api.ts
@@ -1,0 +1,71 @@
+import type {
+    AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse,
+} from 'axios';
+import axios from 'axios';
+
+import {
+    APIError, AuthenticationError,
+    AuthorizationError, BadRequestError,
+    NotFoundError,
+} from '@/space-connector/error';
+import type TokenAPI from '@/space-connector/token-api';
+
+export default class ServiceAPI {
+    instance: AxiosInstance;
+
+    tokenApi: TokenAPI;
+
+
+    constructor(baseURL: string, tokenApi: TokenAPI) {
+        this.instance = axios.create({
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            baseURL,
+        });
+        this.tokenApi = tokenApi;
+        tokenApi.loadToken();
+        this.setAxiosInterceptors();
+    }
+
+
+    private handleRequestError = async (error: AxiosError): Promise<void> => {
+        switch (error.response?.status) {
+        case 400: {
+            throw new BadRequestError(error);
+        }
+        case 401: {
+            const res = await this.tokenApi.refreshAccessToken();
+            if (!res) throw new AuthenticationError(error);
+            else break;
+        }
+        case 403: {
+            throw new AuthorizationError(error);
+        }
+        case 404: {
+            throw new NotFoundError(error);
+        }
+        default: {
+            throw new APIError(error);
+        }
+        }
+    };
+
+    private setAxiosInterceptors(): void {
+        // Axios request interceptor
+        this.instance.interceptors.request.use((request: AxiosRequestConfig) => {
+            if (!request.headers) request.headers = {};
+
+            // Set the access token
+            request.headers.Authorization = `Bearer ${this.tokenApi.getAccessToken()}`;
+
+            return request;
+        });
+
+        // Axios's response interceptor with error handling
+        this.instance.interceptors.response.use(
+            (response: AxiosResponse) => response,
+            this.handleRequestError,
+        );
+    }
+}


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

console api endpoint가 2개로 나뉘어 관리되어야 하는데, 토큰은 하나로 관리되어야 해서 
service-api와  token-api를 분리함.
이후에 따라올 작업을 위한 리팩토링.

### 생각해볼 문제
