### PR TITLE
fix(cost-widget): require error in cost-widget customize tab [WIP]

### DIFF
--- a/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CostDashboardCustomizeDefaultWidgetTab.vue
+++ b/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CostDashboardCustomizeDefaultWidgetTab.vue
@@ -23,7 +23,7 @@
                         </div>
                         <div class="card-content">
                             <img class="card-image"
-                                 :src="require(`@/assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`)"
+                                 :src="import(`../../../../../assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`)"
                             >
                         </div>
                     </li>
@@ -49,7 +49,7 @@
                         </div>
                         <div class="card-content">
                             <img class="card-image"
-                                 :src="require(`@/assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`)"
+                                 :src="import(`../../../../../assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`)"
                             >
                         </div>
                     </li>
@@ -141,6 +141,12 @@ export default {
             costExplorerStore.commit('dashboard/setEditedSelectedWidget', value);
         };
 
+        // FIXME:: WIP
+        const getChartImage = (widget) => {
+            const chartImage = import(`../../../../../assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`);
+            return chartImage;
+        };
+
         (() => {
             getWidgets();
         })();
@@ -151,6 +157,7 @@ export default {
             selectWidget,
             getWidgets,
             getChartTypeImageFileName,
+            getChartImage,
         };
     },
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [ ] `Error / Warning / Lint / Type`

### 작업 내용

# Work In Progress 

cost explorer dashboard custom modal 에서 require 관련 발생 에러를 처리하였습니다.

svg 이미지는 아직 작업 진행 중에 있습니다.

![스크린샷 2022-11-15 오후 7 22 45](https://user-images.githubusercontent.com/29014433/201895258-7ab9f403-9fbe-4fac-80b4-d402f68d4e0e.png)


### 생각해볼 문제
