### PR TITLE
fix(provider-list): solve scroll issue where there is no need for scroll

### DIFF
--- a/src/services/asset-inventory/service-account/modules/ServiceAccountProviderList.vue
+++ b/src/services/asset-inventory/service-account/modules/ServiceAccountProviderList.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     @apply grid w-full gap-2;
     grid-template-columns: repeat(6, minmax(10rem, auto));
     padding-bottom: 1rem;
-    overflow-x: scroll;
+    overflow-x: auto;
     .provider-button {
         @apply flex items-center border rounded-lg border-gray-200 bg-white;
         min-width: 10rem;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [ ] `Error / Warning / Lint / Type`

### 작업 내용
- service account 페이지의 provider list에서 하단에 스크롤이 없을 때 스크롤이 생기는 이슈를 해결했습니다
- `overflow-x: scroll` => `overflow-x: auto`