### PR TITLE
feat(dashboard-menu): add recent Tab markups & fix markup

### DIFF
--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue
@@ -5,16 +5,20 @@
         :to="to"
     >
         <div class="gnb-sub-contents">
-            <p-i v-if="isDraggable"
-                 name="ic_drag-handle--slim"
-                 width="1rem"
-                 height="1rem"
-                 class="drag-icon"
-            />
-            <span>{{ label }}</span>
-            <beta-mark v-if="isBeta" />
-            <new-mark v-if="isNew" />
-            <slot name="extra-mark" />
+            <div class="contents-left">
+                <p-i v-if="isDraggable"
+                     name="ic_drag-handle--slim"
+                     width="1rem"
+                     height="1rem"
+                     class="drag-icon"
+                />
+                <span>{{ label }}</span>
+                <beta-mark v-if="isBeta" />
+                <new-mark v-if="isNew" />
+            </div>
+            <div class="contents-right">
+                <slot name="extra-mark" />
+            </div>
         </div>
     </router-link>
 </template>
@@ -63,7 +67,7 @@ export default {
 <style lang="postcss" scoped>
 .gnb-sub-menu {
     .gnb-sub-contents {
-        @apply text-gray-900 rounded;
+        @apply text-gray-900 rounded flex items-center justify-between;
         position: relative;
         width: 100%;
         height: 2rem;

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue
@@ -1,40 +1,48 @@
 <template>
-    <router-link
-        v-if="show"
-        class="gnb-sub-menu"
-        :to="to"
+    <p-tooltip :contents="label"
+               position="bottom"
     >
-        <div class="gnb-sub-contents">
-            <div class="contents-left">
-                <p-i v-if="isDraggable"
-                     name="ic_drag-handle--slim"
-                     width="1rem"
-                     height="1rem"
-                     class="drag-icon"
-                />
-                <span>{{ label }}</span>
-                <beta-mark v-if="isBeta" />
-                <new-mark v-if="isNew" />
+        <router-link
+            v-if="show"
+            class="gnb-sub-menu"
+            :to="to"
+        >
+            <div class="gnb-sub-contents">
+                <div class="contents-left">
+                    <p-i v-if="isDraggable"
+                         name="ic_drag-handle--slim"
+                         width="1rem"
+                         height="1rem"
+                         class="drag-icon"
+                    />
+                    <div class="label">
+                        {{ label }}
+                    </div>
+                    <beta-mark v-if="isBeta" />
+                    <new-mark v-if="isNew" />
+                </div>
+                <div class="contents-right">
+                    <slot name="extra-mark" />
+                </div>
             </div>
-            <div class="contents-right">
-                <slot name="extra-mark" />
-            </div>
-        </div>
-    </router-link>
+        </router-link>
+    </p-tooltip>
 </template>
 
 <script lang="ts">
 import type { PropType } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { PI } from '@spaceone/design-system';
+import { PI, PTooltip } from '@spaceone/design-system';
 
 import BetaMark from '@/common/components/marks/BetaMark.vue';
 import NewMark from '@/common/components/marks/NewMark.vue';
 
 export default {
     name: 'GNBSubMenu',
-    components: { NewMark, BetaMark, PI },
+    components: {
+        NewMark, BetaMark, PI, PTooltip,
+    },
     props: {
         show: {
             type: Boolean,
@@ -86,6 +94,15 @@ export default {
         }
         &:active {
             @apply bg-white;
+        }
+
+        .contents-left {
+            @apply flex items-center;
+            width: 80%;
+            .label {
+                @apply truncate;
+                display: inline-block;
+            }
         }
     }
 }

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -180,7 +180,7 @@ export default {
 <style lang="postcss" scoped>
 .gnb-dashboard-favorite {
     .gnb-dashboard-favorite-context {
-        max-height: 39rem;
+        max-height: 85vh;
         overflow-y: scroll;
     }
 

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -26,25 +26,12 @@
             <template #no-data>
                 <div class="no-data">
                     <img class="img"
-                         src="@/assets/images/illust_star.svg"
+                         src="@/assets/images/illust_jellyocto-with-a-telescope.svg"
                     >
                     <p class="text">
-                        {{ $t('COMMON.GNB.FAVORITES.FAVORITES_HELP_TEXT') }}
+                        <!--song-lang-->
+                        {{ $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.NO_ITEMS') }}
                     </p>
-                    <div class="button-wrapper">
-                        <p-button style-type="tertiary"
-                                  size="md"
-                                  @click="handleClickMenuButton(FAVORITE_TYPE.PROJECT)"
-                        >
-                            {{ $t('COMMON.GNB.FAVORITES.GO_TO_PROJECT') }}
-                        </p-button>
-                        <p-button style-type="tertiary"
-                                  size="md"
-                                  @click="handleClickMenuButton(FAVORITE_TYPE.CLOUD_SERVICE)"
-                        >
-                            {{ $t('COMMON.GNB.FAVORITES.GO_TO_CLOUD_SERVICE') }}
-                        </p-button>
-                    </div>
                 </div>
             </template>
         </p-data-loader>
@@ -56,9 +43,7 @@ import type { SetupContext } from 'vue';
 import { reactive, toRefs } from 'vue';
 import draggable from 'vuedraggable';
 
-import {
-    PButton, PDataLoader,
-} from '@spaceone/design-system';
+import { PDataLoader } from '@spaceone/design-system';
 
 import { SpaceRouter } from '@/router';
 
@@ -81,7 +66,6 @@ export default {
         FavoriteButton,
         GNBSubMenu,
         PDataLoader,
-        PButton,
         draggable,
     },
     props: {},

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -197,9 +197,9 @@ export default {
     }
     .no-data {
         text-align: center;
-        padding: 3rem 3.25rem;
+        padding: 1.875rem 3.25rem;
         .img {
-            margin: auto;
+            margin-bottom: 0.9375rem;
         }
         .text {
             @apply text-gray-400;

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
@@ -98,7 +98,7 @@ export default defineComponent({
         @apply absolute bg-white rounded-xs border border-gray-200;
         display: flex;
         flex-direction: column;
-        width: 27.5rem;
+        width: 22.5rem;
         min-height: auto;
         top: 100%;
         right: 0;

--- a/src/store/modules/recent/index.ts
+++ b/src/store/modules/recent/index.ts
@@ -10,6 +10,7 @@ const state: Required<RecentState> = {
     projectItems: [],
     projectGroupItems: [],
     cloudServiceItems: [],
+    dashboardItems: [],
 };
 
 export default {

--- a/src/store/modules/recent/type.ts
+++ b/src/store/modules/recent/type.ts
@@ -5,6 +5,7 @@ export const RECENT_TYPE = Object.freeze({
     CLOUD_SERVICE: 'CLOUD_SERVICE',
     PROJECT: 'PROJECT',
     PROJECT_GROUP: 'PROJECT_GROUP',
+    DASHBOARD: 'DASHBOARD',
 } as const);
 export type RecentType = typeof RECENT_TYPE[keyof typeof RECENT_TYPE];
 
@@ -16,7 +17,7 @@ export interface RecentConfig {
 
 export interface RecentItem extends RecentConfig {
     name?: string;
-    label?: TranslateResult;
+    label?: TranslateResult | string;
     icon?: string;
     provider?: string;
     parents?: { name?: string; label?: TranslateResult }[];
@@ -28,4 +29,5 @@ export interface RecentState {
     projectItems: RecentItem[];
     projectGroupItems: RecentItem[];
     cloudServiceItems: RecentItem[];
+    dashboardItems: RecentItem[];
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
메인 작업은 recent Tab 구현입니다. (+ 추가로 자잘하게 수정된 부분들이 있습니다)
- favoriteTab 수정사항
    - favoriteTab에 no-item의 경우를 추가했습니다.(이전에 누락된 작업)
- GNBSubMenu 수정사항
    - GNBSubMenu에서 favorite버튼의 위치수정 (이전에 누락된 작업)
    - GNBSubMenu에서 label이 사이즈를 넘어갈 경우에대한 처리 (truncate + tooltip)
- recentTab 구현사항
    - recentStore에 Dashboard 기본값 추가
    - recentTab markup 작업

![image](https://user-images.githubusercontent.com/50662170/201040662-30be9389-3316-4965-afde-fcbc7cbff512.png)

### 생각해볼 문제
기존 recentFavorite에서 사용된 컴포넌트의 경우 search와 함께 사용하는 컴포넌트로 무겁기도하며 디자인도 달라 재활용하지 않고, dashboard를 위한 메뉴를 생성했습니다.