### PR TITLE
feat: add use-widget-data hook & write monthly cost widget with script setup as sample

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
         "typescript": "^4.8.2",
         "vite": "^3.1.0",
         "vite-plugin-stylelint": "^3.0.8",
+        "vite-plugin-vue-type-imports": "^0.2.4",
         "vitest": "^0.24.3",
         "vue-template-compiler": "^2.7.10",
         "yorkie": "^2.0.0"
@@ -5281,6 +5282,83 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7",
+        "postcss": "^8.1.10",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
     "node_modules/@vue/composition-api": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.6.2.tgz",
@@ -5290,6 +5368,34 @@
       "peerDependencies": {
         "vue": ">= 2.5 < 3"
       }
+    },
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "node_modules/@vue/reactivity-transform/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+      "dev": true
     },
     "node_modules/@vue/test-utils": {
       "version": "1.3.3",
@@ -21319,6 +21425,60 @@
         }
       }
     },
+    "node_modules/vite-plugin-vue-type-imports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vue-type-imports/-/vite-plugin-vue-type-imports-0.2.4.tgz",
+      "integrity": "sha512-qjz1RMd1MgG1gd2KNGo2uDSpGbaB7KwcuUVFZfC8mBdzUG63eR/gJzMUvfpM9JWQ+JTEfEGiLxe6NJvg4n3Kuw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.19.0",
+        "@vue/compiler-sfc": "^3.2.24",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.2.12",
+        "local-pkg": "^0.4.2",
+        "magic-string": "^0.26.4",
+        "picocolors": "^1.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0",
+        "vue": "^2.7.0 || ^3.2.24"
+      }
+    },
+    "node_modules/vite-plugin-vue-type-imports/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-vue-type-imports/node_modules/magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-plugin-vue-type-imports/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/vite/node_modules/rollup": {
       "version": "2.78.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
@@ -25938,6 +26098,81 @@
         "vitest": "0.24.3"
       }
     },
+    "@vue/compiler-core": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7",
+        "postcss": "^8.1.10",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.25.9",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
     "@vue/composition-api": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.6.2.tgz",
@@ -25945,6 +26180,36 @@
       "optional": true,
       "peer": true,
       "requires": {}
+    },
+    "@vue/reactivity-transform": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.25.9",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        }
+      }
+    },
+    "@vue/shared": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+      "dev": true
     },
     "@vue/test-utils": {
       "version": "1.3.3",
@@ -27505,6 +27770,7 @@
         "v-tooltip": "^2.0.2",
         "vite": "^3.1.0",
         "vite-plugin-stylelint": "^3.0.8",
+        "vite-plugin-vue-type-imports": "*",
         "vitest": "^0.24.3",
         "vue": "^2.7.10",
         "vue-focus": "^2.1.0",
@@ -31300,6 +31566,81 @@
             "vitest": "0.24.3"
           }
         },
+        "@vue/compiler-core": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+          "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/shared": "3.2.45",
+            "estree-walker": "^2.0.2",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+          "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-core": "3.2.45",
+            "@vue/shared": "3.2.45"
+          }
+        },
+        "@vue/compiler-sfc": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+          "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/compiler-core": "3.2.45",
+            "@vue/compiler-dom": "3.2.45",
+            "@vue/compiler-ssr": "3.2.45",
+            "@vue/reactivity-transform": "3.2.45",
+            "@vue/shared": "3.2.45",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.25.7",
+            "postcss": "^8.1.10",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "magic-string": {
+              "version": "0.25.9",
+              "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+              "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+              "dev": true,
+              "requires": {
+                "sourcemap-codec": "^1.4.8"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "@vue/compiler-ssr": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+          "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-dom": "3.2.45",
+            "@vue/shared": "3.2.45"
+          }
+        },
         "@vue/composition-api": {
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.6.2.tgz",
@@ -31307,6 +31648,36 @@
           "optional": true,
           "peer": true,
           "requires": {}
+        },
+        "@vue/reactivity-transform": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+          "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/compiler-core": "3.2.45",
+            "@vue/shared": "3.2.45",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.25.7"
+          },
+          "dependencies": {
+            "magic-string": {
+              "version": "0.25.9",
+              "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+              "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+              "dev": true,
+              "requires": {
+                "sourcemap-codec": "^1.4.8"
+              }
+            }
+          }
+        },
+        "@vue/shared": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+          "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+          "dev": true
         },
         "@vue/test-utils": {
           "version": "1.3.3",
@@ -43391,6 +43762,47 @@
             "@rollup/pluginutils": "^4.2.1"
           }
         },
+        "vite-plugin-vue-type-imports": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/vite-plugin-vue-type-imports/-/vite-plugin-vue-type-imports-0.2.4.tgz",
+          "integrity": "sha512-qjz1RMd1MgG1gd2KNGo2uDSpGbaB7KwcuUVFZfC8mBdzUG63eR/gJzMUvfpM9JWQ+JTEfEGiLxe6NJvg4n3Kuw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.19.0",
+            "@vue/compiler-sfc": "^3.2.24",
+            "debug": "^4.3.4",
+            "fast-glob": "^3.2.12",
+            "local-pkg": "^0.4.2",
+            "magic-string": "^0.26.4",
+            "picocolors": "^1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "magic-string": {
+              "version": "0.26.7",
+              "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+              "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+              "dev": true,
+              "requires": {
+                "sourcemap-codec": "^1.4.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
         "vitest": {
           "version": "0.24.3",
           "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.24.3.tgz",
@@ -54573,6 +54985,47 @@
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.2.1"
+      }
+    },
+    "vite-plugin-vue-type-imports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vue-type-imports/-/vite-plugin-vue-type-imports-0.2.4.tgz",
+      "integrity": "sha512-qjz1RMd1MgG1gd2KNGo2uDSpGbaB7KwcuUVFZfC8mBdzUG63eR/gJzMUvfpM9JWQ+JTEfEGiLxe6NJvg4n3Kuw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.19.0",
+        "@vue/compiler-sfc": "^3.2.24",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.2.12",
+        "local-pkg": "^0.4.2",
+        "magic-string": "^0.26.4",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "magic-string": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+          "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "vitest": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "typescript": "^4.8.2",
     "vite": "^3.1.0",
     "vite-plugin-stylelint": "^3.0.8",
+    "vite-plugin-vue-type-imports": "^0.2.4",
     "vitest": "^0.24.3",
     "vue-template-compiler": "^2.7.10",
     "yorkie": "^2.0.0"

--- a/src/services/dashboards/routes.ts
+++ b/src/services/dashboards/routes.ts
@@ -8,6 +8,9 @@ const DashboardCreatePage = () => import('@/services/dashboards/dashboard-create
 const DashboardCustomizePage = () => import('@/services/dashboards/dashboard-customize/DashboardCustomizePage.vue');
 const DashboardDetailPage = () => import('@/services/dashboards/dashboard-detail/DashboardDetailPage.vue');
 
+// TODO: remove after test
+const WidgetPreviewPage = () => import('@/services/dashboards/widgets/WidgetsPreviewPage.vue');
+
 const dashboardsRoute: RouteConfig = {
     path: 'dashboards',
     name: DASHBOARDS_ROUTE._NAME,
@@ -28,6 +31,12 @@ const dashboardsRoute: RouteConfig = {
                     path: 'create',
                     name: DASHBOARDS_ROUTE.CREATE._NAME,
                     component: DashboardCreatePage,
+                },
+                // TODO: remove after test
+                {
+                    path: 'widgets/:widgetId',
+                    props: true,
+                    component: WidgetPreviewPage,
                 },
                 {
                     path: ':dashboardId?',

--- a/src/services/dashboards/widgets/WidgetsPreviewPage.vue
+++ b/src/services/dashboards/widgets/WidgetsPreviewPage.vue
@@ -1,0 +1,41 @@
+<template>
+    <div>
+        <component :is="widgetComponent"
+                   :widget-config-id="widgetId"
+                   :widget-key="widgetId"
+        />
+    </div>
+</template>
+
+<script lang="ts">
+import {
+    defineComponent, reactive, toRefs, computed,
+} from 'vue';
+
+import { getWidgetComponent, getWidgetConfig } from '@/services/dashboards/widgets/helper';
+
+interface Props {
+    widgetId: string
+}
+
+export default defineComponent<Props>({
+    name: 'WidgetsPreviewPage',
+    components: {},
+    props: {
+        widgetId: {
+            type: String,
+            default: '',
+        },
+    },
+    setup(props) {
+        const state = reactive({
+            widgetConfig: computed(() => getWidgetConfig(props.widgetId)),
+            widgetComponent: computed(() => (props.widgetId ? getWidgetComponent(props.widgetId) : null)),
+        });
+
+        return {
+            ...toRefs(state),
+        };
+    },
+});
+</script>

--- a/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
+++ b/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
@@ -1,26 +1,20 @@
 <template>
-    <div />
+    <widget-frame :title="state.title"
+                  :size="state.size"
+                  :width="props.width"
+    >
+        <!-- TODO: implementation -->
+    </widget-frame>
 </template>
 
-<script lang="ts">
-import {
-    defineComponent, reactive, toRefs,
-} from 'vue';
+<script setup lang="ts">
+import { defineProps } from 'vue';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface Props {
-}
+import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
+import type { WidgetProps } from '@/services/dashboards/widgets/config';
+// eslint-disable-next-line import/no-cycle
+import { useWidgetData } from '@/services/dashboards/widgets/use-widget-data';
 
-export default defineComponent<Props>({
-    name: 'MonthlyCostWidget',
-    components: {},
-    props: {},
-    setup() {
-        const state = reactive({});
-
-        return {
-            ...toRefs(state),
-        };
-    },
-});
+const props = defineProps<WidgetProps>();
+const state = useWidgetData(props);
 </script>

--- a/src/services/dashboards/widgets/use-widget-data.ts
+++ b/src/services/dashboards/widgets/use-widget-data.ts
@@ -1,0 +1,39 @@
+import { computed, reactive } from 'vue';
+
+import { merge } from 'lodash';
+
+import type {
+    WidgetConfig, WidgetOptions, WidgetSize,
+    InheritOptions, WidgetProps,
+} from '@/services/dashboards/widgets/config';
+import { getWidgetConfig } from '@/services/dashboards/widgets/helper';
+
+const getRefinedOptions = (
+    configOptions?: WidgetOptions,
+    optionsData?: WidgetOptions,
+    inheritOptions?: InheritOptions,
+    dashboardOptions?: object,
+): WidgetOptions => {
+    const mergedOptions = merge({}, configOptions, optionsData);
+    if (!inheritOptions || !dashboardOptions) return mergedOptions;
+
+    const parentOptions = {};
+    Object.keys(inheritOptions).forEach((key) => {
+        if (inheritOptions[key].enabled) parentOptions[key] = dashboardOptions[key];
+    });
+    return merge({}, mergedOptions, parentOptions);
+};
+
+export const useWidgetData = (props: WidgetProps) => {
+    const state = reactive({
+        widgetConfig: computed<WidgetConfig>(() => getWidgetConfig(props.widgetConfigId)),
+        title: computed<string>(() => props.title ?? state.widgetConfig.title),
+        options: computed<WidgetOptions>(() => getRefinedOptions(state.widgetConfig.widget_options, props.options, props.inheritOptions, props.dashboardOptions)),
+        size: computed<WidgetSize>(() => {
+            if (state.widgetConfig.sizes.includes(props.size)) return props.size;
+            return state.widgetConfig.sizes[0];
+        }),
+    });
+
+    return state;
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import process from 'process';
 import vuePlugin from '@vitejs/plugin-vue2';
 import { defineConfig, loadEnv } from 'vite';
 import StylelintPlugin from 'vite-plugin-stylelint';
+import VueTypeImports from 'vite-plugin-vue-type-imports'
 
 export default defineConfig(({ command, mode }) => {
     process.env = {...process.env, ...loadEnv(mode, process.cwd())};
@@ -13,6 +14,7 @@ export default defineConfig(({ command, mode }) => {
     return {
         plugins: [
             vuePlugin(),
+            VueTypeImports(),
             StylelintPlugin({
                 include: ['src/**/*.{css,vue,pcss,scss}'],
                 exclude: ['node_modules'],


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### 작업 분류
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 체크리스트
- [x] `Error / Warning / Lint / Type`

### 작업 내용
- vite-plugin-vue-type-imports 모듈을 추가하였습니다. 
  - 추가한 이유 참고: https://github.com/vuejs/core/issues/4294
  - 뷰에서 공식적으로 해결해주기 전까지 위 모듈을 사용할 예정입니다.
- use-widget-data 훅을 추가하였습니다.
  - 개별 위젯에서 config와 data들을 병합하기로 하였으므로, 이에 따라 모든 위젯에 동일하게 사용될 것으로 예상되는 값들을 이 훅이 리턴하도록 반영하였습니다.
- 예시로 monthly cost 위젯 컴포넌트를 script setup 방식으로 작성했습니다.
  - script setup 작성 방식 및 이를 도입한 이유 참고: https://vuejs.org/api/sfc-script-setup.html
- dashboards/widgets/:widgetId path로 들어왔을 때 특정 위젯을 띄워줄 수 있도록 WidgetPreviewPage 를 추가하였습니다.
  - 테스트용으로 추가했으나, 이후 widget detail view로 발전 가능성이 있어보입니다.
  - ![image](https://user-images.githubusercontent.com/26986739/202666606-f628517b-6038-4fe0-9d10-728f7006fe6a.png)


### 생각해볼 문제

위젯 컴포넌트들은 script setup 방식으로 작성하고 싶습니다.
- props 이중으로(typescript, props 객체) 작성 및 관리하지 않고, typescript 하나만으로 해결하기 위해
- Vue3에서 지원하는 보다 간결한 문법이며, runtime performance가 좋으므로
- 위젯에서부터 이 문법을 익혀가면 좋을것 같아서