### PR TITLE
feat(dashboard-menu-api): apply api for gnb dashboard menu

### DIFF
--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -46,6 +46,7 @@ import draggable from 'vuedraggable';
 import { PDataLoader } from '@spaceone/design-system';
 
 import { SpaceRouter } from '@/router';
+import { store } from '@/store';
 
 import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
 
@@ -73,66 +74,14 @@ export default {
         const state = reactive({
             loading: true,
             items: [
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard1', name: '1',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard2', name: '2',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard3', name: '3',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard4', name: '4',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard5', name: '5',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard6', name: '6',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard7', name: '7',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard8', name: '8',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard9', name: '9',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard10', name: '10',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard11', name: '11',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard12', name: '12',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard13', name: '13',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard14', name: '14',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard15', name: '15',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard16', name: '16',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard17', name: '17',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard18', name: '18',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard19', name: '19',
-                },
-                {
-                    show: true, to: { name: DASHBOARDS_ROUTE.ALL._NAME }, label: 'dashboard20', name: '20',
-                },
+                { label: 'dashboard1', name: '1' },
+                { label: 'dashboard2', name: '2' },
+                { label: 'dashboard3', name: '3' },
+                { label: 'dashboard4', name: '4' },
+                { label: 'dashboard5', name: '5' },
+                { label: 'dashboard6', name: '6' },
+                { label: 'dashboard7', name: '7' },
+                { label: 'dashboard8', name: '8' },
             ],
         });
 
@@ -161,6 +110,7 @@ export default {
         (async () => {
             state.loading = true;
             await Promise.allSettled([
+                store.dispatch('favorite/load', FAVORITE_TYPE.DASHBOARD),
             ]);
             state.loading = false;
         })();

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -112,12 +112,17 @@ export default {
             favoriteOrderList: [] as string[],
             sortedFavoriteList: computed<FavoriteItem[]>({
                 get: () => {
+                    const nonExistentOrderList: FavoriteItem[] = [];
                     const sortedList: FavoriteItem[] = [];
                     state.favoriteOrderList.forEach((dashboardId) => {
                         const favoriteItem = (state.favoriteDashboardList ?? []).filter((favorite) => favorite.itemId === dashboardId);
                         if (favoriteItem.length > 0) sortedList.push(favoriteItem[0]);
                     });
-                    return sortedList;
+                    state.favoriteDashboardList.forEach((item) => {
+                        const itemId = state.favoriteOrderList.find((id) => item.itemId === id);
+                        if (!itemId) nonExistentOrderList.push(item);
+                    });
+                    return [...nonExistentOrderList, ...sortedList];
                 },
                 set: (value) => {
                     state.favoriteOrderList = value.map((favorite) => favorite.itemId);

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -115,8 +115,8 @@ export default {
                     const nonExistentOrderList: FavoriteItem[] = [];
                     const sortedList: FavoriteItem[] = [];
                     state.favoriteOrderList.forEach((dashboardId) => {
-                        const favoriteItem = (state.favoriteDashboardList ?? []).filter((favorite) => favorite.itemId === dashboardId);
-                        if (favoriteItem.length > 0) sortedList.push(favoriteItem[0]);
+                        const favoriteItem = (state.favoriteDashboardList ?? []).find((favorite) => favorite.itemId === dashboardId);
+                        if (favoriteItem) sortedList.push(favoriteItem);
                     });
                     state.favoriteDashboardList.forEach((item) => {
                         const itemId = state.favoriteOrderList.find((id) => item.itemId === id);

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -85,7 +85,7 @@ export default {
         const state = reactive({
             loading: true,
             favoriteDashboardId: computed<FavoriteItem[]>(() => store.state.favorite.dashboardItems),
-            dashboardList: [
+            dashboardList: [ // load from dashboard api
                 { name: 'dashboard1', dashboardId: '1' },
                 { name: 'dashboard2', dashboardId: '2' },
                 { name: 'dashboard3', dashboardId: '3' },

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -1,22 +1,22 @@
 <template>
     <div class="gnb-dashboard-favorite">
-        <p-data-loader :data="items"
+        <p-data-loader :data="sortedFavoriteList"
                        :loading="loading"
                        class="gnb-dashboard-favorite-context"
-                       :class="{ loading: loading }"
+                       :class="{ loading }"
         >
-            <draggable v-model="items">
-                <div v-for="(item, index) in items"
+            <draggable v-model="sortedFavoriteList">
+                <div v-for="(item, index) in sortedFavoriteList"
                      :key="`favorite-${item.label}-${index}`"
                      @click="hideMenu"
                 >
                     <g-n-b-sub-menu :label="item.label"
                                     :is-draggable="true"
-                                    :to="dashboardRouteFormatter(item.name)"
+                                    :to="dashboardRouteFormatter(item.itemId)"
                     >
                         <template #extra-mark>
                             <favorite-button :favorite-type="FAVORITE_TYPE.DASHBOARD"
-                                             :item-id="item.name"
+                                             :item-id="item.itemId"
                                              scale="0.65"
                             />
                         </template>
@@ -40,16 +40,22 @@
 
 <script lang="ts">
 import type { SetupContext } from 'vue';
-import { reactive, toRefs } from 'vue';
+import {
+    computed, reactive, toRefs,
+} from 'vue';
 import draggable from 'vuedraggable';
 
 import { PDataLoader } from '@spaceone/design-system';
 
+import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 
+import type { FavoriteItem } from '@/store/modules/favorite/type';
 import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
 
+import ErrorHandler from '@/common/composables/error/errorHandler';
 import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteButton.vue';
 import GNBSubMenu from '@/common/modules/navigations/gnb/modules/gnb-menu/GNBSubMenu.vue';
 import type { SuggestionType } from '@/common/modules/navigations/gnb/modules/gnb-search/config';
@@ -60,6 +66,11 @@ import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 import { PROJECT_ROUTE } from '@/services/project/route-config';
 
 const FAVORITE_LIMIT = 5;
+
+interface TempDashboardModel {
+    name: string;
+    dashboardId: string;
+}
 
 export default {
     name: 'GNBDashboardFavorite',
@@ -73,16 +84,46 @@ export default {
     setup(props, { emit }: SetupContext) {
         const state = reactive({
             loading: true,
-            items: [
-                { label: 'dashboard1', name: '1' },
-                { label: 'dashboard2', name: '2' },
-                { label: 'dashboard3', name: '3' },
-                { label: 'dashboard4', name: '4' },
-                { label: 'dashboard5', name: '5' },
-                { label: 'dashboard6', name: '6' },
-                { label: 'dashboard7', name: '7' },
-                { label: 'dashboard8', name: '8' },
-            ],
+            favoriteDashboardId: computed<FavoriteItem[]>(() => store.state.favorite.dashboardItems),
+            dashboardList: [
+                { name: 'dashboard1', dashboardId: '1' },
+                { name: 'dashboard2', dashboardId: '2' },
+                { name: 'dashboard3', dashboardId: '3' },
+                { name: 'dashboard4', dashboardId: '4' },
+                { name: 'dashboard5', dashboardId: '5' },
+                { name: 'dashboard6', dashboardId: '6' },
+                { name: 'dashboard7', dashboardId: '7' },
+                { name: 'dashboard8', dashboardId: '8' },
+            ] as TempDashboardModel[],
+            favoriteDashboardList: computed<FavoriteItem[]>(() => {
+                const favoriteList: FavoriteItem[] = [];
+                state.dashboardList.forEach((dashboard) => {
+                    const isFavoriteDashboard = !!(state.favoriteDashboardId ?? []).filter((d) => dashboard.dashboardId === d.itemId).length;
+                    if (isFavoriteDashboard) {
+                        favoriteList.push({
+                            itemId: dashboard.dashboardId,
+                            label: dashboard.name,
+                            itemType: FAVORITE_TYPE.DASHBOARD,
+                        });
+                    }
+                });
+                return favoriteList;
+            }),
+            favoriteOrderList: [] as string[],
+            sortedFavoriteList: computed<FavoriteItem[]>({
+                get: () => {
+                    const sortedList: FavoriteItem[] = [];
+                    state.favoriteOrderList.forEach((dashboardId) => {
+                        const favoriteItem = (state.favoriteDashboardList ?? []).filter((favorite) => favorite.itemId === dashboardId);
+                        if (favoriteItem.length > 0) sortedList.push(favoriteItem[0]);
+                    });
+                    return sortedList;
+                },
+                set: (value) => {
+                    state.favoriteOrderList = value.map((favorite) => favorite.itemId);
+                    setFavoriteOrderList();
+                },
+            }),
         });
 
         const hideMenu = () => { emit('close'); };
@@ -106,10 +147,36 @@ export default {
         });
         const handleSelect = () => { hideMenu(); };
 
+        const getFavoriteOrderList = async () => {
+            try {
+                const { results } = await SpaceConnector.client.addOns.favorite.orderList.get({
+                    type: FAVORITE_TYPE.DASHBOARD,
+                });
+                state.favoriteOrderList = results[0]?.data?.order_list ?? [];
+            } catch (e) {
+                ErrorHandler.handleError(e);
+                state.favoriteOrderList = [];
+            }
+        };
+
+        const setFavoriteOrderList = async () => {
+            try {
+                state.loading = true;
+                await SpaceConnector.client.addOns.favorite.orderList.set({
+                    type: FAVORITE_TYPE.DASHBOARD,
+                    order_list: state.favoriteOrderList,
+                });
+            } catch (e) {
+                ErrorHandler.handleError(e);
+            } finally {
+                state.loading = false;
+            }
+        };
         /* Init */
         (async () => {
             state.loading = true;
             await Promise.allSettled([
+                getFavoriteOrderList(),
                 store.dispatch('favorite/load', FAVORITE_TYPE.DASHBOARD),
             ]);
             state.loading = false;

--- a/src/store/modules/favorite/actions.ts
+++ b/src/store/modules/favorite/actions.ts
@@ -34,6 +34,7 @@ const addCommitsByItemType = {
     [FAVORITE_TYPE.PROJECT]: 'addProjectItem',
     [FAVORITE_TYPE.PROJECT_GROUP]: 'addProjectGroupItem',
     [FAVORITE_TYPE.CLOUD_SERVICE]: 'addCloudServiceItem',
+    [FAVORITE_TYPE.DASHBOARD]: 'addDashboardItem',
     [FAVORITE_TYPE.MENU]: 'addMenuItem',
 };
 export const addItem: Action<FavoriteState, any> = async ({ commit }, favorite: FavoriteConfig): Promise<void> => {
@@ -47,6 +48,7 @@ const removeCommitsByItemType = {
     [FAVORITE_TYPE.PROJECT]: 'removeProjectItem',
     [FAVORITE_TYPE.PROJECT_GROUP]: 'removeProjectGroupItem',
     [FAVORITE_TYPE.CLOUD_SERVICE]: 'removeCloudServiceItem',
+    [FAVORITE_TYPE.DASHBOARD]: 'removeDashboardItem',
     [FAVORITE_TYPE.MENU]: 'removeMenuItem',
 };
 export const removeItem: Action<FavoriteState, any> = async ({ commit }, favorite: FavoriteConfig): Promise<void> => {
@@ -61,12 +63,14 @@ const favoriteItemsByItemType = {
     [FAVORITE_TYPE.PROJECT]: 'projectItems',
     [FAVORITE_TYPE.PROJECT_GROUP]: 'projectGroupItems',
     [FAVORITE_TYPE.CLOUD_SERVICE]: 'cloudServiceItems',
+    [FAVORITE_TYPE.DASHBOARD]: 'dashboardItems',
 };
 const setCommitsByItemType = {
     [FAVORITE_TYPE.PROJECT]: 'setProjectItems',
     [FAVORITE_TYPE.PROJECT_GROUP]: 'setProjectGroupItems',
     [FAVORITE_TYPE.CLOUD_SERVICE]: 'setCloudServiceItems',
     [FAVORITE_TYPE.MENU]: 'setMenuItems',
+    [FAVORITE_TYPE.DASHBOARD]: 'setDashboardItems',
 };
 export const load: Action<FavoriteState, any> = async ({ state, commit }, itemType: FavoriteType): Promise<void|Error> => {
     const stateName = favoriteItemsByItemType[itemType];

--- a/src/store/modules/favorite/mutations.ts
+++ b/src/store/modules/favorite/mutations.ts
@@ -49,3 +49,14 @@ export const removeCloudServiceItem = (state: FavoriteState, favorite: Partial<F
 export const setCloudServiceItems = (state: FavoriteState, favorite: FavoriteConfig[]): void => {
     state.cloudServiceItems = favorite;
 };
+
+/* Dashboard Type */
+export const addDashboardItem = (state: FavoriteState, favorite: FavoriteConfig): void => {
+    if (state.dashboardItems) state.dashboardItems.unshift(favorite);
+};
+export const removeDashboardItem = (state: FavoriteState, favorite: Partial<FavoriteConfig>): void => {
+    state.dashboardItems = state.dashboardItems?.filter((d) => d.itemId !== favorite.itemId) ?? null;
+};
+export const setDashboardItems = (state: FavoriteState, favorite: FavoriteConfig[]): void => {
+    state.dashboardItems = favorite;
+};

--- a/src/store/modules/recent/actions.ts
+++ b/src/store/modules/recent/actions.ts
@@ -24,6 +24,7 @@ const addCommitsByItemType = {
     [RECENT_TYPE.PROJECT]: 'addProjectItem',
     [RECENT_TYPE.PROJECT_GROUP]: 'addProjectGroupItem',
     [RECENT_TYPE.CLOUD_SERVICE]: 'addCloudServiceItem',
+    [RECENT_TYPE.DASHBOARD]: 'addDashboardItem',
     [RECENT_TYPE.MENU]: 'addMenuItem',
 };
 export const addItem: Action<RecentState, any> = async ({ commit }, recent: RecentConfig): Promise<void> => {
@@ -41,6 +42,7 @@ const setCommitsByItemType = {
     [RECENT_TYPE.PROJECT]: 'setProjectItems',
     [RECENT_TYPE.PROJECT_GROUP]: 'setProjectGroupItems',
     [RECENT_TYPE.CLOUD_SERVICE]: 'setCloudServiceItems',
+    [RECENT_TYPE.DASHBOARD]: 'setDashboardItems',
     [RECENT_TYPE.MENU]: 'setMenuItems',
 };
 export const load: Action<RecentState, any> = async ({ commit }, payload: RecentLoadPayload): Promise<void|Error> => {
@@ -49,6 +51,7 @@ export const load: Action<RecentState, any> = async ({ commit }, payload: Recent
         type: itemType,
         limit: payload?.limit,
     });
+    console.log(results);
     const recents: RecentConfig[] = results.map((d) => ({
         itemType: d.data.type,
         itemId: d.data.id,

--- a/src/store/modules/recent/mutations.ts
+++ b/src/store/modules/recent/mutations.ts
@@ -48,6 +48,18 @@ export const setCloudServiceItems = (state: RecentState, recent: RecentConfig[])
     state.cloudServiceItems = recent;
 };
 
+/* Dashboard Type */
+export const addDashboardItem = (state: RecentState, recent: RecentConfig): void => {
+    const exist = state.dashboardItems.find((d) => d.itemId === recent.itemId);
+    if (exist) {
+        state.dashboardItems = state.dashboardItems.filter((d) => d.itemId !== recent.itemId);
+    }
+    state.dashboardItems.unshift(recent);
+};
+export const setDashboardItems = (state: RecentState, recent: RecentConfig[]): void => {
+    state.dashboardItems = recent;
+};
+
 /* All Type */
 export const loadAllItem = (state: RecentState, recent: RecentConfig[]): void => {
     state.allItems = recent;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
gnb-menu에서 favorite과 recent의 api 를 연결하였습니다.

현재 dashboard에 대한 api가 나오지 않은 상태여서, dashboardList는 더미로 진행하였습니다.

- favorite add/remove/list
- favorite sorting
- recent list

추후 dashboard api가 나오면 추가 수정이 필요한 부분
- 기존 더미데이터에대한 데이터 삭제
- projectDashboard, domainDashboard list와 연동
- lnb에서 추가 삭제한 favorite 반영확인
- recent add 로직 추가
### 생각해볼 문제
