### PR TITLE
fix(widget-frame): refactoring for changed specifications

### DIFF
--- a/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -23,19 +23,14 @@
             </div>
             <div class="footer-right">
                 <slot name="footer-right">
-                    <component :is="fullDataTag"
-                               v-if="(widgetLink || widgetRoute) && !printMode"
-                               :href="widgetLink"
-                               :to="widgetRoute"
-                               class="anchor-button"
+                    <p-anchor v-if="(widgetLink || widgetRoute) && !printMode"
+                              :href="widgetLink"
+                              :to="widgetRoute"
+                              class="anchor-button"
+                              icon-name="ic_arrow_right"
                     >
                         {{ $t('BILLING.COST_MANAGEMENT.DASHBOARD.FULL_DATA') }}
-                        <p-i name="ic_arrow_right"
-                             width="1rem"
-                             height="1rem"
-                             color="inherit transparent"
-                        />
-                    </component>
+                    </p-anchor>
                 </slot>
             </div>
         </div>
@@ -50,7 +45,7 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 import type { Route } from 'vue-router';
 
-import { PDivider, PI } from '@spaceone/design-system';
+import { PAnchor, PDivider } from '@spaceone/design-system';
 import dayjs from 'dayjs';
 
 import { i18n } from '@/translations';
@@ -62,8 +57,6 @@ import { useI18nDayjs } from '@/common/composables/i18n-dayjs';
 
 import type { WidgetOptions, WidgetSize } from '@/services/dashboards/widgets/config';
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/config';
-
-import CurrencySelectDropdown from './CurrencySelectDropdown.vue';
 
 interface Props {
     title: string;
@@ -81,9 +74,8 @@ interface Props {
 export default defineComponent<Props>({
     name: 'WidgetFrame',
     components: {
-        CurrencySelectDropdown,
+        PAnchor,
         PDivider,
-        PI,
     },
     props: {
         title: {
@@ -132,7 +124,6 @@ export default defineComponent<Props>({
         const setBasicDateFormat = (date) => (date ? dayjs(date).format('YYYY-MM-DD') : undefined);
         const state = reactive({
             isFull: computed<boolean>(() => props.size === WIDGET_SIZE.full),
-            fullDataTag: computed<string>(() => (props.widgetLink ? 'a' : 'router-link')),
             dateLabel: computed<TranslateResult|undefined>(() => {
                 const start = setBasicDateFormat(props.dateRange?.start);
                 const end = setBasicDateFormat(props.dateRange?.end);
@@ -140,8 +131,8 @@ export default defineComponent<Props>({
                     return `${start} ~ ${end}`;
                 }
                 if (start && !end) {
-                    const today = dayjs().utc();
-                    const diff = today.diff(dayjs(start), 'day', true);
+                    const today = dayjs();
+                    const diff = today.diff(start, 'day', true);
                     if (diff < 1) return i18n.t('Today'); // song-lang
                     if (diff >= 6 && diff < 7) return i18n.t('Past 7 days'); // song-lang
                     return i18nDayjs.value(start).from(today.subtract(1, 'day'));

--- a/src/services/project/ProjectPage.vue
+++ b/src/services/project/ProjectPage.vue
@@ -101,12 +101,6 @@
                             </div>
                         </template>
                     </p-page-title>
-                    <widget-frame :widget-route="{name: 'my_page'}">
-                        <div style="background-color: #0062b8; height: 100%;" />
-                        <template #header-right>
-                            <span>hello</span>
-                        </template>
-                    </widget-frame>
                     <project-card-list class="card-container"
                                        :parent-groups="storeState.parentGroups"
                                        :manage-disabled="!hasRootProjectGroupManagePermission"
@@ -164,7 +158,6 @@ import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteB
 import FavoriteList from '@/common/modules/favorites/favorite-list/FavoriteList.vue';
 import PVerticalPageLayout from '@/common/modules/page-layouts/VerticalPageLayout.vue';
 
-import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
 import ProjectCardList from '@/services/project/modules/ProjectCardList.vue';
 import ProjectGroupDeleteCheckModal from '@/services/project/modules/ProjectGroupDeleteCheckModal.vue';
 import ProjectGroupFormModal from '@/services/project/modules/ProjectGroupFormModal.vue';
@@ -180,7 +173,6 @@ import type {
 export default {
     name: 'ProjectGroupPage',
     components: {
-        WidgetFrame,
         ProjectGroupDeleteCheckModal,
         SidebarTitle,
         ProjectGroupMember,

--- a/src/services/project/ProjectPage.vue
+++ b/src/services/project/ProjectPage.vue
@@ -101,6 +101,12 @@
                             </div>
                         </template>
                     </p-page-title>
+                    <widget-frame :widget-route="{name: 'my_page'}">
+                        <div style="background-color: #0062b8; height: 100%;" />
+                        <template #header-right>
+                            <span>hello</span>
+                        </template>
+                    </widget-frame>
                     <project-card-list class="card-container"
                                        :parent-groups="storeState.parentGroups"
                                        :manage-disabled="!hasRootProjectGroupManagePermission"
@@ -158,6 +164,7 @@ import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteB
 import FavoriteList from '@/common/modules/favorites/favorite-list/FavoriteList.vue';
 import PVerticalPageLayout from '@/common/modules/page-layouts/VerticalPageLayout.vue';
 
+import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
 import ProjectCardList from '@/services/project/modules/ProjectCardList.vue';
 import ProjectGroupDeleteCheckModal from '@/services/project/modules/ProjectGroupDeleteCheckModal.vue';
 import ProjectGroupFormModal from '@/services/project/modules/ProjectGroupFormModal.vue';
@@ -173,6 +180,7 @@ import type {
 export default {
     name: 'ProjectGroupPage',
     components: {
+        WidgetFrame,
         ProjectGroupDeleteCheckModal,
         SidebarTitle,
         ProjectGroupMember,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
- We don't need to think about portals anymore.(slot is added.)
- The added attributes were applied as the structure of the 'Widget Frame' was changed.
- The displayed value varies depending on the value passed through 'props.dateRange'.

Features to add
- Edit mode is added.
    - Edit/delete is opened through modals.
    - The full view feature is added.
![image](https://user-images.githubusercontent.com/50662170/202998917-da58b3c4-8a11-4251-9c22-4dd416680e94.png)

### Things to Talk About


----
- 포탈은 사용되지 않습니다. (slot이 추가됨)
- '위젯 프레임'의 구조가 변경됨에 따라 추가된 속성들을 적용하였습니다.
- `props.dateRange`를 통해 넘어오는 값에 따라 디스플레이되는 값이 다릅니다.

추가될 예정인 기능
- editMode가 추가될 예정입니다.
    - edit/delete는 모달을 통해 열어줍니다.
    - 전체보기 기능이 추가됩니다.
    - ![image](https://user-images.githubusercontent.com/50662170/202998917-da58b3c4-8a11-4251-9c22-4dd416680e94.png)
