### PR TITLE
feat: add widget lifecycle hook and update basePieWidget for reference 

### DIFF
--- a/src/common/composables/amcharts5/index.ts
+++ b/src/common/composables/amcharts5/index.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue';
 import {
-    reactive, toRefs, watch,
+    reactive, toRef, watch,
 } from 'vue';
 
 import * as am5 from '@amcharts/amcharts5';
@@ -44,10 +44,10 @@ const createTooltip = (root: Root, settings?: ITooltipSettings): am5.Tooltip => 
 };
 
 export const useAmcharts5 = (
-    chartContext?: Ref<ChartContext>|null,
+    chartContext: Ref<ChartContext>,
 ) => {
     const state = reactive({
-        chartContext: chartContext ?? null,
+        chartContext,
         root: undefined as undefined | Root,
     });
 
@@ -93,7 +93,7 @@ export const useAmcharts5 = (
     });
 
     return {
-        ...toRefs(state),
+        root: toRef(state, 'root'),
         disposeRoot,
         clearChildrenOfRoot,
         //

--- a/src/common/composables/amcharts5/index.ts
+++ b/src/common/composables/amcharts5/index.ts
@@ -44,10 +44,10 @@ const createTooltip = (root: Root, settings?: ITooltipSettings): am5.Tooltip => 
 };
 
 export const useAmcharts5 = (
-    chartContext: Ref<ChartContext>,
+    chartContext?: Ref<ChartContext>|null,
 ) => {
     const state = reactive({
-        chartContext,
+        chartContext: chartContext ?? null,
         root: undefined as undefined | Root,
     });
 
@@ -105,7 +105,7 @@ export const useAmcharts5 = (
             if (!state.root) throw new Error('No root');
             return createXYCategoryChart(state.root as Root, settings);
         },
-        createPieChart: (settings?: IPieChartSettings) => {
+        createPieChart: (settings?: IPieChartSettings): PieChart => {
             if (!state.root) throw new Error('No root');
             return createPieChart(state.root as Root, settings);
         },

--- a/src/services/dashboards/widgets/WidgetsPreviewPage.vue
+++ b/src/services/dashboards/widgets/WidgetsPreviewPage.vue
@@ -1,9 +1,16 @@
 <template>
     <div>
         <component :is="widgetComponent"
+                   ref="widgetRef"
                    :widget-config-id="widgetId"
                    :widget-key="widgetId"
+                   :currency-rates="currencyRates"
         />
+        <p-button class="m-4"
+                  @click="refresh"
+        >
+            Refresh
+        </p-button>
     </div>
 </template>
 
@@ -11,6 +18,10 @@
 import {
     defineComponent, reactive, toRefs, computed,
 } from 'vue';
+
+import { PButton } from '@spaceone/design-system';
+
+import { store } from '@/store';
 
 import { getWidgetComponent, getWidgetConfig } from '@/services/dashboards/widgets/helper';
 
@@ -20,7 +31,7 @@ interface Props {
 
 export default defineComponent<Props>({
     name: 'WidgetsPreviewPage',
-    components: {},
+    components: { PButton },
     props: {
         widgetId: {
             type: String,
@@ -31,10 +42,16 @@ export default defineComponent<Props>({
         const state = reactive({
             widgetConfig: computed(() => getWidgetConfig(props.widgetId)),
             widgetComponent: computed(() => (props.widgetId ? getWidgetComponent(props.widgetId) : null)),
+            widgetRef: null as any,
+            currencyRates: computed(() => store.state.display.currencyRates),
         });
 
+        const refresh = () => {
+            if (state.widgetRef) state.widgetRef.refreshWidget();
+        };
         return {
             ...toRefs(state),
+            refresh,
         };
     },
 });

--- a/src/services/dashboards/widgets/WidgetsPreviewPage.vue
+++ b/src/services/dashboards/widgets/WidgetsPreviewPage.vue
@@ -1,16 +1,24 @@
 <template>
     <div>
+        <p-button class="m-4"
+                  @click="handleMount"
+        >
+            {{ mounted ? 'Unmount Widget' : 'Mount Widget' }}
+        </p-button>
+        <p-button class="m-4"
+                  style-type="secondary"
+                  @click="refresh"
+        >
+            Refresh Widget
+        </p-button>
+        <br>
         <component :is="widgetComponent"
+                   v-if="mounted"
                    ref="widgetRef"
                    :widget-config-id="widgetId"
                    :widget-key="widgetId"
                    :currency-rates="currencyRates"
         />
-        <p-button class="m-4"
-                  @click="refresh"
-        >
-            Refresh
-        </p-button>
     </div>
 </template>
 
@@ -44,13 +52,18 @@ export default defineComponent<Props>({
             widgetComponent: computed(() => (props.widgetId ? getWidgetComponent(props.widgetId) : null)),
             widgetRef: null as any,
             currencyRates: computed(() => store.state.display.currencyRates),
+            mounted: false,
         });
 
+        const handleMount = () => {
+            state.mounted = !state.mounted;
+        };
         const refresh = () => {
             if (state.widgetRef) state.widgetRef.refreshWidget();
         };
         return {
             ...toRefs(state),
+            handleMount,
             refresh,
         };
     },

--- a/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
@@ -52,7 +52,9 @@ type ChartData = Partial<Record<GroupBy, string>> & { usd_cost: number; };
 const props = defineProps<WidgetProps>();
 
 const {
-    chartContext, createPieChart, createTooltip, createPieSeries, setPieTooltipText,
+    chartContext,
+    createPieChart, createTooltip, createPieSeries, setPieTooltipText,
+    disposeRoot,
 } = useAmcharts5();
 
 const state = reactive({
@@ -70,7 +72,7 @@ const state = reactive({
     }),
     tableFields: computed(() => [
         { label: state.groupByLabel, name: state.groupBy },
-        { label: 'Cost', name: 'usd_cost' },
+        { label: 'Cost', name: 'usd_cost', type: 'cost' },
     ]),
 });
 
@@ -136,7 +138,7 @@ const refreshWidget = async () => {
 };
 
 useWidgetLifecycle({
-    initWidget,
+    initWidget, disposeWidget: disposeRoot,
 });
 
 defineExpose({

--- a/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
@@ -29,7 +29,7 @@
 import {
     computed,
     defineExpose,
-    defineProps, nextTick, reactive,
+    defineProps, nextTick, reactive, ref,
 } from 'vue';
 
 import { PDataLoader } from '@spaceone/design-system';
@@ -51,11 +51,11 @@ type ChartData = Partial<Record<GroupBy, string>> & { usd_cost: number; };
 
 const props = defineProps<WidgetProps>();
 
+const chartContext = ref<HTMLElement|null>(null);
 const {
-    chartContext,
     createPieChart, createTooltip, createPieSeries, setPieTooltipText,
     disposeRoot,
-} = useAmcharts5();
+} = useAmcharts5(chartContext);
 
 const state = reactive({
     ...useWidgetState<Data[]>(props),

--- a/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
@@ -3,18 +3,156 @@
                   :size="state.size"
                   :width="props.width"
     >
-        <!-- TODO: implementation -->
+        <div class="chart-wrapper">
+            <p-data-loader class="chart-loader"
+                           :loadig="state.loading"
+                           :data="state.data"
+                           loader-type="skeleton"
+                           show-data-from-scratch
+            >
+                <div ref="chartContext"
+                     class="chart"
+                />
+            </p-data-loader>
+        </div>
+
+        <widget-data-table :loading="state.loading"
+                           :fields="state.tableFields"
+                           :items="state.chartData"
+                           :currency="state.options.currency"
+                           :currency-rates="props.currencyRates"
+        />
     </widget-frame>
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import {
+    computed,
+    defineExpose,
+    defineProps, nextTick, reactive,
+} from 'vue';
 
+import { PDataLoader } from '@spaceone/design-system';
+import { random } from 'lodash';
+
+import { useAmcharts5 } from '@/common/composables/amcharts5';
+
+import WidgetDataTable from '@/services/dashboards/widgets/_components/WidgetDataTable.vue';
 import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
-import type { WidgetProps } from '@/services/dashboards/widgets/config';
+import type { GroupBy, WidgetProps } from '@/services/dashboards/widgets/config';
+import { GROUP_BY } from '@/services/dashboards/widgets/config';
+import { useWidgetLifecycle } from '@/services/dashboards/widgets/use-widget-lifecycle';
 // eslint-disable-next-line import/no-cycle
-import { useWidgetData } from '@/services/dashboards/widgets/use-widget-data';
+import { useWidgetState } from '@/services/dashboards/widgets/use-widget-state';
+import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/view-config';
+
+type Data = Partial<Record<GroupBy, string>> & { usd_cost: number; };
+type ChartData = Partial<Record<GroupBy, string>> & { usd_cost: number; };
 
 const props = defineProps<WidgetProps>();
-const state = useWidgetData(props);
+
+const {
+    chartContext, createPieChart, createTooltip, createPieSeries, setPieTooltipText,
+} = useAmcharts5();
+
+const state = reactive({
+    ...useWidgetState<Data[]>(props),
+    chart: null as null|ReturnType<typeof createPieChart>,
+    series: null as null|ReturnType<typeof createPieSeries>,
+    groupBy: computed<GroupBy>(() => state.options.group_by ?? GROUP_BY.PROVIDER),
+    groupByLabel: computed<string>(() => {
+        const groupBy = state.groupBy;
+        return GROUP_BY_ITEM_MAP[groupBy]?.label ?? groupBy;
+    }),
+    chartData: computed<Data[]>(() => {
+        if (!state.data) return [];
+        return state.data;
+    }),
+    tableFields: computed(() => [
+        { label: state.groupByLabel, name: state.groupBy },
+        { label: 'Cost', name: 'usd_cost' },
+    ]),
+});
+
+// TODO: api binding
+const fetchData = async (): Promise<Data[]> => new Promise((resolve) => {
+    setTimeout(() => {
+        resolve([{
+            provider: 'google cloud',
+            usd_cost: random(1000, 5000),
+        },
+        {
+            provider: 'aws',
+            usd_cost: random(1000, 5000),
+        },
+        {
+            provider: 'azure',
+            usd_cost: random(1000, 5000),
+        },
+        {
+            provider: 'alibaba',
+            usd_cost: random(1000, 5000),
+        },
+        ]);
+    }, 2000);
+});
+
+const drawChart = (chartData: ChartData[]) => {
+    const chart = createPieChart();
+
+    const seriesSettings = {
+        categoryField: state.groupBy,
+        valueField: 'usd_cost',
+    };
+    const series = createPieSeries(chart, seriesSettings);
+    const tooltip = createTooltip();
+    setPieTooltipText(series, tooltip, state.options.currency, props.currencyRates);
+    series.slices.template.set('tooltip', tooltip);
+    series.data.setAll(chartData);
+
+    state.chart = chart;
+    state.series = series;
+};
+
+const updateChart = (chartData: ChartData[]) => {
+    if (!state.series) return;
+    state.series.data.setAll(chartData);
+};
+
+const initWidget = async () => {
+    state.loading = true;
+    state.data = await fetchData();
+    await nextTick();
+    drawChart(state.chartData);
+    state.loading = false;
+};
+
+const refreshWidget = async () => {
+    state.loading = true;
+    state.data = await fetchData();
+    await nextTick();
+    updateChart(state.chartData);
+    state.loading = false;
+};
+
+useWidgetLifecycle({
+    initWidget,
+});
+
+defineExpose({
+    refreshWidget,
+});
+
 </script>
+
+<style scoped lang="postcss">
+.chart-wrapper {
+    height: 155px;
+    .chart {
+        height: 100%;
+    }
+}
+.chart-loader {
+    height: 100%;
+}
+</style>

--- a/src/services/dashboards/widgets/config.ts
+++ b/src/services/dashboards/widgets/config.ts
@@ -8,6 +8,7 @@ import type { QueryStoreFilter } from '@cloudforet/core-lib/query/type';
 import type { Tags } from '@/models';
 
 import type { Currency } from '@/store/modules/display/config';
+import type { CurrencyRates } from '@/store/modules/display/type';
 
 import type { CHART_TYPE } from '@/services/cost-explorer/cost-analysis/type';
 
@@ -75,7 +76,7 @@ type ChartType = typeof CHART_TYPE[keyof typeof CHART_TYPE];
 export interface WidgetOptions {
     date_range?: { start?: string; end?: string; };
     currency?: Currency;
-    group_by?: string[];
+    group_by?: GroupBy[];
     granularity?: Granularity;
     stacked?: boolean;
     enable_legend?: boolean;
@@ -117,4 +118,5 @@ export interface WidgetProps {
     width?: number;
     theme?: string; // e.g. 'violet', 'coral', 'peacock', ... default: violet
     widgetKey: string; // unique widget key to identify widgets in layout
+    currencyRates?: CurrencyRates;
 }

--- a/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
+++ b/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
@@ -13,8 +13,8 @@ import { defineProps } from 'vue';
 import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
 import type { WidgetProps } from '@/services/dashboards/widgets/config';
 // eslint-disable-next-line import/no-cycle
-import { useWidgetData } from '@/services/dashboards/widgets/use-widget-data';
+import { useWidgetState } from '@/services/dashboards/widgets/use-widget-state';
 
 const props = defineProps<WidgetProps>();
-const state = useWidgetData(props);
+const state = useWidgetState(props);
 </script>

--- a/src/services/dashboards/widgets/use-widget-lifecycle.ts
+++ b/src/services/dashboards/widgets/use-widget-lifecycle.ts
@@ -1,13 +1,14 @@
 import {
-    onMounted,
+    onMounted, onUnmounted,
 } from 'vue';
 
 interface UseWidgetLifecycleOptions {
     initWidget: () => void;
+    disposeWidget?: () => void;
 }
 
 export const useWidgetLifecycle = ({
-    initWidget,
+    initWidget, disposeWidget,
 }: UseWidgetLifecycleOptions): void => {
     let isInitiated = false;
     // auto initiating
@@ -16,5 +17,9 @@ export const useWidgetLifecycle = ({
             initWidget();
             isInitiated = true;
         }
+    });
+
+    onUnmounted(() => {
+        if (disposeWidget) disposeWidget();
     });
 };

--- a/src/services/dashboards/widgets/use-widget-lifecycle.ts
+++ b/src/services/dashboards/widgets/use-widget-lifecycle.ts
@@ -1,0 +1,20 @@
+import {
+    onMounted,
+} from 'vue';
+
+interface UseWidgetLifecycleOptions {
+    initWidget: () => void;
+}
+
+export const useWidgetLifecycle = ({
+    initWidget,
+}: UseWidgetLifecycleOptions): void => {
+    let isInitiated = false;
+    // auto initiating
+    onMounted(() => {
+        if (!isInitiated) {
+            initWidget();
+            isInitiated = true;
+        }
+    });
+};

--- a/src/services/dashboards/widgets/use-widget-state.ts
+++ b/src/services/dashboards/widgets/use-widget-state.ts
@@ -1,4 +1,6 @@
-import { computed, reactive } from 'vue';
+import {
+    computed, reactive,
+} from 'vue';
 
 import { merge } from 'lodash';
 
@@ -24,16 +26,25 @@ const getRefinedOptions = (
     return merge({}, mergedOptions, parentOptions);
 };
 
-export const useWidgetData = (props: WidgetProps) => {
+export function useWidgetState<Data = any>(
+    props: WidgetProps,
+) {
     const state = reactive({
         widgetConfig: computed<WidgetConfig>(() => getWidgetConfig(props.widgetConfigId)),
         title: computed<string>(() => props.title ?? state.widgetConfig.title),
-        options: computed<WidgetOptions>(() => getRefinedOptions(state.widgetConfig.widget_options, props.options, props.inheritOptions, props.dashboardOptions)),
+        options: computed<WidgetOptions>(() => getRefinedOptions(
+            state.widgetConfig.widget_options,
+            props.options,
+            props.inheritOptions,
+            props.dashboardOptions,
+        )),
         size: computed<WidgetSize>(() => {
             if (state.widgetConfig.sizes.includes(props.size)) return props.size;
             return state.widgetConfig.sizes[0];
         }),
+        loading: true,
+        data: null as Data|null,
     });
 
     return state;
-};
+}

--- a/src/services/dashboards/widgets/view-config.ts
+++ b/src/services/dashboards/widgets/view-config.ts
@@ -1,0 +1,14 @@
+import { GROUP_BY } from '@/services/dashboards/widgets/config';
+
+export const GROUP_BY_ITEM_MAP = {
+    [GROUP_BY.PROJECT_GROUP]: { name: GROUP_BY.PROJECT_GROUP, label: 'Project Group' },
+    [GROUP_BY.PROJECT]: { name: GROUP_BY.PROJECT, label: 'Project' },
+    [GROUP_BY.PROVIDER]: { name: GROUP_BY.PROVIDER, label: 'Provider' },
+    [GROUP_BY.SERVICE_ACCOUNT]: { name: GROUP_BY.SERVICE_ACCOUNT, label: 'Service Account' },
+    [GROUP_BY.CATEGORY]: { name: GROUP_BY.CATEGORY, label: 'Category' },
+    [GROUP_BY.RESOURCE_GROUP]: { name: GROUP_BY.RESOURCE_GROUP, label: 'Resource Group' },
+    [GROUP_BY.PRODUCT]: { name: GROUP_BY.PRODUCT, label: 'Product' },
+    [GROUP_BY.REGION]: { name: GROUP_BY.REGION, label: 'Region' },
+    [GROUP_BY.TYPE]: { name: GROUP_BY.TYPE, label: 'Type' },
+    [GROUP_BY.ACCOUNT]: { name: GROUP_BY.ACCOUNT, label: 'Account ID' },
+} as const;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

#### Please read the commit logs step by step. Sorry for big size of PR 🙏

- Add `useWidgetLifecycle` hook for initiating widget
- Add `view-config.ts` to manage constants that are needed for display contents, not the real data
- Rename `useWidgetData` to `useWidgetState`
- add `currencyRates` to `widgetProps`
- update `useAmchart5` hook argument `chartContext` to take `null` and `undefined`. If `chartContext` is not given, hook automatically generate it.
- implement `basePieWidget` as a reference for widget implementation and usage of hooks
- add refresh button to `widgetPreviewPage` for test

![image](https://user-images.githubusercontent.com/26986739/203336723-eec238b9-9128-419f-a660-4500ea4af265.png)

Result:

https://user-images.githubusercontent.com/26986739/203456540-2ec55689-3499-406e-a004-ece7017dd078.mov



### Things to Talk About

I guess there is some bugs in `DataLoader` component that the loader does not disappear even if the `loading` prop is `false`. 
I will check it on Mirinae project after this PR.
