### PR TITLE
feat(gnb-dashboard): create dashboard-menu as custom-menu-wrapper

### DIFF
--- a/src/common/modules/navigations/gnb/GNB.vue
+++ b/src/common/modules/navigations/gnb/GNB.vue
@@ -13,7 +13,7 @@
             <g-n-b-menu v-for="(menu, idx) in gnbMenuList"
                         :key="idx"
                         :show="menu.show"
-                        :name="menu.id"
+                        :menu-id="menu.id"
                         :label="menu.label"
                         :to="menu.to"
                         :sub-menu-list="menu.subMenuList"

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
@@ -27,7 +27,8 @@
                  class="custom-menu-wrapper"
                  @click.stop
             >
-                <p-tab v-if="name === MENU_ID.DASHBOARD" :tabs="tabs"
+                <p-tab v-if="menuId === MENU_ID.DASHBOARD"
+                       :tabs="tabs"
                        :active-tab.sync="activeTab"
                 >
                     <template #recent>
@@ -103,7 +104,7 @@ export default defineComponent({
             type: Boolean,
             default: true,
         },
-        name: {
+        menuId: {
             type: String as PropType<MenuId>,
             default: '',
         },
@@ -134,7 +135,7 @@ export default defineComponent({
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
-            hasCustomMenu: computed<boolean>(() => customMenuNameList.includes(props.name)),
+            hasCustomMenu: computed<boolean>(() => customMenuNameList.includes(props.menuId)),
             hasSubMenu: computed<boolean>(() => props.subMenuList?.length > 0),
             isMenuWithAdditionalMenu: computed<boolean>(() => state.hasSubMenu || state.hasCustomMenu),
             tabs: computed(() => ([
@@ -145,9 +146,9 @@ export default defineComponent({
         });
         const handleMenu = () => {
             if (state.isMenuWithAdditionalMenu) {
-                emit('open-menu', props.name);
+                emit('open-menu', props.menuId);
             } else {
-                const isDuplicatePath = SpaceRouter.router.currentRoute.name === props.name;
+                const isDuplicatePath = SpaceRouter.router.currentRoute.name === props.menuId;
                 if (isDuplicatePath) return;
                 SpaceRouter.router.push(props.to);
             }

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
@@ -8,13 +8,13 @@
     >
         <div class="menu-button"
              :class="[{
-                 opened: subMenuList.length > 0 && isOpened,
+                 opened: isMenuWithAdditionalMenu && isOpened,
                  selected: isSelected,
              }]"
         >
             <span tabindex="0">
                 <span>{{ label }}</span>
-                <p-i v-if="subMenuList.length > 0"
+                <p-i v-if="isMenuWithAdditionalMenu"
                      class="arrow-button"
                      :name="isOpened ? 'ic_arrow_top_sm' : 'ic_arrow_bottom_sm'"
                      width="0.5rem"
@@ -23,7 +23,24 @@
                 />
             </span>
 
-            <div v-if="isOpened && subMenuList.length > 0"
+            <div v-if="isOpened && hasCustomMenu"
+                 class="custom-menu-wrapper"
+                 @click.stop
+            >
+                <p-tab v-if="name === MENU_ID.DASHBOARD" :tabs="tabs"
+                       :active-tab.sync="activeTab"
+                >
+                    <template #recent>
+                        <g-n-b-dashboard-recent :visible="activeTab === 'recent'"
+                                                @close="hideMenu"
+                        />
+                    </template>
+                    <template #favorite>
+                        <g-n-b-dashboard-favorite @close="hideMenu" />
+                    </template>
+                </p-tab>
+            </div>
+            <div v-if="isOpened && hasSubMenu"
                  class="sub-menu-wrapper"
                  @click.stop="hideMenu"
             >
@@ -43,21 +60,39 @@
 <script lang="ts">
 
 import { vOnClickOutside } from '@vueuse/components';
-import { defineComponent } from 'vue';
+import {
+    computed, defineComponent, reactive, toRefs,
+} from 'vue';
 import type { PropType, DirectiveFunction, SetupContext } from 'vue';
 
-import { PI } from '@spaceone/design-system';
+import { PI, PTab } from '@spaceone/design-system';
+import type { TabItem } from '@spaceone/design-system/dist/src/navigation/tabs/tab/type';
 
 import { SpaceRouter } from '@/router';
+import { i18n } from '@/translations';
 
 import type { DisplayMenu } from '@/store/modules/display/type';
 
+import type { MenuId } from '@/lib/menu/config';
+import { MENU_ID } from '@/lib/menu/config';
+
 import GNBSubMenu from '@/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue';
+import GNBDashboardFavorite
+    from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue';
+import GNBDashboardRecent
+    from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue';
+
+const customMenuNameList: MenuId[] = [
+    MENU_ID.DASHBOARD,
+];
 
 export default defineComponent({
     name: 'GNBMenu',
     components: {
+        PTab,
         PI,
+        GNBDashboardRecent,
+        GNBDashboardFavorite,
         GNBSubMenu,
     },
     directives: {
@@ -69,7 +104,7 @@ export default defineComponent({
             default: true,
         },
         name: {
-            type: String,
+            type: String as PropType<MenuId>,
             default: '',
         },
         label: {
@@ -98,8 +133,18 @@ export default defineComponent({
         },
     },
     setup(props, { emit }: SetupContext) {
+        const state = reactive({
+            hasCustomMenu: computed<boolean>(() => customMenuNameList.includes(props.name)),
+            hasSubMenu: computed<boolean>(() => props.subMenuList?.length > 0),
+            isMenuWithAdditionalMenu: computed<boolean>(() => state.hasSubMenu || state.hasCustomMenu),
+            tabs: computed(() => ([
+                { label: i18n.t('COMMON.GNB.RECENT.RECENT'), name: 'recent', keepAlive: true },
+                { label: i18n.t('COMMON.GNB.FAVORITES.FAVORITES'), name: 'favorite', keepAlive: true },
+            ] as TabItem[])),
+            activeTab: 'recent',
+        });
         const handleMenu = () => {
-            if (props.subMenuList?.length > 0) {
+            if (state.isMenuWithAdditionalMenu) {
                 emit('open-menu', props.name);
             } else {
                 const isDuplicatePath = SpaceRouter.router.currentRoute.name === props.name;
@@ -113,8 +158,10 @@ export default defineComponent({
         };
 
         return {
+            ...toRefs(state),
             handleMenu,
             hideMenu,
+            MENU_ID,
         };
     },
 });
@@ -162,6 +209,16 @@ export default defineComponent({
         min-width: 10rem;
         box-shadow: 0 0 0.875rem rgba(0, 0, 0, 0.1);
         padding: 0.5rem;
+    }
+    .custom-menu-wrapper {
+        @apply rounded-xs;
+        width: 22.5rem;
+        position: absolute;
+        top: $gnb-height;
+        margin-top: -0.5rem;
+        left: -1.125rem;
+        min-width: 10rem;
+        box-shadow: 0 0 0.875rem rgba(0, 0, 0, 0.1);
     }
 }
 

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue
@@ -13,6 +13,9 @@
 </template>
 
 <script lang="ts">
+import type { PropType } from 'vue';
+import type { TranslateResult } from 'vue-i18n';
+
 import BetaMark from '@/common/components/marks/BetaMark.vue';
 import NewMark from '@/common/components/marks/NewMark.vue';
 
@@ -29,7 +32,7 @@ export default {
             default: () => ({}),
         },
         label: {
-            type: String,
+            type: String as PropType<string|undefined|TranslateResult>,
             default: '',
         },
         isBeta: {

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -18,7 +18,9 @@
                                  @click="handleClickShowAll(item.itemType)"
                             >
                                 <span class="text">{{ $t('COMMON.GNB.FAVORITES.SHOW_ALL') }}</span>
-                                <p-i name="ic_arrow_right" width="1rem" height="1rem"
+                                <p-i name="ic_arrow_right"
+                                     width="1rem"
+                                     height="1rem"
                                      color="inherit"
                                 />
                             </div>
@@ -26,7 +28,8 @@
                     </template>
                     <template v-else>
                         <div class="all-items-header">
-                            <p-icon-button name="ic_back" size="sm"
+                            <p-icon-button name="ic_back"
+                                           size="sm"
                                            @click="handleGoBack"
                             />
                             <span class="title-text">{{ item.label }}</span>
@@ -36,7 +39,9 @@
             </g-n-b-suggestion-list>
             <template #no-data>
                 <div class="no-data">
-                    <img class="img" src="@/assets/images/illust_star.svg">
+                    <img class="img"
+                         src="@/assets/images/illust_star.svg"
+                    >
                     <p class="text">
                         {{ $t('COMMON.GNB.FAVORITES.FAVORITES_HELP_TEXT') }}
                     </p>
@@ -78,7 +83,6 @@ import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
 import type { CloudServiceTypeReferenceMap } from '@/store/modules/reference/cloud-service-type/type';
 import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
-
 
 import { isUserAccessibleToMenu } from '@/lib/access-control';
 import {

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -1,0 +1,339 @@
+<template>
+    <div class="gnb-dashboard-favorite">
+        <p-data-loader :data="items"
+                       :loading="loading"
+                       :class="{ loading: loading }"
+        >
+            <g-n-b-suggestion-list :items="showAll ? allItems : items"
+                                   use-favorite
+                                   @close="$emit('close')"
+                                   @select="handleSelect"
+            >
+                <template #header-title="{ item }">
+                    <template v-if="!showAll">
+                        <div class="context-header">
+                            {{ item.label }}
+                            <div v-if="getItemLength(item.itemType) > FAVORITE_LIMIT"
+                                 class="show-all-button"
+                                 @click="handleClickShowAll(item.itemType)"
+                            >
+                                <span class="text">{{ $t('COMMON.GNB.FAVORITES.SHOW_ALL') }}</span>
+                                <p-i name="ic_arrow_right" width="1rem" height="1rem"
+                                     color="inherit"
+                                />
+                            </div>
+                        </div>
+                    </template>
+                    <template v-else>
+                        <div class="all-items-header">
+                            <p-icon-button name="ic_back" size="sm"
+                                           @click="handleGoBack"
+                            />
+                            <span class="title-text">{{ item.label }}</span>
+                        </div>
+                    </template>
+                </template>
+            </g-n-b-suggestion-list>
+            <template #no-data>
+                <div class="no-data">
+                    <img class="img" src="@/assets/images/illust_star.svg">
+                    <p class="text">
+                        {{ $t('COMMON.GNB.FAVORITES.FAVORITES_HELP_TEXT') }}
+                    </p>
+                    <div class="button-wrapper">
+                        <p-button style-type="tertiary"
+                                  size="md"
+                                  @click="handleClickMenuButton(FAVORITE_TYPE.PROJECT)"
+                        >
+                            {{ $t('COMMON.GNB.FAVORITES.GO_TO_PROJECT') }}
+                        </p-button>
+                        <p-button style-type="tertiary"
+                                  size="md"
+                                  @click="handleClickMenuButton(FAVORITE_TYPE.CLOUD_SERVICE)"
+                        >
+                            {{ $t('COMMON.GNB.FAVORITES.GO_TO_CLOUD_SERVICE') }}
+                        </p-button>
+                    </div>
+                </div>
+            </template>
+        </p-data-loader>
+    </div>
+</template>
+
+<script lang="ts">
+import type { SetupContext } from 'vue';
+import { computed, reactive, toRefs } from 'vue';
+import type { TranslateResult } from 'vue-i18n';
+
+import {
+    PButton, PI, PIconButton, PDataLoader,
+} from '@spaceone/design-system';
+
+import { SpaceRouter } from '@/router';
+import { store } from '@/store';
+import { i18n } from '@/translations';
+
+import type { FavoriteItem } from '@/store/modules/favorite/type';
+import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
+import type { CloudServiceTypeReferenceMap } from '@/store/modules/reference/cloud-service-type/type';
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
+import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
+
+
+import { isUserAccessibleToMenu } from '@/lib/access-control';
+import {
+    convertCloudServiceConfigToReferenceData,
+    convertMenuConfigToReferenceData, convertProjectConfigToReferenceData, convertProjectGroupConfigToReferenceData,
+} from '@/lib/helper/config-data-helper';
+import type { MenuInfo } from '@/lib/menu/config';
+import { MENU_ID } from '@/lib/menu/config';
+import { MENU_INFO_MAP } from '@/lib/menu/menu-info';
+import { referenceRouter } from '@/lib/reference/referenceRouter';
+
+import type { SuggestionItem, SuggestionType } from '@/common/modules/navigations/gnb/modules/gnb-search/config';
+import { SUGGESTION_TYPE } from '@/common/modules/navigations/gnb/modules/gnb-search/config';
+import GNBSuggestionList from '@/common/modules/navigations/gnb/modules/GNBSuggestionList.vue';
+
+import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
+import { PROJECT_ROUTE } from '@/services/project/route-config';
+
+const FAVORITE_LIMIT = 5;
+
+export default {
+    name: 'GNBDashboardFavorite',
+    components: {
+        GNBSuggestionList,
+        PDataLoader,
+        PButton,
+        PI,
+        PIconButton,
+    },
+    props: {},
+    setup(props, { emit }: SetupContext) {
+        const state = reactive({
+            loading: true,
+            showAll: false,
+            showAllType: undefined as undefined|SuggestionType,
+            items: computed<SuggestionItem[]>(() => {
+                const results: SuggestionItem[] = [];
+                if (state.favoriteMenuItems.length) {
+                    results.push({
+                        name: 'title', label: i18n.t('COMMON.GNB.FAVORITES.MENU'), type: 'header', itemType: SUGGESTION_TYPE.MENU,
+                    });
+                    results.push(...state.favoriteMenuItems.slice(0, FAVORITE_LIMIT));
+                }
+                if (state.favoriteProjects.length) {
+                    if (results.length !== 0) results.push({ type: 'divider' });
+                    results.push({
+                        name: 'title', label: i18n.t('MENU.PROJECT'), type: 'header', itemType: SUGGESTION_TYPE.PROJECT,
+                    });
+                    results.push(...state.favoriteProjects.slice(0, FAVORITE_LIMIT));
+                }
+                if (state.favoriteCloudServiceItems.length) {
+                    if (results.length !== 0) results.push({ type: 'divider' });
+                    results.push({
+                        name: 'title', label: i18n.t('MENU.ASSET_INVENTORY_CLOUD_SERVICE'), type: 'header', itemType: SUGGESTION_TYPE.CLOUD_SERVICE,
+                    });
+                    results.push(...state.favoriteCloudServiceItems.slice(0, FAVORITE_LIMIT));
+                }
+                return results;
+            }),
+            allItems: computed<SuggestionItem[]>(() => {
+                let items: FavoriteItem[] = [];
+                let label: TranslateResult = '';
+                if (state.showAllType === SUGGESTION_TYPE.MENU) {
+                    items = state.favoriteMenuItems;
+                    label = i18n.t('COMMON.GNB.FAVORITES.ALL_MENU');
+                }
+                if (state.showAllType === SUGGESTION_TYPE.PROJECT) {
+                    items = state.favoriteProjects;
+                    label = i18n.t('COMMON.GNB.FAVORITES.ALL_PROJECTS');
+                }
+                if (state.showAllType === SUGGESTION_TYPE.CLOUD_SERVICE) {
+                    items = state.favoriteCloudServiceItems;
+                    label = i18n.t('COMMON.GNB.FAVORITES.ALL_CLOUD_SERVICES');
+                }
+                return [
+                    {
+                        name: 'title', type: 'header', label, itemType: state.showAllType,
+                    },
+                    ...items,
+                ];
+            }),
+            //
+            cloudServiceTypes: computed<CloudServiceTypeReferenceMap>(() => store.getters['reference/cloudServiceTypeItems']),
+            projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
+            //
+            favoriteMenuItems: computed<FavoriteItem[]>(() => convertMenuConfigToReferenceData(
+                store.state.favorite.menuItems,
+                store.getters['display/allMenuList'],
+            )),
+            favoriteCloudServiceItems: computed<FavoriteItem[]>(() => {
+                const isUserAccessible = isUserAccessibleToMenu(MENU_ID.ASSET_INVENTORY_CLOUD_SERVICE, store.getters['user/pagePermissionList']);
+                return isUserAccessible ? convertCloudServiceConfigToReferenceData(
+                    store.state.favorite.cloudServiceItems,
+                    state.cloudServiceTypes,
+                ) : [];
+            }),
+            favoriteProjects: computed<FavoriteItem[]>(() => {
+                const isUserAccessible = isUserAccessibleToMenu(MENU_ID.PROJECT, store.getters['user/pagePermissionList']);
+                if (!isUserAccessible) return [];
+                const favoriteProjectItems = convertProjectConfigToReferenceData(store.state.favorite.projectItems, state.projects);
+                const favoriteProjectGroupItems = convertProjectGroupConfigToReferenceData(store.state.favorite.projectGroupItems, state.projectGroups);
+                return [...favoriteProjectGroupItems, ...favoriteProjectItems];
+            }),
+        });
+
+        /* Util */
+        const getItemLength = (type: SuggestionType): number => {
+            if (type === SUGGESTION_TYPE.MENU) return state.favoriteMenuItems.length;
+            if (type === SUGGESTION_TYPE.PROJECT) return state.favoriteProjects.length;
+            if (type === SUGGESTION_TYPE.CLOUD_SERVICE) return state.favoriteCloudServiceItems.length;
+            return 0;
+        };
+
+        /* Event */
+        const handleClickMenuButton = (type: SuggestionType) => {
+            if (type === SUGGESTION_TYPE.PROJECT) {
+                SpaceRouter.router.replace({
+                    name: PROJECT_ROUTE._NAME,
+                });
+            } else if (type === SUGGESTION_TYPE.CLOUD_SERVICE) {
+                SpaceRouter.router.replace({
+                    name: ASSET_INVENTORY_ROUTE.CLOUD_SERVICE._NAME,
+                });
+            }
+            emit('close');
+        };
+        const handleClickShowAll = (type: SuggestionType) => {
+            state.showAll = true;
+            state.showAllType = type;
+        };
+        const handleShowAll = (type) => {
+            state.showAll = true;
+            state.showAllType = type;
+        };
+        const handleGoBack = () => {
+            state.showAll = false;
+            state.showAllType = undefined;
+        };
+        const handleSelect = (item: SuggestionItem) => {
+            const itemName = item.name as string;
+            if (item.itemType === SUGGESTION_TYPE.MENU) {
+                const menuInfo: MenuInfo = MENU_INFO_MAP[itemName];
+                if (menuInfo && SpaceRouter.router.currentRoute.name !== itemName) {
+                    SpaceRouter.router.push({ name: itemName }).catch(() => {});
+                }
+            } else if (item.itemType === SUGGESTION_TYPE.PROJECT) {
+                SpaceRouter.router.push(referenceRouter(itemName, { resource_type: 'identity.Project' })).catch(() => {});
+            } else if (item.itemType === SUGGESTION_TYPE.PROJECT_GROUP) {
+                SpaceRouter.router.push(referenceRouter(itemName, { resource_type: 'identity.ProjectGroup' })).catch(() => {});
+            } else if (item.itemType === SUGGESTION_TYPE.CLOUD_SERVICE) {
+                const itemInfo: string[] = itemName.split('.');
+                SpaceRouter.router.push({
+                    name: ASSET_INVENTORY_ROUTE.CLOUD_SERVICE.DETAIL._NAME,
+                    params: {
+                        provider: itemInfo[0],
+                        group: itemInfo[1],
+                        name: itemInfo[2],
+                    },
+                }).catch(() => {});
+            }
+            emit('close');
+        };
+
+        /* Init */
+        (async () => {
+            state.loading = true;
+            await Promise.allSettled([
+                store.dispatch('reference/project/load'),
+                store.dispatch('reference/projectGroup/load'),
+                store.dispatch('reference/cloudServiceType/load'),
+                store.dispatch('favorite/load', FAVORITE_TYPE.MENU),
+                store.dispatch('favorite/load', FAVORITE_TYPE.PROJECT),
+                store.dispatch('favorite/load', FAVORITE_TYPE.PROJECT_GROUP),
+                store.dispatch('favorite/load', FAVORITE_TYPE.CLOUD_SERVICE),
+            ]);
+            state.loading = false;
+        })();
+
+        return {
+            ...toRefs(state),
+            FAVORITE_TYPE,
+            FAVORITE_LIMIT,
+            handleClickShowAll,
+            handleClickMenuButton,
+            handleGoBack,
+            handleSelect,
+            handleShowAll,
+            getItemLength,
+        };
+    },
+};
+</script>
+<style lang="postcss" scoped>
+.gnb-favorite {
+    /* custom design-system component - p-data-loader */
+    :deep(.p-data-loader) {
+        &.loading {
+            height: 15rem;
+        }
+        .data-loader-container {
+            max-height: calc(100vh - $gnb-height - 3.75rem);
+            overflow-y: auto;
+            padding: 1rem 0;
+        }
+    }
+
+    /* custom gnb-suggestion-list */
+    :deep(.gnb-search-suggestion-list) {
+        .context-header {
+            display: flex;
+            justify-content: space-between;
+            .show-all-button {
+                @apply text-blue-700;
+                font-size: 0.75rem;
+                cursor: pointer;
+                .text {
+                    font-weight: normal;
+                }
+                &:hover {
+                    .text {
+                        text-decoration: underline;
+                    }
+                }
+            }
+        }
+        .all-items-header {
+            display: flex;
+            align-items: center;
+            font-size: 0.875rem;
+            font-weight: 700;
+            padding-bottom: 0.5rem;
+        }
+    }
+    .no-data {
+        text-align: center;
+        padding: 3rem 3.25rem;
+        .img {
+            margin: auto;
+        }
+        .text {
+            @apply text-gray-400;
+            font-size: 0.875rem;
+            line-height: 1.5;
+            padding-top: 1.5rem;
+        }
+        .button-wrapper {
+            display: flex;
+            gap: 0.5rem;
+            justify-content: center;
+            padding-top: 1rem;
+            .p-button {
+                width: 10.5rem;
+            }
+        }
+    }
+}
+</style>

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue
@@ -1,0 +1,199 @@
+<template>
+    <div class="gnb-dashboard-recent">
+        <p-data-loader :data="items"
+                       :loading="loading"
+                       :class="{ loading: loading && !items.length }"
+        >
+            <g-n-b-suggestion-list :items="items"
+                                   use-favorite
+                                   @close="$emit('close')"
+                                   @select="handleSelect"
+            />
+            <template #no-data>
+                <div class="no-data">
+                    <img class="img" src="@/assets/images/illust_spaceship_3.svg">
+                    <p class="text">
+                        {{ $t('COMMON.GNB.RECENT.RECENT_HELP_TEXT') }}
+                    </p>
+                </div>
+            </template>
+        </p-data-loader>
+    </div>
+</template>
+
+<script lang="ts">
+
+
+import type { SetupContext } from 'vue';
+import {
+    computed, defineComponent, reactive, toRefs, watch,
+} from 'vue';
+
+import { PDataLoader } from '@spaceone/design-system';
+import { sortBy } from 'lodash';
+
+
+import { SpaceRouter } from '@/router';
+import { store } from '@/store';
+
+import type { DisplayMenu } from '@/store/modules/display/type';
+import type { RecentConfig, RecentItem } from '@/store/modules/recent/type';
+import { RECENT_TYPE } from '@/store/modules/recent/type';
+import type { CloudServiceTypeReferenceMap } from '@/store/modules/reference/cloud-service-type/type';
+import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
+import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
+
+import { isUserAccessibleToMenu } from '@/lib/access-control';
+import {
+    convertCloudServiceConfigToReferenceData,
+    convertMenuConfigToReferenceData,
+    convertProjectConfigToReferenceData,
+    convertProjectGroupConfigToReferenceData,
+} from '@/lib/helper/config-data-helper';
+import type { MenuInfo } from '@/lib/menu/config';
+import { MENU_ID } from '@/lib/menu/config';
+import { MENU_INFO_MAP } from '@/lib/menu/menu-info';
+import { referenceRouter } from '@/lib/reference/referenceRouter';
+
+import type { SuggestionItem } from '@/common/modules/navigations/gnb/modules/gnb-search/config';
+import { SUGGESTION_TYPE } from '@/common/modules/navigations/gnb/modules/gnb-search/config';
+import GNBSuggestionList from '@/common/modules/navigations/gnb/modules/GNBSuggestionList.vue';
+
+import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
+
+
+const RECENT_LIMIT = 30;
+
+export default defineComponent({
+    name: 'GNBDashboardRecent',
+    components: {
+        GNBSuggestionList,
+        PDataLoader,
+    },
+    props: {
+        visible: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    setup(props, { emit }: SetupContext) {
+        const storeState = reactive({
+            menuItems: computed<DisplayMenu[]>(() => store.getters['display/allMenuList']),
+            projects: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
+            projectGroups: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
+            cloudServiceTypes: computed<CloudServiceTypeReferenceMap>(() => store.getters['reference/cloudServiceTypeItems']),
+            recents: computed<RecentConfig[]>(() => store.state.recent.allItems),
+        });
+        const state = reactive({
+            loading: true,
+            items: computed<SuggestionItem[]>(() => sortBy(
+                state.recentMenuItems
+                    .concat(state.recentCloudServiceItems)
+                    .concat(state.recentProjectItems)
+                    .concat(state.recentProjectGroupItems),
+                recent => recent.updatedAt,
+            ).reverse()),
+            recentMenuItems: computed<RecentItem[]>(() => convertMenuConfigToReferenceData(
+                storeState.recents.filter(d => d.itemType === RECENT_TYPE.MENU),
+                storeState.menuItems,
+            )),
+            recentCloudServiceItems: computed<RecentItem[]>(() => {
+                const isUserAccessible = isUserAccessibleToMenu(MENU_ID.ASSET_INVENTORY_CLOUD_SERVICE, store.getters['user/pagePermissionList']);
+                return isUserAccessible ? convertCloudServiceConfigToReferenceData(
+                    storeState.recents.filter(d => d.itemType === RECENT_TYPE.CLOUD_SERVICE),
+                    storeState.cloudServiceTypes,
+                ) : [];
+            }),
+            recentProjectItems: computed<RecentItem[]>(() => {
+                const isUserAccessible = isUserAccessibleToMenu(MENU_ID.PROJECT, store.getters['user/pagePermissionList']);
+                return isUserAccessible ? convertProjectConfigToReferenceData(
+                    storeState.recents.filter(d => d.itemType === RECENT_TYPE.PROJECT),
+                    storeState.projects,
+                ) : [];
+            }),
+            recentProjectGroupItems: computed<RecentItem[]>(() => {
+                const isUserAccessible = isUserAccessibleToMenu(MENU_ID.PROJECT, store.getters['user/pagePermissionList']);
+                return isUserAccessible ? convertProjectGroupConfigToReferenceData(
+                    storeState.recents.filter(d => d.itemType === RECENT_TYPE.PROJECT_GROUP),
+                    storeState.projectGroups,
+                ) : [];
+            }),
+        });
+
+        const handleSelect = (item: SuggestionItem) => {
+            const itemName = item.name as string;
+            if (item.itemType === SUGGESTION_TYPE.MENU) {
+                const menuInfo: MenuInfo = MENU_INFO_MAP[itemName];
+                if (menuInfo && SpaceRouter.router.currentRoute.name !== itemName) {
+                    SpaceRouter.router.push({ name: itemName }).catch(() => {});
+                }
+            } else if (item.itemType === SUGGESTION_TYPE.PROJECT) {
+                SpaceRouter.router.push(referenceRouter(itemName, { resource_type: 'identity.Project' })).catch(() => {});
+            } else if (item.itemType === SUGGESTION_TYPE.PROJECT_GROUP) {
+                SpaceRouter.router.push(referenceRouter(itemName, { resource_type: 'identity.ProjectGroup' })).catch(() => {});
+            } else if (item.itemType === SUGGESTION_TYPE.CLOUD_SERVICE) {
+                const itemInfo: string[] = itemName.split('.');
+                SpaceRouter.router.push({
+                    name: ASSET_INVENTORY_ROUTE.CLOUD_SERVICE.DETAIL._NAME,
+                    params: {
+                        provider: itemInfo[0],
+                        group: itemInfo[1],
+                        name: itemInfo[2],
+                    },
+                }).catch(() => {});
+            }
+            emit('close');
+        };
+
+        /* Init */
+        (async () => {
+            await Promise.allSettled([
+                store.dispatch('reference/project/load'),
+                store.dispatch('reference/projectGroup/load'),
+                store.dispatch('reference/cloudServiceType/load'),
+            ]);
+        })();
+
+        /* Watcher */
+        watch(() => props.visible, async (visible) => {
+            if (visible) {
+                state.loading = true;
+                await store.dispatch('recent/load', { limit: RECENT_LIMIT });
+                state.loading = false;
+            }
+        });
+
+        return {
+            ...toRefs(state),
+            handleSelect,
+        };
+    },
+});
+</script>
+<style lang="postcss" scoped>
+.gnb-recent {
+    /* custom design-system component - p-data-loader */
+    :deep(.p-data-loader) {
+        &.loading {
+            height: 13rem;
+        }
+        .data-loader-container {
+            max-height: calc(100vh - $gnb-height - 3.75rem);
+            overflow-y: auto;
+            padding: 1rem 0;
+        }
+    }
+    .no-data {
+        text-align: center;
+        padding: 3rem 3.25rem;
+        .img {
+            margin: auto;
+        }
+        .text {
+            @apply text-gray-400;
+            font-size: 0.875rem;
+            line-height: 1.5;
+        }
+    }
+}
+</style>

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue
@@ -11,7 +11,10 @@
             />
             <template #no-data>
                 <div class="no-data">
-                    <img class="img" src="@/assets/images/illust_spaceship_3.svg">
+                    <img class="img"
+                         alt="no-data-image"
+                         src="@/assets/images/illust_spaceship_3.svg"
+                    >
                     <p class="text">
                         {{ $t('COMMON.GNB.RECENT.RECENT_HELP_TEXT') }}
                     </p>
@@ -23,7 +26,6 @@
 
 <script lang="ts">
 
-
 import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs, watch,
@@ -31,7 +33,6 @@ import {
 
 import { PDataLoader } from '@spaceone/design-system';
 import { sortBy } from 'lodash';
-
 
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
@@ -60,7 +61,6 @@ import { SUGGESTION_TYPE } from '@/common/modules/navigations/gnb/modules/gnb-se
 import GNBSuggestionList from '@/common/modules/navigations/gnb/modules/GNBSuggestionList.vue';
 
 import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
-
 
 const RECENT_LIMIT = 30;
 
@@ -91,30 +91,30 @@ export default defineComponent({
                     .concat(state.recentCloudServiceItems)
                     .concat(state.recentProjectItems)
                     .concat(state.recentProjectGroupItems),
-                recent => recent.updatedAt,
+                (recent) => recent.updatedAt,
             ).reverse()),
             recentMenuItems: computed<RecentItem[]>(() => convertMenuConfigToReferenceData(
-                storeState.recents.filter(d => d.itemType === RECENT_TYPE.MENU),
+                storeState.recents.filter((d) => d.itemType === RECENT_TYPE.MENU),
                 storeState.menuItems,
             )),
             recentCloudServiceItems: computed<RecentItem[]>(() => {
                 const isUserAccessible = isUserAccessibleToMenu(MENU_ID.ASSET_INVENTORY_CLOUD_SERVICE, store.getters['user/pagePermissionList']);
                 return isUserAccessible ? convertCloudServiceConfigToReferenceData(
-                    storeState.recents.filter(d => d.itemType === RECENT_TYPE.CLOUD_SERVICE),
+                    storeState.recents.filter((d) => d.itemType === RECENT_TYPE.CLOUD_SERVICE),
                     storeState.cloudServiceTypes,
                 ) : [];
             }),
             recentProjectItems: computed<RecentItem[]>(() => {
                 const isUserAccessible = isUserAccessibleToMenu(MENU_ID.PROJECT, store.getters['user/pagePermissionList']);
                 return isUserAccessible ? convertProjectConfigToReferenceData(
-                    storeState.recents.filter(d => d.itemType === RECENT_TYPE.PROJECT),
+                    storeState.recents.filter((d) => d.itemType === RECENT_TYPE.PROJECT),
                     storeState.projects,
                 ) : [];
             }),
             recentProjectGroupItems: computed<RecentItem[]>(() => {
                 const isUserAccessible = isUserAccessibleToMenu(MENU_ID.PROJECT, store.getters['user/pagePermissionList']);
                 return isUserAccessible ? convertProjectGroupConfigToReferenceData(
-                    storeState.recents.filter(d => d.itemType === RECENT_TYPE.PROJECT_GROUP),
+                    storeState.recents.filter((d) => d.itemType === RECENT_TYPE.PROJECT_GROUP),
                     storeState.projectGroups,
                 ) : [];
             }),
@@ -171,7 +171,7 @@ export default defineComponent({
 });
 </script>
 <style lang="postcss" scoped>
-.gnb-recent {
+.gnb-dashboard-recent {
     /* custom design-system component - p-data-loader */
     :deep(.p-data-loader) {
         &.loading {

--- a/src/services/project/project-detail/project-summary/modules/ProjectTrustedAdvisor.vue
+++ b/src/services/project/project-detail/project-summary/modules/ProjectTrustedAdvisor.vue
@@ -13,7 +13,9 @@
             <div v-else-if="!data"
                  class="no-data-wrapper"
             >
-                <img src="@/assets/images/illust_star.svg">
+                <img alt="no-data-image"
+                     src="@/assets/images/illust_star.svg"
+                >
                 <div class="text">
                     {{ $t('COMMON.WIDGETS.TRUSTED_ADVISOR.NO_DATA') }}
                 </div>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- 기존 GNBRecentFavorite에 들어가는 컴포넌트를 일단 복사하고 GNBMenu에 맞게 수정하였습니다.
- 마크업만 존재하는 상태입니다. 
![image](https://user-images.githubusercontent.com/50662170/200220720-75835437-ec52-447b-a58d-00a28c23c2d9.png)

### 생각해볼 문제
![image](https://user-images.githubusercontent.com/50662170/200220744-58ff5d56-6aeb-4e42-8c61-53e7d7f766a0.png)
위와 같은 subMenu가 모든 탭에 동일하게 존재해야 해서 PTab컴포넌트의 모든 탭에 공통 적용되는 slot을 하나 추가하면 좋을 것 같습니다.
혹시, 슬롯이 추가되었을 때 우려되는 점이 있다면 코멘트 부탁드려요
