### PR TITLE
fix(cost-widget): fix widget image broken

### DIFF
--- a/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CostDashboardCustomizeDefaultWidgetTab.vue
+++ b/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CostDashboardCustomizeDefaultWidgetTab.vue
@@ -6,7 +6,7 @@
             >
                 <p-field-title>{{ $t('BILLING.COST_MANAGEMENT.DASHBOARD.CUSTOMIZE.ADD_WIDGET_MODAL.RECOMMENDED_WIDGET') }} ({{ recommendedWidgetList.length }})</p-field-title>
                 <ul class="widget-list">
-                    <li v-for="widget in recommendedWidgetList"
+                    <li v-for="(widget, index) in recommendedWidgetList"
                         :key="widget.widget_id"
                         class="widget-card"
                         :class="{'selected' : selectedWidget.widget_id === widget.widget_id}"
@@ -23,7 +23,7 @@
                         </div>
                         <div class="card-content">
                             <img class="card-image"
-                                 :src="import(`../../../../../assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`)"
+                                 :src="widgetCardImageList[index].value.default"
                             >
                         </div>
                     </li>
@@ -32,7 +32,7 @@
             <div class="widgets-area widgets-all">
                 <p-field-title>{{ $t('BILLING.COST_MANAGEMENT.DASHBOARD.CUSTOMIZE.ADD_WIDGET_MODAL.ALL') }} ({{ widgetList.length }})</p-field-title>
                 <ul class="widget-list">
-                    <li v-for="widget in widgetList"
+                    <li v-for="(widget, index) in widgetList"
                         :key="widget.widget_id"
                         class="widget-card"
                         :class="{'selected' : selectedWidget.widget_id === widget.widget_id}"
@@ -49,7 +49,7 @@
                         </div>
                         <div class="card-content">
                             <img class="card-image"
-                                 :src="import(`../../../../../assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`)"
+                                 :src="widgetCardImageList[index].value.default"
                             >
                         </div>
                     </li>
@@ -124,6 +124,7 @@ export default {
             thisPage: 1,
             allPage: computed(() => Math.ceil(state.totalCount / PAGE_SIZE) || 1),
             layoutOfSpace: computed(() => costExplorerStore.state.dashboard.layoutOfSpace),
+            widgetCardImageList: [],
         });
         const getWidgets = async () => {
             try {
@@ -141,14 +142,15 @@ export default {
             costExplorerStore.commit('dashboard/setEditedSelectedWidget', value);
         };
 
-        // FIXME:: WIP
-        const getChartImage = (widget) => {
-            const chartImage = import(`../../../../../assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`);
-            return chartImage;
+        const getWidgetCardImageList = async (): Promise<void> => {
+            state.widgetCardImageList = await Promise.allSettled(
+                state.widgetList.map((d) => import(`../../../../../assets/images/${getChartTypeImageFileName(d.options.chart_type)}.svg`)),
+            );
         };
 
-        (() => {
-            getWidgets();
+        (async () => {
+            await getWidgets();
+            await getWidgetCardImageList();
         })();
 
         return {
@@ -157,7 +159,6 @@ export default {
             selectWidget,
             getWidgets,
             getChartTypeImageFileName,
-            getChartImage,
         };
     },
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [ ] `Error / Warning / Lint / Type`

### 작업 내용

Continue from #318 


`<template>` 내에서 import 혹은 async 를 사용할 수 없어서, 
init 시에 imgList 를 state 에 저장한 후
`index` 로 접근하도록 변경하였습니다.

![스크린샷 2022-11-16 오후 3 09 03](https://user-images.githubusercontent.com/29014433/202098016-795075af-9d82-4b9f-bbb1-687a87f2b90b.png)

### 생각해볼 문제
