### PR TITLE
feat: add empty widget components, configs, and get helpers

### DIFF
--- a/src/services/dashboards/widgets/_base/base-horizontal/BaseHorizontalWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-horizontal/BaseHorizontalWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'BaseHorizontalWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/_base/base-horizontal/widget-config.ts
+++ b/src/services/dashboards/widgets/_base/base-horizontal/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/_base/base-map/BasePieWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-map/BasePieWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'BasePieWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/_base/base-map/widget-config.ts
+++ b/src/services/dashboards/widgets/_base/base-map/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/_base/base-pie/BaseMapWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-pie/BaseMapWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'BaseMapWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/_base/base-pie/widget-config.ts
+++ b/src/services/dashboards/widgets/_base/base-pie/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/_base/base-region/BaseRegionWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-region/BaseRegionWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'BaseRegionWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/_base/base-region/widget-config.ts
+++ b/src/services/dashboards/widgets/_base/base-region/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'BaseTrendWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/_base/base-trend/widget-config.ts
+++ b/src/services/dashboards/widgets/_base/base-trend/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/aws-cloud-front-cost/widget-config.ts
+++ b/src/services/dashboards/widgets/aws-cloud-front-cost/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/aws-data-transfer-by-region/widget-config.ts
+++ b/src/services/dashboards/widgets/aws-data-transfer-by-region/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/aws-data-transfer-cost-trend/widget-config.ts
+++ b/src/services/dashboards/widgets/aws-data-transfer-cost-trend/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/budget-status/BudgetStatusWidget.vue
+++ b/src/services/dashboards/widgets/budget-status/BudgetStatusWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'BudgetStatusWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/budget-status/widget-config.ts
+++ b/src/services/dashboards/widgets/budget-status/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
+++ b/src/services/dashboards/widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'BudgetUsageSummaryWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/budget-usage-summary/widget-config.ts
+++ b/src/services/dashboards/widgets/budget-usage-summary/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/budget-usage-with-forecast/BudgetUsageSummaryWidget.vue
+++ b/src/services/dashboards/widgets/budget-usage-with-forecast/BudgetUsageSummaryWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'BudgetUsageSummaryWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/budget-usage-with-forecast/widget-config.ts
+++ b/src/services/dashboards/widgets/budget-usage-with-forecast/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/config.ts
+++ b/src/services/dashboards/widgets/config.ts
@@ -1,0 +1,60 @@
+// base widgets
+import baseHorizontal from './_base/base-horizontal/widget-config';
+import baseMap from './_base/base-map/widget-config';
+import basePie from './_base/base-pie/widget-config';
+import baseRegion from './_base/base-region/widget-config';
+import baseTrend from './_base/base-trend/widget-config';
+// console widgets
+import awsCloudFrontCost from './aws-cloud-front-cost/widget-config';
+import awsDataTransferByRegion from './aws-data-transfer-by-region/widget-config';
+import awsDataTransferCostTrend from './aws-data-transfer-cost-trend/widget-config';
+import budgetStatus from './budget-status/widget-config';
+import budgetUsageSummary from './budget-usage-summary/widget-config';
+import budgetUsageWithForecast from './budget-usage-with-forecast/widget-config';
+import costByRegion from './cost-by-region/widget-config';
+import costDonut from './cost-donut/widget-config';
+import costMap from './cost-map/widget-config';
+import costPie from './cost-pie/widget-config';
+import costTrendStacked from './cost-trend-stacked/widget-config';
+import costTrend from './cost-trend/widget-config';
+import monthlyCost from './monthly-cost/widget-config';
+
+export const CONSOLE_WIDGET_ORDER = [
+    'monthlyCost',
+    'budgetUsageSummary',
+    'costMap',
+    'costTrend',
+    'awsDataTransferCostTrend',
+    'costTrendStacked',
+    'awsCloudFrontCost',
+    'costDonut',
+    'costByRegion',
+    'awsDataTransferByRegion',
+    'budgetStatus',
+    'budgetUsageWithForecast',
+    'costPie',
+];
+
+export const CONSOLE_WIDGET_CONFIGS = {
+    monthlyCost,
+    budgetUsageSummary,
+    costMap,
+    costTrend,
+    awsDataTransferCostTrend,
+    costTrendStacked,
+    awsCloudFrontCost,
+    costDonut,
+    costByRegion,
+    awsDataTransferByRegion,
+    budgetStatus,
+    budgetUsageWithForecast,
+    costPie,
+};
+
+export const BASE_WIDGET_CONFIGS = {
+    baseTrend,
+    baseRegion,
+    baseHorizontal,
+    basePie,
+    baseMap,
+};

--- a/src/services/dashboards/widgets/cost-by-region/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-by-region/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/cost-donut/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-donut/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
+++ b/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'CostMapWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/cost-map/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-map/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/cost-pie/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-pie/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/cost-trend-stacked/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-trend-stacked/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/cost-trend/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-trend/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/helper.ts
+++ b/src/services/dashboards/widgets/helper.ts
@@ -1,0 +1,28 @@
+import type { AsyncComponent } from 'vue';
+import type { ImportedComponent } from 'vue/types/options';
+
+import { kebabCase, merge, startCase } from 'lodash';
+
+import { BASE_WIDGET_CONFIGS, CONSOLE_WIDGET_CONFIGS } from '@/services/dashboards/widgets/config';
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+const widgetConfigCacheMap = {};
+export const getWidgetConfig = (widgetName: string): WidgetConfig => {
+    const config = CONSOLE_WIDGET_CONFIGS[widgetName];
+    if (!config?.base_widget_name) return config;
+
+    if (!widgetConfigCacheMap[widgetName]) {
+        const baseWidgetName = config?.base_widget_name;
+        widgetConfigCacheMap[widgetName] = merge({}, BASE_WIDGET_CONFIGS[baseWidgetName], config);
+    }
+    return widgetConfigCacheMap[widgetName];
+};
+
+export const getWidgetComponent = (widgetName: string): AsyncComponent => {
+    const config = getWidgetConfig(widgetName);
+    const baseWidgetName = config?.base_widget_name;
+    const componentName = baseWidgetName ?? widgetName;
+    return () => ({
+        component: import(`./${baseWidgetName ? '_base/' : ''}${kebabCase(componentName)}/${startCase(componentName)}Widget.vue`) as Promise<ImportedComponent>,
+    });
+};

--- a/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
+++ b/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
@@ -1,0 +1,26 @@
+<template>
+    <div />
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs,
+} from 'vue';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Props {
+}
+
+export default defineComponent<Props>({
+    name: 'MonthlyCostWidget',
+    components: {},
+    props: {},
+    setup() {
+        const state = reactive({});
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/monthly-cost/widget-config.ts
+++ b/src/services/dashboards/widgets/monthly-cost/widget-config.ts
@@ -1,0 +1,3 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/type';
+
+export default {} as WidgetConfig;

--- a/src/services/dashboards/widgets/type.ts
+++ b/src/services/dashboards/widgets/type.ts
@@ -1,0 +1,69 @@
+import type { DynamicField } from '@spaceone/design-system/dist/src/data-display/dynamic/dynamic-field/type/field-schema';
+import type { DynamicWidgetType } from '@spaceone/design-system/src/data-display/dynamic/dynamic-widget/type';
+
+import type { QueryStoreFilter } from '@cloudforet/core-lib/query/type';
+
+import type { Currency } from '@/store/modules/display/config';
+
+import type { WidgetSize } from '@/common/components/widgets/type';
+
+import type { GRANULARITY } from '@/services/cost-explorer/lib/config';
+
+export interface WidgetConfig {
+    widget_name: string; // unique name
+    title: string;
+    labels: string[];
+
+    description?: {
+        translation_id?: string;
+        preview_image?: string;
+        chart_type?: string;
+    };
+    scopes: Array<'DOMAIN'|'WORKSPACE'|'PROJECT'>;
+
+    theme: {
+        inherit?: boolean;
+        inherit_count?: number;
+    };
+    link?: WidgetLink;
+
+    sizes: WidgetSize[];
+    widget_options_schema: object;
+
+    base_widget_name?: string;
+    widget_options: WidgetOptions;
+}
+
+interface WidgetLink {
+    enabled?: boolean;
+    external?: boolean;
+    location: Location; // Vue Router spec
+}
+type Dictionary<T> = { [key: string]: T };
+interface Location {
+    name?: string;
+    path?: string;
+    hash?: string;
+    query?: Dictionary<string | (string | null)[] | null | undefined>;
+    params?: Dictionary<string>;
+    version: string;
+}
+
+type Granularity = typeof GRANULARITY[keyof typeof GRANULARITY];
+interface WidgetOptions {
+    currency?: Currency;
+    date_range?: { start: string; end?: string; };
+    stack?: boolean;
+    granularity?: Granularity;
+    enable_legends: boolean;
+    dynamic_widget_type?: DynamicWidgetType;
+    group_by?: string[];
+    datetime_range?: { start: string; end?: string; };
+    page?: { start?: number; limit: number; };
+    sort?: Array<{ key: string; desc: boolean; }>;
+    field?: { string: { key?: string; operator: string; } };
+    field_options?: Record<string, DynamicField>;
+    // value_options?: DynamicField;
+    // name_options?: DynamicField;
+    filter?: QueryStoreFilter[];
+}


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- cost widget 들을 추가하였습니다. 
- 위젯 디렉토리 구조를 잡았습니다.
  
<img width="338" alt="image" src="https://user-images.githubusercontent.com/26986739/201043091-a2e72787-a594-489c-82b3-9ab614c580f4.png">

- get widget config, get widget component helper를 추가하였습니다.

### 생각해볼 문제

- base component들을 가장 상단에 두기 위해 `_base` 디렉토리 안에 두었습니다. 다른 의견이 있으시면 알려주세요!
- widget config, widget type을 추가하였습니다. 아직 미정인 내용들도 있으므로 참고만 해주세요.
