### PR TITLE
feat(dashboards): create dashboards LNB & make some changes at routes

### DIFF
--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -90,64 +90,64 @@ export default {
             loading: true,
             items: [
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard1', name: '1',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard1', name: '1',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard2', name: '2',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard2', name: '2',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard3', name: '3',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard3', name: '3',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard4', name: '4',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard4', name: '4',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard5', name: '5',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard5', name: '5',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard6', name: '6',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard6', name: '6',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard7', name: '7',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard7', name: '7',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard8', name: '8',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard8', name: '8',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard9', name: '9',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard9', name: '9',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard10', name: '10',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard10', name: '10',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard11', name: '11',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard11', name: '11',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard12', name: '12',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard12', name: '12',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard13', name: '13',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard13', name: '13',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard14', name: '14',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard14', name: '14',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard15', name: '15',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard15', name: '15',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard16', name: '16',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard16', name: '16',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard17', name: '17',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard17', name: '17',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard18', name: '18',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard18', name: '18',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard19', name: '19',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard19', name: '19',
                 },
                 {
-                    show: true, to: { name: DASHBOARDS_ROUTE._NAME }, label: 'dashboard20', name: '20',
+                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard20', name: '20',
                 },
             ],
         });

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
@@ -74,7 +74,7 @@ export default defineComponent({
             subMenuList: [
                 {
                     label: 'View All Dashboards', // song-lang
-                    to: { name: DASHBOARDS_ROUTE._NAME },
+                    to: { name: DASHBOARDS_ROUTE.ALL._NAME },
                 },
                 {
                     label: 'Create New Dashboard', // song-lang

--- a/src/common/modules/navigations/lnb/LNB.vue
+++ b/src/common/modules/navigations/lnb/LNB.vue
@@ -49,6 +49,7 @@
                      :key="`${idx}-${getUUID()}`"
                      class="favorite-only-wrapper"
                 >
+                    <!--song-lang-->
                     <span>Show favorites only</span>
                     <p-toggle-button :value="proxyFavoriteOnly"
                                      sync

--- a/src/common/modules/navigations/lnb/LNB.vue
+++ b/src/common/modules/navigations/lnb/LNB.vue
@@ -51,7 +51,7 @@
                 >
                     <!--song-lang-->
                     <span>Show favorites only</span>
-                    <p-toggle-button :value="proxyFavoriteOnly"
+                    <p-toggle-button :value="proxyShowFavoriteOnly"
                                      sync
                                      @change="handleFavoriteToggle"
                     />
@@ -118,7 +118,7 @@ export default {
             type: Array as () => LNBMenu[],
             default: () => [],
         },
-        favoriteOnly: {
+        showFavoriteOnly: {
             type: Boolean,
             default: undefined,
         },
@@ -128,11 +128,11 @@ export default {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             currentPath: computed(() => vm.$route.fullPath),
-            proxyFavoriteOnly: useProxyValue<boolean | undefined>('favoriteOnly', props, emit),
+            proxyShowFavoriteOnly: useProxyValue<boolean | undefined>('showFavoriteOnly', props, emit),
         });
 
         const handleFavoriteToggle = () => {
-            state.proxyFavoriteOnly = !state.proxyFavoriteOnly;
+            state.proxyShowFavoriteOnly = !state.proxyShowFavoriteOnly;
         };
 
         return {

--- a/src/common/modules/navigations/lnb/LNB.vue
+++ b/src/common/modules/navigations/lnb/LNB.vue
@@ -1,7 +1,9 @@
 <template>
     <nav class="lnb">
         <div class="header">
-            {{ header }}
+            <slot name="header">
+                {{ header }}
+            </slot>
         </div>
         <p-divider class="divider" />
         <div class="menu-wrapper">
@@ -42,46 +44,61 @@
                     />
                 </router-link>
             </div>
-            <l-n-b-menu-item v-for="(menuData, idx) in menuSet"
-                             :key="`${idx}-${getUUID()}`"
-                             :menu-data="menuData"
-                             :current-path="currentPath"
-                             :depth="Array.isArray(menuData) ? 2 : 1"
-            >
-                <template v-for="(_, slot) of $scopedSlots"
-                          #[slot]="scope"
+            <template v-for="(menuData, idx) in menuSet">
+                <div v-if="menuData.type === MENU_ITEM_TYPE.FAVORITE_ONLY"
+                     :key="`${idx}-${getUUID()}`"
+                     class="favorite-only-wrapper"
                 >
-                    <slot :name="slot"
-                          v-bind="scope"
+                    <span>Show favorites only</span>
+                    <p-toggle-button :value="proxyFavoriteOnly"
+                                     sync
+                                     @change="handleFavoriteToggle"
                     />
-                </template>
-            </l-n-b-menu-item>
+                </div>
+                <l-n-b-menu-item v-else
+                                 :key="`${idx}-${getUUID()}`"
+                                 :menu-data="menuData"
+                                 :current-path="currentPath"
+                                 :depth="Array.isArray(menuData) ? 2 : 1"
+                >
+                    <template v-for="(_, slot) of $scopedSlots"
+                              #[slot]="scope"
+                    >
+                        <slot :name="slot"
+                              v-bind="scope"
+                        />
+                    </template>
+                </l-n-b-menu-item>
+            </template>
         </div>
     </nav>
 </template>
 
 <script lang="ts">
+import type { SetupContext } from 'vue';
 import {
     computed, getCurrentInstance, reactive, toRefs,
 } from 'vue';
 import type { Vue } from 'vue/types/vue';
 
 import {
-    PDivider, PI, PLazyImg,
+    PDivider, PI, PLazyImg, PToggleButton,
 } from '@spaceone/design-system';
 
 import { getUUID } from '@/lib/component-util/getUUID';
 import { assetUrlConverter } from '@/lib/helper/asset-helper';
 
+import { useProxyValue } from '@/common/composables/proxy-state';
 import LNBMenuItem from '@/common/modules/navigations/lnb/modules/LNBMenuItem.vue';
 import type {
     BackLink, LNBMenu, TopTitle,
 } from '@/common/modules/navigations/lnb/type';
+import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
 
 export default {
     name: 'LNB',
     components: {
-        LNBMenuItem, PDivider, PI, PLazyImg,
+        LNBMenuItem, PDivider, PI, PLazyImg, PToggleButton,
     },
     props: {
         header: {
@@ -100,18 +117,29 @@ export default {
             type: Array as () => LNBMenu[],
             default: () => [],
         },
+        favoriteOnly: {
+            type: Boolean,
+            default: undefined,
+        },
     },
 
-    setup() {
+    setup(props, { emit }: SetupContext) {
         const vm = getCurrentInstance()?.proxy as Vue;
         const state = reactive({
             currentPath: computed(() => vm.$route.fullPath),
+            proxyFavoriteOnly: useProxyValue<boolean | undefined>('favoriteOnly', props, emit),
         });
+
+        const handleFavoriteToggle = () => {
+            state.proxyFavoriteOnly = !state.proxyFavoriteOnly;
+        };
 
         return {
             ...toRefs(state),
+            MENU_ITEM_TYPE,
             assetUrlConverter,
             getUUID,
+            handleFavoriteToggle,
         };
     },
 };
@@ -145,6 +173,11 @@ export default {
             @apply text-gray-800 cursor-pointer;
             text-decoration: underline;
         }
+    }
+    .favorite-only-wrapper {
+        @apply flex justify-between items-center text-gray-500;
+        font-size: 0.75rem;
+        padding: 0 0.5rem;
     }
     .top-title {
         @apply text-gray-800 font-bold flex justify-between items-center;

--- a/src/common/modules/navigations/lnb/modules/LNBMenuItem.vue
+++ b/src/common/modules/navigations/lnb/modules/LNBMenuItem.vue
@@ -9,7 +9,7 @@
             >
                 <span v-if="item.foldable"
                       class="title foldable"
-                      @click="handleToggle"
+                      @click="handleFoldableToggle"
                 >{{ item.label }}</span>
                 <span v-else
                       class="title"
@@ -21,7 +21,7 @@
                 <beta-mark v-if="item.isBeta" />
                 <span v-if="item.foldable"
                       class="toggle-button"
-                      @click="handleToggle"
+                      @click="handleFoldableToggle"
                 >
                     <p-i width="1rem"
                          height="1rem"
@@ -30,6 +30,12 @@
                     />
                 </span>
             </p>
+            <p v-if="item.type === MENU_ITEM_TYPE.TOP_TITLE"
+               class="top-title-wrapper"
+            >
+                <span class="top-title">{{ item.label }}</span>
+            </p>
+
             <div v-if="item.type === MENU_ITEM_TYPE.DIVIDER && showMenu"
                  class="divider"
             >
@@ -72,7 +78,7 @@
 </template>
 
 <script lang="ts">
-import type { PropType } from 'vue';
+import type { PropType, SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
@@ -87,6 +93,7 @@ import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
 
 import BetaMark from '@/common/components/marks/BetaMark.vue';
 import NewMark from '@/common/components/marks/NewMark.vue';
+import { useProxyValue } from '@/common/composables/proxy-state';
 import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteButton.vue';
 import type { LNBMenu } from '@/common/modules/navigations/lnb/type';
 import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
@@ -120,7 +127,7 @@ export default defineComponent<Props>({
         },
     },
 
-    setup(props) {
+    setup(props, { emit }: SetupContext) {
         const state = reactive({
             isDomainOwner: computed(() => store.getters['user/isDomainOwner']),
             processedMenuData: computed(() => (Array.isArray(props.menuData) ? props.menuData : [props.menuData])),
@@ -128,9 +135,10 @@ export default defineComponent<Props>({
             isFoldableMenu: computed(() => state.processedMenuData?.some((item) => item.foldable)),
             showMenu: computed(() => (state.isFoldableMenu && !state.isFolded) || !state.isFoldableMenu), // toggle menu
             hoveredItem: '',
+            proxyFavoriteOnly: useProxyValue('favoriteOnly', props, emit),
         });
 
-        const handleToggle = () => {
+        const handleFoldableToggle = () => {
             state.isFolded = !state.isFolded;
         };
 
@@ -147,7 +155,6 @@ export default defineComponent<Props>({
             let resolvedHref = resolved.href;
             if (!currentPath.endsWith('/')) currentPath += '/';
             if (!resolvedHref.endsWith('/')) resolvedHref += '/';
-
             return currentPath.startsWith(resolvedHref);
         };
 
@@ -155,7 +162,7 @@ export default defineComponent<Props>({
 
         return {
             ...toRefs(state),
-            handleToggle,
+            handleFoldableToggle,
             isSelectedMenu,
             FAVORITE_TYPE,
             MENU_ITEM_TYPE,
@@ -186,6 +193,14 @@ export default defineComponent<Props>({
                 @apply text-gray-800 cursor-pointer;
             }
         }
+    }
+    .top-title-wrapper {
+        @apply font-bold inline-flex items-center;
+        font-size: 0.75rem;
+        line-height: 125%;
+        padding-top: 1.25rem;
+        padding-left: 0.5rem;
+        padding-bottom: 0.75rem;
     }
     .menu-item {
         @apply border border-transparent inline-flex items-center w-full h-full justify-between;

--- a/src/common/modules/navigations/lnb/modules/LNBMenuItem.vue
+++ b/src/common/modules/navigations/lnb/modules/LNBMenuItem.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script lang="ts">
-import type { PropType, SetupContext } from 'vue';
+import type { PropType } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
@@ -93,7 +93,6 @@ import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
 
 import BetaMark from '@/common/components/marks/BetaMark.vue';
 import NewMark from '@/common/components/marks/NewMark.vue';
-import { useProxyValue } from '@/common/composables/proxy-state';
 import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteButton.vue';
 import type { LNBMenu } from '@/common/modules/navigations/lnb/type';
 import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
@@ -127,7 +126,7 @@ export default defineComponent<Props>({
         },
     },
 
-    setup(props, { emit }: SetupContext) {
+    setup(props) {
         const state = reactive({
             isDomainOwner: computed(() => store.getters['user/isDomainOwner']),
             processedMenuData: computed(() => (Array.isArray(props.menuData) ? props.menuData : [props.menuData])),
@@ -135,7 +134,6 @@ export default defineComponent<Props>({
             isFoldableMenu: computed(() => state.processedMenuData?.some((item) => item.foldable)),
             showMenu: computed(() => (state.isFoldableMenu && !state.isFolded) || !state.isFoldableMenu), // toggle menu
             hoveredItem: '',
-            proxyFavoriteOnly: useProxyValue('favoriteOnly', props, emit),
         });
 
         const handleFoldableToggle = () => {

--- a/src/common/modules/navigations/lnb/type.ts
+++ b/src/common/modules/navigations/lnb/type.ts
@@ -5,17 +5,19 @@ import type { FavoriteType } from '@/store/modules/favorite/type';
 
 import type { MenuId } from '@/lib/menu/config';
 
-export const MENU_ITEM_TYPE = Object.freeze({
+export const MENU_ITEM_TYPE = {
     TITLE: 'title',
+    TOP_TITLE: 'top-title',
     ITEM: 'item',
     DIVIDER: 'divider',
-} as const);
+    FAVORITE_ONLY: 'favorite-only',
+} as const;
 type MenuItemType = typeof MENU_ITEM_TYPE[keyof typeof MENU_ITEM_TYPE];
 
 export interface LNBItem {
     type: MenuItemType;
     label?: TranslateResult;
-    id?: MenuId;
+    id?: MenuId | string; // It can be change MenuId or etc.
     foldable?: boolean;
     to?: Location;
     isNew?: boolean;

--- a/src/services/dashboards/DashboardsContainer.vue
+++ b/src/services/dashboards/DashboardsContainer.vue
@@ -4,9 +4,8 @@
                               :breadcrumbs="breadcrumbs"
         >
             <template #sidebar>
-                <div />
+                <dashboards-l-n-b />
             </template>
-            <router-view />
         </vertical-page-layout>
         <general-page-layout v-else
                              :breadcrumbs="breadcrumbs"
@@ -21,9 +20,11 @@ import { useBreadcrumbs } from '@/common/composables/breadcrumbs';
 import GeneralPageLayout from '@/common/modules/page-layouts/GeneralPageLayout.vue';
 import VerticalPageLayout from '@/common/modules/page-layouts/VerticalPageLayout.vue';
 
+import DashboardsLNB from '@/services/dashboards/DashboardsLNB.vue';
+
 export default {
     name: 'DashboardsContainer',
-    components: { GeneralPageLayout, VerticalPageLayout },
+    components: { DashboardsLNB, GeneralPageLayout, VerticalPageLayout },
     setup() {
         const { breadcrumbs } = useBreadcrumbs();
         return {

--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -6,9 +6,11 @@
         <template #header>
             <div class="header-wrapper">
                 <span>{{ header }}</span>
-                <p-icon-button name="ic_plus_bold"
-                               size="sm"
-                />
+                <router-link :to="{ name: DASHBOARDS_ROUTE.CREATE._NAME, path: DASHBOARDS_ROUTE.CREATE._NAME }">
+                    <p-icon-button name="ic_plus_bold"
+                                   size="sm"
+                    />
+                </router-link>
             </div>
         </template>
     </l-n-b>
@@ -93,7 +95,7 @@ export default {
             menuSet: computed<LNBMenu[]>(() => [
                 {
                     type: 'item',
-                    label: 'View All Dashboards',
+                    label: 'View All Dashboards', // song-lang
                     id: MENU_ID.DASHBOARDS,
                     foldable: false,
                     to: { name: DASHBOARDS_ROUTE.ALL._NAME },
@@ -120,6 +122,7 @@ export default {
 
         return {
             ...toRefs(state),
+            DASHBOARDS_ROUTE,
         };
     },
 };

--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -1,7 +1,7 @@
 <template>
     <l-n-b class="dashboards-lnb"
            :menu-set="menuSet"
-           :favorite-only.sync="favoriteOnly"
+           :show-favorite-only.sync="showFavoriteOnly"
     >
         <template #header>
             <div class="header-wrapper">
@@ -18,7 +18,7 @@
 
 <script lang="ts">
 import {
-    computed, reactive, toRefs,
+    computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
 import { PIconButton } from '@spaceone/design-system';
@@ -38,13 +38,13 @@ import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
 
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
-export default {
+export default defineComponent({
     name: 'DashboardsLNB',
     components: { LNB, PIconButton },
     setup() {
         const state = reactive({
             loading: true,
-            favoriteOnly: false,
+            showFavoriteOnly: false,
             header: computed(() => i18n.t(MENU_INFO_MAP[MENU_ID.DASHBOARDS].translationId)),
             favoriteItemMap: computed(() => {
                 const stateName = FAVORITE_TYPE_TO_STATE_NAME[FAVORITE_TYPE.MENU];
@@ -64,8 +64,9 @@ export default {
                     type: 'item', id: 'Budget Summary', label: 'Budget Summary', to: { name: DASHBOARDS_ROUTE.DETAIL._NAME, params: { dashboardId: 'work_02' } },
                 },
             ])),
-            projectMenuSet: computed<LNBMenu[]>(() => (
-                [
+            projectMenuSet: computed<LNBItem[][]>(() => {
+                const result = [] as LNBItem[][];
+                const projects: LNBItem[][] = [
                     [{
                         type: 'title',
                         label: 'Project_01',
@@ -90,8 +91,12 @@ export default {
                     {
                         type: 'item', id: 'Project_02_Dashboard2', label: 'Project_02_Dashboard2', to: { name: DASHBOARDS_ROUTE.DETAIL._NAME, params: { dashboardId: 'project_02_2' } },
                     }],
-                ]
-            )),
+                ];
+                projects.forEach((d) => {
+                    result.push(filterFavoriteItems(d));
+                });
+                return result;
+            }),
             menuSet: computed<LNBMenu[]>(() => [
                 {
                     type: 'item',
@@ -110,14 +115,8 @@ export default {
         });
 
         const filterFavoriteItems = (menuItems: LNBItem[] = []) => {
-            if (!state.favoriteOnly) return menuItems;
-            const result = [] as LNBItem[];
-            menuItems.forEach((d) => {
-                if (d.id && state.favoriteItemMap[d.id] || d.type !== MENU_ITEM_TYPE.ITEM) {
-                    result.push(d);
-                }
-            });
-            return result;
+            if (!state.showFavoriteOnly) return menuItems;
+            return menuItems.filter((d) => (d.id && state.favoriteItemMap[d.id]) || d.type !== MENU_ITEM_TYPE.ITEM);
         };
 
         return {
@@ -125,7 +124,7 @@ export default {
             DASHBOARDS_ROUTE,
         };
     },
-};
+});
 </script>
 
 <style lang="postcss" scoped>

--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -1,0 +1,135 @@
+<template>
+    <l-n-b class="dashboards-lnb"
+           :menu-set="menuSet"
+           :favorite-only.sync="favoriteOnly"
+    >
+        <template #header>
+            <div class="header-wrapper">
+                <span>{{ header }}</span>
+                <p-icon-button name="ic_plus_bold"
+                               size="sm"
+                />
+            </div>
+        </template>
+    </l-n-b>
+</template>
+
+<script lang="ts">
+import {
+    computed, reactive, toRefs,
+} from 'vue';
+
+import { PIconButton } from '@spaceone/design-system';
+
+import { store } from '@/store';
+import { i18n } from '@/translations';
+
+import type { FavoriteConfig } from '@/store/modules/favorite/type';
+import { FAVORITE_TYPE, FAVORITE_TYPE_TO_STATE_NAME } from '@/store/modules/favorite/type';
+
+import { MENU_ID } from '@/lib/menu/config';
+import { MENU_INFO_MAP } from '@/lib/menu/menu-info';
+
+import LNB from '@/common/modules/navigations/lnb/LNB.vue';
+import type { LNBItem, LNBMenu } from '@/common/modules/navigations/lnb/type';
+import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
+
+import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
+
+export default {
+    name: 'DashboardsLNB',
+    components: { LNB, PIconButton },
+    setup() {
+        const state = reactive({
+            loading: true,
+            favoriteOnly: false,
+            header: computed(() => i18n.t(MENU_INFO_MAP[MENU_ID.DASHBOARDS].translationId)),
+            favoriteItemMap: computed(() => {
+                const stateName = FAVORITE_TYPE_TO_STATE_NAME[FAVORITE_TYPE.MENU];
+                const result: Record<string, FavoriteConfig> = {};
+                if (stateName) {
+                    store.state.favorite[stateName]?.forEach((d) => {
+                        result[d.itemId] = d;
+                    });
+                }
+                return result;
+            }),
+            workSpaceMenuSet: computed<LNBItem[]>(() => ([
+                {
+                    type: 'item', id: 'Menu Item', label: 'Menu Item', to: { name: DASHBOARDS_ROUTE.DETAIL._NAME, params: { dashboardId: 'work_01' } },
+                },
+                {
+                    type: 'item', id: 'Budget Summary', label: 'Budget Summary', to: { name: DASHBOARDS_ROUTE.DETAIL._NAME, params: { dashboardId: 'work_02' } },
+                },
+            ])),
+            projectMenuSet: computed<LNBMenu[]>(() => (
+                [
+                    [{
+                        type: 'title',
+                        label: 'Project_01',
+                        id: 'Project_01',
+                        foldable: true,
+                    },
+                    {
+                        type: 'item', id: 'Project_01_Dashboard', label: 'Project_01_Dashboard', to: { name: DASHBOARDS_ROUTE.DETAIL._NAME, params: { dashboardId: 'project_01_1' } },
+                    },
+                    {
+                        type: 'item', id: 'Project_01_Dashboard2', label: 'Project_01_Dashboard2', to: { name: DASHBOARDS_ROUTE.DETAIL._NAME, params: { dashboardId: 'project_01_2' } },
+                    }],
+                    [{
+                        type: 'title',
+                        label: 'Project_02',
+                        id: 'Project_02',
+                        foldable: true,
+                    },
+                    {
+                        type: 'item', id: 'Project_02_Dashboard', label: 'Project_02_Dashboard', to: { name: DASHBOARDS_ROUTE.DETAIL._NAME, params: { dashboardId: 'project_02_1' } },
+                    },
+                    {
+                        type: 'item', id: 'Project_02_Dashboard2', label: 'Project_02_Dashboard2', to: { name: DASHBOARDS_ROUTE.DETAIL._NAME, params: { dashboardId: 'project_02_2' } },
+                    }],
+                ]
+            )),
+            menuSet: computed<LNBMenu[]>(() => [
+                {
+                    type: 'item',
+                    label: 'View All Dashboards',
+                    id: MENU_ID.DASHBOARDS,
+                    foldable: false,
+                    to: { name: DASHBOARDS_ROUTE.ALL._NAME },
+                },
+                { type: 'divider' },
+                { type: 'favorite-only' },
+                { type: 'top-title', label: 'Workspace' },
+                ...filterFavoriteItems(state.workSpaceMenuSet),
+                { type: 'top-title', label: 'Project' },
+                ...filterFavoriteItems(state.projectMenuSet),
+            ]),
+        });
+
+        const filterFavoriteItems = (menuItems: LNBItem[] = []) => {
+            if (!state.favoriteOnly) return menuItems;
+            const result = [] as LNBItem[];
+            menuItems.forEach((d) => {
+                if (d.id && state.favoriteItemMap[d.id] || d.type !== MENU_ITEM_TYPE.ITEM) {
+                    result.push(d);
+                }
+            });
+            return result;
+        };
+
+        return {
+            ...toRefs(state),
+        };
+    },
+};
+</script>
+
+<style lang="postcss" scoped>
+.dashboards-lnb {
+    .header-wrapper {
+        @apply flex justify-between items-center font-bold;
+        padding-right: 1.25rem;
+    }
+}
+</style>

--- a/src/services/dashboards/route-config.ts
+++ b/src/services/dashboards/route-config.ts
@@ -2,6 +2,9 @@ import { MENU_ID } from '@/lib/menu/config';
 
 export const DASHBOARDS_ROUTE = Object.freeze({
     _NAME: MENU_ID.DASHBOARDS,
+    ALL: {
+        _NAME: `${MENU_ID.DASHBOARDS}.all`,
+    },
     DETAIL: {
         _NAME: `${MENU_ID.DASHBOARDS}.detail`,
     },

--- a/src/services/dashboards/routes.ts
+++ b/src/services/dashboards/routes.ts
@@ -10,30 +10,38 @@ const DashboardDetailPage = () => import('@/services/dashboards/dashboard-detail
 
 const dashboardsRoute: RouteConfig = {
     path: 'dashboards',
+    name: DASHBOARDS_ROUTE._NAME,
     component: DashboardsContainer,
     children: [
         {
             path: '/',
-            name: DASHBOARDS_ROUTE._NAME,
-            meta: { lnbVisible: true },
-            component: AllDashboardsPage,
+            component: { template: '<router-view/>' },
+            children: [
+                {
+                    path: 'all',
+                    name: DASHBOARDS_ROUTE.ALL._NAME,
+                    meta: { lnbVisible: true },
+                    component: AllDashboardsPage,
+                },
+                {
+                    path: 'create',
+                    name: DASHBOARDS_ROUTE.CREATE._NAME,
+                    component: DashboardCreatePage,
+                },
+                {
+                    path: ':dashboardId',
+                    name: DASHBOARDS_ROUTE.DETAIL._NAME,
+                    meta: { lnbVisible: true },
+                    component: DashboardDetailPage,
+                },
+                {
+                    path: ':dashboardId/edit',
+                    name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME,
+                    component: DashboardCustomizePage,
+                },
+            ],
         },
-        {
-            path: 'create',
-            name: DASHBOARDS_ROUTE.CREATE._NAME,
-            component: DashboardCreatePage,
-        },
-        {
-            path: ':dashboardId',
-            name: DASHBOARDS_ROUTE.DETAIL._NAME,
-            meta: { lnbVisible: true },
-            component: DashboardDetailPage,
-        },
-        {
-            path: ':dashboardId/edit',
-            name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME,
-            component: DashboardCustomizePage,
-        },
+
     ],
 };
 

--- a/src/services/dashboards/routes.ts
+++ b/src/services/dashboards/routes.ts
@@ -11,6 +11,7 @@ const DashboardDetailPage = () => import('@/services/dashboards/dashboard-detail
 const dashboardsRoute: RouteConfig = {
     path: 'dashboards',
     name: DASHBOARDS_ROUTE._NAME,
+    redirect: () => ({ name: DASHBOARDS_ROUTE.ALL._NAME }),
     component: DashboardsContainer,
     children: [
         {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
Dashboards LNB 마크업 작업
- LNB의 `MENU_ITEM_TYPE`에 `top-title`과 `favorite-only`가 추가되었습니다.
- Top-title 이 한번 이상 사용됨에 따라 메뉴 타입에 추가되었으나, 현 Dashboards LNB에만 우선 적용되었습니다.
(다른 LNB에서는 차근차근 리펙토링이 필요합니다.)
- LNB의 `header` 도 아이콘이 추가됨에 따라 변경이 필요합니다. 현재는 `slot`으로 임시 작업해놓았고 추가 작업예정입니다.
- Favorite only toggle이 LNB에 추가되었습니다. 쨴님이 앞으로 _"비슷한 토글이 다른 목적으로 추가되거나 여러개가 추가될 수 있다"_ 가능성을 내비치셔서 `LNBMenuItem`의 스펙으로 추가하진 않았습니다.

![image](https://user-images.githubusercontent.com/83635051/200981932-4c431734-dddb-43cb-98aa-cc706c5d6d25.png)


Dashboards All page에 해당하는 path가 변경되었습니다. `/dashboards` => `/dashboards/all`

**`GNBDashboardFavorite`, `GNBDashboardMenu` 파일은 무시하셔도 됩니다.**
