### PR TITLE
feat(gnb-dashboard): add dashboard routing to gnbDashboardMenu footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@amcharts/amcharts4": "^4.10.10",
         "@amcharts/amcharts4-geodata": "^4.1.18",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.448",
+        "@spaceone/design-system": "^1.1.0-beta.449",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -3748,9 +3748,9 @@
       }
     },
     "node_modules/@spaceone/design-system": {
-      "version": "1.1.0-beta.448",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.448.tgz",
-      "integrity": "sha512-JUj7LAi9w7AP7UsoWzDG8C24gJjIcNlMapECTm5O6+a6E0tT2zv1lHruphhwcZ6a6/7D3Jn0dCh1ZBWol/HeLw==",
+      "version": "1.1.0-beta.449",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.449.tgz",
+      "integrity": "sha512-11AbyJmBxYaJxmMl2Y6pYXV1zVfWHw7L+pysauPZvfKC4odlTWH5fUPIFT3mOnkHNCbbnBuUN3MHJG/EleJElg==",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -23896,9 +23896,9 @@
       }
     },
     "@spaceone/design-system": {
-      "version": "1.1.0-beta.448",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.448.tgz",
-      "integrity": "sha512-JUj7LAi9w7AP7UsoWzDG8C24gJjIcNlMapECTm5O6+a6E0tT2zv1lHruphhwcZ6a6/7D3Jn0dCh1ZBWol/HeLw==",
+      "version": "1.1.0-beta.449",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.449.tgz",
+      "integrity": "sha512-11AbyJmBxYaJxmMl2Y6pYXV1zVfWHw7L+pysauPZvfKC4odlTWH5fUPIFT3mOnkHNCbbnBuUN3MHJG/EleJElg==",
       "requires": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -26168,7 +26168,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.448",
+        "@spaceone/design-system": "^1.1.0-beta.449",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -28898,9 +28898,9 @@
           }
         },
         "@spaceone/design-system": {
-          "version": "1.1.0-beta.448",
-          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.448.tgz",
-          "integrity": "sha512-JUj7LAi9w7AP7UsoWzDG8C24gJjIcNlMapECTm5O6+a6E0tT2zv1lHruphhwcZ6a6/7D3Jn0dCh1ZBWol/HeLw==",
+          "version": "1.1.0-beta.449",
+          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.449.tgz",
+          "integrity": "sha512-11AbyJmBxYaJxmMl2Y6pYXV1zVfWHw7L+pysauPZvfKC4odlTWH5fUPIFT3mOnkHNCbbnBuUN3MHJG/EleJElg==",
           "requires": {
             "@amcharts/amcharts4": "^4.10.10",
             "@babel/runtime": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@amcharts/amcharts4": "^4.10.10",
     "@amcharts/amcharts4-geodata": "^4.1.18",
     "@gtm-support/vue2-gtm": "^1.3.0",
-    "@spaceone/design-system": "^1.1.0-beta.448",
+    "@spaceone/design-system": "^1.1.0-beta.449",
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-color": "^2.0.0-beta.12",
     "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
@@ -25,9 +25,9 @@
 
             <div v-if="isOpened && hasCustomMenu"
                  class="custom-menu-wrapper"
-                 @click.stop
+                 @click.stop="hideMenu"
             >
-                <g-n-b-dashboard-menu v-if="menuId === MENU_ID.DASHBOARD" />
+                <g-n-b-dashboard-menu v-if="menuId === MENU_ID.DASHBOARDS" />
             </div>
             <div v-if="isOpened && hasSubMenu"
                  class="sub-menu-wrapper"
@@ -68,7 +68,7 @@ import GNBDashboardMenu
     from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue';
 
 const customMenuNameList: MenuId[] = [
-    MENU_ID.DASHBOARD,
+    MENU_ID.DASHBOARDS,
 ];
 
 export default defineComponent({

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
@@ -27,19 +27,7 @@
                  class="custom-menu-wrapper"
                  @click.stop
             >
-                <p-tab v-if="menuId === MENU_ID.DASHBOARD"
-                       :tabs="tabs"
-                       :active-tab.sync="activeTab"
-                >
-                    <template #recent>
-                        <g-n-b-dashboard-recent :visible="activeTab === 'recent'"
-                                                @close="hideMenu"
-                        />
-                    </template>
-                    <template #favorite>
-                        <g-n-b-dashboard-favorite @close="hideMenu" />
-                    </template>
-                </p-tab>
+                <g-n-b-dashboard-menu v-if="menuId === MENU_ID.DASHBOARD" />
             </div>
             <div v-if="isOpened && hasSubMenu"
                  class="sub-menu-wrapper"
@@ -66,11 +54,9 @@ import {
 } from 'vue';
 import type { PropType, DirectiveFunction, SetupContext } from 'vue';
 
-import { PI, PTab } from '@spaceone/design-system';
-import type { TabItem } from '@spaceone/design-system/dist/src/navigation/tabs/tab/type';
+import { PI } from '@spaceone/design-system';
 
 import { SpaceRouter } from '@/router';
-import { i18n } from '@/translations';
 
 import type { DisplayMenu } from '@/store/modules/display/type';
 
@@ -78,10 +64,8 @@ import type { MenuId } from '@/lib/menu/config';
 import { MENU_ID } from '@/lib/menu/config';
 
 import GNBSubMenu from '@/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue';
-import GNBDashboardFavorite
-    from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue';
-import GNBDashboardRecent
-    from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue';
+import GNBDashboardMenu
+    from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue';
 
 const customMenuNameList: MenuId[] = [
     MENU_ID.DASHBOARD,
@@ -90,10 +74,8 @@ const customMenuNameList: MenuId[] = [
 export default defineComponent({
     name: 'GNBMenu',
     components: {
-        PTab,
+        GNBDashboardMenu,
         PI,
-        GNBDashboardRecent,
-        GNBDashboardFavorite,
         GNBSubMenu,
     },
     directives: {
@@ -138,11 +120,6 @@ export default defineComponent({
             hasCustomMenu: computed<boolean>(() => customMenuNameList.includes(props.menuId)),
             hasSubMenu: computed<boolean>(() => props.subMenuList?.length > 0),
             isMenuWithAdditionalMenu: computed<boolean>(() => state.hasSubMenu || state.hasCustomMenu),
-            tabs: computed(() => ([
-                { label: i18n.t('COMMON.GNB.RECENT.RECENT'), name: 'recent', keepAlive: true },
-                { label: i18n.t('COMMON.GNB.FAVORITES.FAVORITES'), name: 'favorite', keepAlive: true },
-            ] as TabItem[])),
-            activeTab: 'recent',
         });
         const handleMenu = () => {
             if (state.isMenuWithAdditionalMenu) {

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
@@ -1,0 +1,106 @@
+<template>
+    <div class="g-n-b-dashboard-menu">
+        <p-tab :tabs="tabs"
+               :active-tab.sync="activeTab"
+        >
+            <template #favorite>
+                <g-n-b-dashboard-favorite />
+            </template>
+            <template #recent>
+                <g-n-b-dashboard-recent :visible="activeTab === 'recent'" />
+            </template>
+            <template #footer>
+                <div v-for="(subMenu, index) in subMenuList"
+                     :key="index"
+                     class="sub-menu"
+                >
+                    <g-n-b-sub-menu :show="!subMenu.hideOnGNB"
+                                    :label="subMenu.label"
+                                    :to="subMenu.to"
+                                    :is-beta="subMenu.isBeta"
+                                    :is-new="subMenu.isNew"
+                    />
+                </div>
+            </template>
+        </p-tab>
+    </div>
+</template>
+
+<script lang="ts">
+import {
+    computed, defineComponent, reactive, toRefs,
+} from 'vue';
+
+import { PTab } from '@spaceone/design-system';
+import type { TabItem } from '@spaceone/design-system/dist/src/navigation/tabs/tab/type';
+
+import { i18n } from '@/translations';
+
+import type { DisplayMenu } from '@/store/modules/display/type';
+
+import GNBSubMenu from '@/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue';
+import GNBDashboardFavorite
+    from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue';
+import GNBDashboardRecent
+    from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue';
+
+import { DASHBOARD_ROUTE } from '@/services/dashboard/route-config';
+
+export default defineComponent({
+    name: 'GNBDashboardMenu',
+    components: {
+        PTab,
+        GNBDashboardRecent,
+        GNBDashboardFavorite,
+        GNBSubMenu,
+    },
+    setup() {
+        const state = reactive({
+            tabs: computed(() => ([
+                { label: i18n.t('COMMON.GNB.FAVORITES.FAVORITES'), name: 'favorite', keepAlive: true },
+                { label: i18n.t('COMMON.GNB.RECENT.RECENT'), name: 'recent', keepAlive: true },
+            ] as TabItem[])),
+            activeTab: 'favorite',
+            subMenuList: [
+                {
+                    label: 'View All Dashboards', // song-lang
+                    to: { name: DASHBOARD_ROUTE._NAME },
+                },
+                {
+                    label: 'Create New Dashboard', // song-lang
+                    to: { name: DASHBOARD_ROUTE.CREATE._NAME },
+                },
+            ] as DisplayMenu[],
+        });
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>
+
+<style lang="postcss" scoped>
+.g-n-b-dashboard-menu {
+    /* custom design-system component - p-tab */
+    :deep(.p-tab) {
+        @apply absolute bg-white rounded-xs border border-gray-200;
+        display: flex;
+        flex-direction: column;
+        width: 27.5rem;
+        min-height: auto;
+        top: 100%;
+        right: 0;
+        box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.08);
+        margin-top: -0.5rem;
+        margin-right: -0.5rem;
+        .tab-pane {
+            padding-bottom: 0;
+        }
+    }
+    .sub-menu {
+        @apply border-t border-gray-200;
+        padding: 0.5rem;
+    }
+}
+
+</style>

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
@@ -11,7 +11,7 @@
             </template>
             <template #footer>
                 <div v-for="(subMenu, index) in subMenuList"
-                     :key="index"
+                     :key="`footer-${subMenu.label}-${index}`"
                      class="sub-menu"
                 >
                     <g-n-b-sub-menu :show="!subMenu.hideOnGNB"
@@ -44,7 +44,7 @@ import GNBDashboardFavorite
 import GNBDashboardRecent
     from '@/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue';
 
-import { DASHBOARD_ROUTE } from '@/services/dashboard/route-config';
+import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
 export default defineComponent({
     name: 'GNBDashboardMenu',
@@ -64,11 +64,11 @@ export default defineComponent({
             subMenuList: [
                 {
                     label: 'View All Dashboards', // song-lang
-                    to: { name: DASHBOARD_ROUTE._NAME },
+                    to: { name: DASHBOARDS_ROUTE._NAME },
                 },
                 {
                     label: 'Create New Dashboard', // song-lang
-                    to: { name: DASHBOARD_ROUTE.CREATE._NAME },
+                    to: { name: DASHBOARDS_ROUTE.CREATE._NAME },
                 },
             ] as DisplayMenu[],
         });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
![image](https://user-images.githubusercontent.com/50662170/200452284-794a1a6f-9a22-4ff0-8bdc-c2362e067d78.png)

대시보드로 이동하는 메뉴를 푸터에 추가하였습니다. 일단 이동에 불편함이 없도록 라우팅 작업만 바로 올렸습니다. 메뉴가 안꺼진다거나 이런 버그가 있을 예정인데, 다음 기능과 함께 수정하여 올리겠습니다.
(이전까지 url로 직접 이동해주셔서 감사..)

GNBMenu가 앞으로 천천히 두꺼워질 것 같아 dashboard의 favorite과 recent도 따로 묶어 분리하였습니다.
### 생각해볼 문제
