### PR TITLE
feat(widget): configure Widget Default Components

### DIFF
--- a/src/common/components/widgets/modules/WidgetDataTable.vue
+++ b/src/common/components/widgets/modules/WidgetDataTable.vue
@@ -1,0 +1,316 @@
+<template>
+    <div class="widget-data-table" :class="{'print-mode': printMode}">
+        <p-data-table :fields="items.length ? fields : []"
+                      :items="slicedItems"
+                      :total-count="totalCount"
+                      :loading="loading"
+                      :row-height-fixed="!printMode"
+                      table-style-type="simple"
+                      disable-hover
+        >
+            <template v-for="field in fields" #[`th-${field.name}-format`]>
+                <div :key="field.name" class="tooltip-container">
+                    <span>{{ field.label }}</span>
+                    <p-i v-if="field.tooltipText" v-tooltip.bottom="field.tooltipText"
+                         name="ic_tooltip" width="0.875rem" height="0.875rem"
+                    />
+                </div>
+            </template>
+            <template #col-format="{field: { name, type }, value, index, colIndex}">
+                <div class="status-wrapper" :class="{legend: showLegend && colIndex === 0}">
+                    <template v-if="fields[0].name === name && showIndex">
+                        <p-status v-if="showLegend"
+                                  class="toggle-button"
+                                  :text="(getConvertedIndex(index) + 1)?.toString()"
+                                  :icon-color="getLegendIconColor(index)"
+                                  :text-color="getLegendTextColor(index)"
+                                  @click="handleClickLegend(index)"
+                        />
+                        <slot :name="`${name}-format`" v-bind="{ value }">
+                            <span class="name" :style="{ color: labelColorFormatter(index) }">
+                                {{ labelTextFormatter(index) }}
+                            </span>
+                        </slot>
+                    </template>
+                    <template v-else-if="typeof value === 'string'">
+                        {{ value }}
+                    </template>
+                    <template v-else-if="typeof value === 'number'">
+                        <template v-if="type === 'size'">
+                            {{ byteFormatter(value) }}
+                        </template>
+                        <template v-else-if="type === 'number'">
+                            {{ numberFormatter(value) }}
+                        </template>
+                        <template v-else>
+                            {{ CURRENCY_SYMBOL[currency] }}{{ currencyMoneyFormatter(value, currency, currencyRates, true) }}
+                        </template>
+                    </template>
+                    <template v-else>
+                        --
+                    </template>
+                    <!--                    <template v-else>-->
+                    <!--                        <span v-if="value.isRaised" :class="{raised: value.isRaised}">-->
+                    <!--                            <span>{{ value.value }}</span>-->
+                    <!--                            <p-i name="ic_bold-arrow-up" width="0.75rem" />-->
+                    <!--                        </span>-->
+                    <!--                        <span>{{ value.value }}</span>-->
+                    <!--                    </template>-->
+                </div>
+            </template>
+        </p-data-table>
+        <div v-if="paginationVisible" class="table-pagination-wrapper">
+            <p-text-pagination :all-page="allPage"
+                               :this-page.sync="proxyThisPage"
+            />
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+
+import {
+    computed, reactive, toRefs,
+} from 'vue';
+import type { PropType } from 'vue';
+
+import {
+    PDataTable, PTextPagination, PStatus, PI,
+} from '@spaceone/design-system';
+import type { DataTableFieldType } from '@spaceone/design-system/dist/src/data-display/tables/data-table/type';
+
+import { byteFormatter, numberFormatter } from '@cloudforet/core-lib';
+
+import { CURRENCY, CURRENCY_SYMBOL } from '@/store/modules/display/config';
+
+import { currencyMoneyFormatter } from '@/lib/helper/currency-helper';
+
+import { useProxyValue } from '@/common/composables/proxy-state';
+
+import { DEFAULT_CHART_COLORS, DISABLED_LEGEND_COLOR } from '@/styles/colorsets';
+
+import { GROUP_BY } from '@/services/cost-explorer/lib/config';
+
+
+interface Field extends DataTableFieldType {
+    type?: 'cost'|'size'|'number';
+}
+export default {
+    name: 'WidgetDataTable',
+    components: {
+        PDataTable,
+        PTextPagination,
+        PStatus,
+        PI,
+    },
+    props: {
+        loading: {
+            type: Boolean,
+            default: false,
+        },
+        fields: {
+            type: Array as PropType<Field[]>,
+            default: () => ([]),
+        },
+        items: {
+            type: Array,
+            default: () => ([]),
+        },
+        thisPage: {
+            type: Number,
+            default: 1,
+        },
+        pageSize: {
+            type: Number,
+            default: 5,
+        },
+        showIndex: {
+            type: Boolean,
+            default: true,
+        },
+        showLegend: {
+            type: Boolean,
+            default: false,
+        },
+        legends: {
+            type: Array,
+            default: undefined,
+        },
+        currency: {
+            type: String,
+            default: CURRENCY.USD,
+        },
+        currencyRates: {
+            type: Object,
+            default: () => ({}),
+        },
+        // showSharpRises: {
+        //     type: Boolean,
+        //     default: false,
+        // },
+        paginationVisible: {
+            type: Boolean,
+            default: true,
+        },
+        printMode: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    setup(props, { emit }) {
+        const state = reactive({
+            slicedItems: computed(() => {
+                if (props.printMode) return props.items;
+                const startIndex = state.proxyThisPage * props.pageSize - props.pageSize;
+                const endIndex = state.proxyThisPage * props.pageSize;
+                return props.items.slice(startIndex, endIndex);
+            }),
+            totalCount: computed(() => props.items.length),
+            allPage: computed(() => Math.ceil(state.totalCount / props.pageSize) || 1),
+            proxyThisPage: useProxyValue('thisPage', props, emit),
+        });
+
+        /* util */
+        const getConvertedIndex = index => index + ((state.proxyThisPage - 1) * props.pageSize);
+        const labelColorFormatter = index => ((props.legends && props.legends[getConvertedIndex(index)]) ? props.legends[getConvertedIndex(index)].color : 'text-gray-900');
+        const labelTextFormatter = index => ((props.legends && props.legends[getConvertedIndex(index)]) ? props.legends[getConvertedIndex(index)].label : '');
+        const getIndexNumber = (index) => {
+            const tableIndex = index + ((state.proxyThisPage - 1) * props.pageSize) + 1;
+            return tableIndex?.toString();
+        };
+        const getLegendIconColor = (index) => {
+            const legend = props.legends[getConvertedIndex(index)];
+            if (legend?.disabled) return DISABLED_LEGEND_COLOR;
+            if (legend?.color) return legend.color;
+            return DEFAULT_CHART_COLORS[getConvertedIndex(index)];
+        };
+        const getLegendTextColor = (index) => {
+            const legend = props.legends[getConvertedIndex(index)];
+            if (legend?.disabled) return DISABLED_LEGEND_COLOR;
+            return null;
+        };
+        // const getConvertedItems = (items) => {
+        //     const convertedItems: Item[] = [];
+        //     items.forEach((item) => {
+        //         const convertedItem: Item = {};
+        //         Object.entries(item).forEach(([k, v]) => {
+        //             const date = dayjs.utc(k);
+        //             if (date.isValid()) {
+        //                 const pastDate = date.subtract(1, 'month').format('YYYY-MM');
+        //                 const pastValue = item[pastDate] || undefined;
+        //                 let isRaised = false;
+        //                 const value: number = v as number;
+        //                 if (value && pastValue && pastValue * 1.5 < value) {
+        //                     isRaised = true;
+        //                 }
+        //                 convertedItem[k] = {
+        //                     value: commaFormatter(numberFormatter(value)),
+        //                     isRaised,
+        //                 };
+        //             } else {
+        //                 convertedItem[k] = {
+        //                     value: v,
+        //                 };
+        //             }
+        //         });
+        //         convertedItems.push(convertedItem);
+        //     });
+        //     return convertedItems;
+        // };
+
+        /* event */
+        const handleClickLegend = (index) => {
+            if (props.printMode) return;
+            emit('toggle-legend', index);
+        };
+
+        // watch([() => props.showSharpRises, () => props.items], ([showSharpRises, items]) => {
+        //     if (showSharpRises && items.length) {
+        //         state.convertedItems = getConvertedItems(items);
+        //     }
+        // }, { immediate: true });
+
+        return {
+            ...toRefs(state),
+            GROUP_BY,
+            getIndexNumber,
+            getConvertedIndex,
+            getLegendIconColor,
+            getLegendTextColor,
+            handleClickLegend,
+            labelColorFormatter,
+            labelTextFormatter,
+            currencyMoneyFormatter,
+            byteFormatter,
+            numberFormatter,
+            CURRENCY_SYMBOL,
+        };
+    },
+};
+</script>
+
+<style lang="postcss" scoped>
+.widget-data-table {
+    .tooltip-container {
+        @apply flex flex-wrap gap-2 items-end;
+        line-height: 0.9375rem;
+        .tooltip-button:hover {
+            cursor: pointer;
+        }
+    }
+    .table-pagination-wrapper {
+        text-align: center;
+        font-size: 0.875rem;
+    }
+
+    /* custom design-system component - p-data-table */
+    :deep(.p-data-table) {
+        .status-wrapper {
+            display: inline-flex;
+            .toggle-button {
+                cursor: pointer;
+                padding-right: 1rem;
+                > .text {
+                    flex-shrink: 0;
+                    white-space: nowrap;
+                }
+            }
+            &.legend {
+                width: 100%;
+                > .name {
+                    word-break: break-all;
+                }
+            }
+        }
+
+        .raised {
+            @apply text-alert;
+        }
+        tr:nth-of-type(even) {
+            @apply bg-gray-100;
+        }
+        td {
+            @apply border-none;
+        }
+    }
+
+    &.print-mode {
+        /* custom design-system component - p-data-table */
+        :deep(.p-data-table) {
+            .table-container {
+                overflow: hidden;
+            }
+            table {
+                width: 100%;
+            }
+            .toggle-button {
+                cursor: default;
+            }
+        }
+        .status-wrapper {
+            min-width: 2rem;
+            padding: 0.125rem 0;
+        }
+    }
+}
+</style>

--- a/src/common/components/widgets/modules/WidgetFrame.vue
+++ b/src/common/components/widgets/modules/WidgetFrame.vue
@@ -14,9 +14,9 @@
         </div>
         <div class="widget-footer">
             <div class="footer-left">
-                <p-datetime-picker style-type="text" select-mode="range" :selected-dates.sync="selectedDates" />
+                <p-datetime-picker style-type="text" select-mode="range" :selected-dates.sync="proxySelectedDates" />
                 <p-divider :vertical="true" />
-                <currency-select-dropdown />
+                <currency-select-dropdown :print-mode="printMode" @update="handleUpdateCurrency" />
             </div>
             <div class="footer-right">
                 <slot name="footer-right">
@@ -39,11 +39,24 @@ import { reactive, toRefs, defineComponent } from 'vue';
 import { PDatetimePicker, PDivider, PI } from '@spaceone/design-system';
 import { CARD_SIZE } from '@spaceone/design-system/src/data-display/cards/card/config';
 
+import type { Currency } from '@/store/modules/display/config';
+import { CURRENCY } from '@/store/modules/display/config';
+
 import { useProxyValue } from '@/common/composables/proxy-state';
 
 import CurrencySelectDropdown from '@/services/cost-explorer/modules/CurrencySelectDropdown.vue';
 
-export default defineComponent({
+interface Props {
+    title: string;
+    size: CARD_SIZE;
+    widgetLink: string;
+    noData: boolean;
+    printMode: boolean;
+    selectedDates: string[];
+    currency: Currency;
+}
+
+export default defineComponent<Props>({
     name: 'WidgetFrame',
     components: {
         CurrencySelectDropdown,
@@ -72,14 +85,27 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
-        // currency
+        selectedDates: {
+            type: Array as PropType<string[]>,
+            default: () => [],
+        },
+        currency: {
+            type: String as PropType<Currency>,
+            default: CURRENCY.USD,
+        },
     },
     setup(props, { emit }:SetupContext) {
         const state = reactive({
-            selectedDates: useProxyValue('selectedDates', props, emit),
+            proxySelectedDates: useProxyValue('selectedDates', props, emit),
+            proxyCurrency: useProxyValue('currency', props, emit),
         });
+
+        const handleUpdateCurrency = (currency: Currency) => {
+            state.proxyCurrency = currency;
+        };
         return {
             ...toRefs(state),
+            handleUpdateCurrency,
         };
     },
 });

--- a/src/common/components/widgets/modules/WidgetFrame.vue
+++ b/src/common/components/widgets/modules/WidgetFrame.vue
@@ -37,18 +37,19 @@ import type { PropType, SetupContext } from 'vue';
 import { reactive, toRefs, defineComponent } from 'vue';
 
 import { PDatetimePicker, PDivider, PI } from '@spaceone/design-system';
-import { CARD_SIZE } from '@spaceone/design-system/src/data-display/cards/card/config';
 
 import type { Currency } from '@/store/modules/display/config';
 import { CURRENCY } from '@/store/modules/display/config';
 
+import type { WidgetSize } from '@/common/components/widgets/type';
+import { WIDGET_SIZE } from '@/common/components/widgets/type';
 import { useProxyValue } from '@/common/composables/proxy-state';
 
 import CurrencySelectDropdown from '@/services/cost-explorer/modules/CurrencySelectDropdown.vue';
 
 interface Props {
     title: string;
-    size: CARD_SIZE;
+    size: WidgetSize;
     widgetLink: string;
     noData: boolean;
     printMode: boolean;
@@ -70,8 +71,8 @@ export default defineComponent<Props>({
             default: 'Title',
         },
         size: {
-            type: String as PropType<CARD_SIZE>,
-            default: CARD_SIZE.md,
+            type: String as PropType<WidgetSize>,
+            default: WIDGET_SIZE.md,
         },
         widgetLink: {
             type: [Object, String],
@@ -175,6 +176,9 @@ export default defineComponent<Props>({
     }
     &.lg {
         @mixin widget-size 44rem;
+    }
+    &.xl {
+        @mixin widget-size 54rem;
     }
 }
 </style>

--- a/src/common/components/widgets/type.ts
+++ b/src/common/components/widgets/type.ts
@@ -1,0 +1,7 @@
+export const WIDGET_SIZE = {
+    sm: 'sm',
+    md: 'md',
+    lg: 'lg',
+    xl: 'xl',
+} as const;
+export type WidgetSize = typeof WIDGET_SIZE[keyof typeof WIDGET_SIZE];

--- a/src/common/components/widgets/type.ts
+++ b/src/common/components/widgets/type.ts
@@ -3,5 +3,6 @@ export const WIDGET_SIZE = {
     md: 'md',
     lg: 'lg',
     xl: 'xl',
+    full: 'full',
 } as const;
 export type WidgetSize = typeof WIDGET_SIZE[keyof typeof WIDGET_SIZE];


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
일단 마무리 된 부분까지 먼저 올렸습니다.

- WidgetFrame에 필터프롭을 연결
- widgetDataTable 생성
    - 기존 costExplorer에서 위젯 만들 때 사용하던 CostDashboardDataTable을 그대로 가져온 컴포넌트입니다.
    - 추후 스펙이 확정되면 그때 수정하고, 현재는 마크업만 진행하기위해 복붙하기로 결정하였습니다.

WidgetFrame에서 slot은 3가지가 있습니다.
- defalut slot (body에 해당합니다.)
- header-right
- footer-right

예시
![image](https://user-images.githubusercontent.com/50662170/199635257-56bb1390-0b69-4d25-90c1-4cc6a04e32c7.png)

### 생각해볼 문제
구조설계에대한 제안은 언제나 환영입니다