### PR TITLE
fix(dashboard-create): fix wrong naming, types on dashboardScopeForm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27411,7 +27411,7 @@
         "@amcharts/amcharts4": "^4.10.10",
         "@amcharts/amcharts4-geodata": "^4.1.18",
         "@amcharts/amcharts5": "^5.2.31",
-        "@amcharts/amcharts5-geodata": "*",
+        "@amcharts/amcharts5-geodata": "^5.0.6",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/preset-env": "^7.19.1",
         "@cloudforet/core-lib": "file:packages/cloudforet/core-lib",

--- a/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -25,6 +25,7 @@ import DashboardScopeForm from '@/services/dashboards/dashboard-create/modules/D
 import DashboardTemplateForm from '@/services/dashboards/dashboard-create/modules/DashboardTemplateForm.vue';
 import DashboardViewerForm from '@/services/dashboards/dashboard-create/modules/DashboardViewerForm.vue';
 import type { DashboardScope } from '@/services/dashboards/dashboard-create/type';
+import type { ProjectItemResp } from '@/services/project/type';
 
 export default {
     name: 'CreateDashboardPage',
@@ -37,7 +38,7 @@ export default {
     setup() {
         const state = reactive({
             scope: undefined as undefined|DashboardScope,
-            project: [] as Array<string>,
+            project: undefined as undefined|ProjectItemResp,
         });
 
         return { ...toRefs(state) };

--- a/src/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue
@@ -20,7 +20,7 @@
                 </p-radio-group>
                 <project-select-dropdown v-show="!isEntireScope"
                                          project-selectable
-                                         @select="handleSelectProject"
+                                         @select="handleSelectProjects"
                 />
             </div>
         </p-pane-layout>
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts">
-import type { PropType, SetupContext } from 'vue';
+import type { SetupContext } from 'vue';
 import { defineComponent, reactive, toRefs } from 'vue';
 
 import {
@@ -41,6 +41,7 @@ import ProjectSelectDropdown from '@/common/modules/project/ProjectSelectDropdow
 
 import { DASHBOARD_ENTIRE_SCOPE, DASHBOARD_SINGLE_SCOPE } from '@/services/dashboards/dashboard-create/config';
 import type { DashboardScope } from '@/services/dashboards/dashboard-create/type';
+import type { ProjectItemResp } from '@/services/project/type';
 
 export default defineComponent({
     name: 'DashboardScopeForm',
@@ -50,16 +51,6 @@ export default defineComponent({
         PRadio,
         PPanelTop,
         PPaneLayout,
-    },
-    props: {
-        scope: {
-            type: String as PropType<DashboardScope>,
-            default: undefined,
-        },
-        project: {
-            type: Array as PropType<Array<string>>,
-            default: () => [],
-        },
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
@@ -71,8 +62,9 @@ export default defineComponent({
             emit('update:scope', scopeType);
         };
 
-        const handleSelectProject = (project: Array<string>) => {
-            emit('update:project', project);
+        const handleSelectProjects = (projects: Array<ProjectItemResp>) => {
+            // Emit projects as project.
+            emit('update:project', projects[0]);
         };
 
         // LOAD REFERENCE STORE
@@ -83,7 +75,7 @@ export default defineComponent({
         return {
             ...toRefs(state),
             handleSelectScope,
-            handleSelectProject,
+            handleSelectProjects,
             DASHBOARD_ENTIRE_SCOPE,
             DASHBOARD_SINGLE_SCOPE,
         };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용

Continues https://github.com/cloudforet-io/console/pull/295#discussion_r1018582432

네이밍 컨벤션이 맞지 않은 부분 수정하였습니다.
또한 잘못된 project-select-dropdown 에서 emit 되는 type 을 수정하였습니다. (`Array<string>` -> `Array<ProjectItemResp>`)

dashboard-create-page(project) <-> dashboard-scope-form(emit 시 projects를 project로 컨버팅) <-> project-select-dropdown(projects)



### 생각해볼 문제
