### PR TITLE
feat(widget-frame): add width prop and full size markup

### DIFF
--- a/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/GNBMenu.vue
@@ -10,7 +10,8 @@
                  selected: isSelected,
              }]"
         >
-            <span tabindex="0"
+            <span class="button-label"
+                  tabindex="0"
                   @click="handleMenu"
                   @keydown.enter="handleMenu"
             >
@@ -169,6 +170,11 @@ export default defineComponent<Props>({
         cursor: pointer;
         text-decoration: none;
         text-transform: capitalize;
+
+        .button-label {
+            display: inline-block;
+            height: 100%;
+        }
 
         &.opened, &:hover {
             @apply text-violet-600;

--- a/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -1,8 +1,7 @@
 <template>
     <div class="widget-frame"
-         :class="{
-             [size]: true,
-         }"
+         :class="{ full: isFull }"
+         :style="{ width: isFull ? '100%' : width }"
     >
         <div class="widget-header">
             <h3 class="title">
@@ -44,7 +43,9 @@
 
 <script lang="ts">
 import type { PropType, SetupContext } from 'vue';
-import { reactive, toRefs, defineComponent } from 'vue';
+import {
+    reactive, toRefs, defineComponent, computed,
+} from 'vue';
 
 import { PDatetimePicker, PDivider, PI } from '@spaceone/design-system';
 
@@ -60,6 +61,7 @@ import CurrencySelectDropdown from './CurrencySelectDropdown.vue';
 interface Props {
     title: string;
     size: WidgetSize;
+    width: string;
     widgetLink: string;
     noData: boolean;
     printMode: boolean;
@@ -83,6 +85,10 @@ export default defineComponent<Props>({
         size: {
             type: String as PropType<WidgetSize>,
             default: WIDGET_SIZE.md,
+        },
+        width: {
+            type: String,
+            default: '30rem', // default width of md size
         },
         widgetLink: {
             type: [Object, String],
@@ -109,6 +115,7 @@ export default defineComponent<Props>({
         const state = reactive({
             proxySelectedDates: useProxyValue('selectedDates', props, emit),
             proxyCurrency: useProxyValue('currency', props, emit),
+            isFull: computed<boolean>(() => props.size === WIDGET_SIZE.full),
         });
 
         const handleUpdateCurrency = (currency: Currency) => {
@@ -117,20 +124,16 @@ export default defineComponent<Props>({
         return {
             ...toRefs(state),
             handleUpdateCurrency,
+            WIDGET_SIZE,
         };
     },
 });
 </script>
 
 <style lang="postcss" scoped>
-@define-mixin widget-size $widget-width {
-    & {
-        height: 29rem;
-        width: $widget-width;
-    }
-}
-
 .widget-frame {
+    height: 29rem;
+
     @apply border rounded-lg bg-white;
     border-color: theme('colors.gray.200');
     display: inline-flex;
@@ -151,8 +154,8 @@ export default defineComponent<Props>({
     }
     .body {
         height: auto;
-        flex-grow: 1;
-        flex-shrink: 1;
+        flex: 1 1;
+        overflow-y: scroll;
     }
     .widget-footer {
         @apply border-t rounded-b-lg flex justify-between items-center;
@@ -178,17 +181,10 @@ export default defineComponent<Props>({
             }
         }
     }
-    &.sm {
-        @mixin widget-size 24rem;
-    }
-    &.md {
-        @mixin widget-size 34.625rem;
-    }
-    &.lg {
-        @mixin widget-size 44rem;
-    }
-    &.xl {
-        @mixin widget-size 54rem;
+    &.full {
+        height: 100%;
+        min-height: 29rem;
     }
 }
+
 </style>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [x] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
WidgetFrame에 full 사이즈 옵션과 width를 받아 설정할 수 있도록 수정하였습니다.
width는 WidgetSize 별로 추가적인 config를 구성하면 좋을 것 같은데, 민서님 Dashboard 위젯 정렬때 편한 구조로 정하는게 좋아보여 일단 값으로만 추가하였고 따로 type, config는 생성하지 않았습니다.

(추가로 gnb에 클릭 범위 수정 스윽 넣었습니다)
### 생각해볼 문제
