### PR TITLE
feat: Add props binding from WidgetPreviewPage.vue to Widget components - dashboardOptions, inheritOptions

### DIFF
--- a/src/services/dashboards/widgets/WidgetsPreviewPage.vue
+++ b/src/services/dashboards/widgets/WidgetsPreviewPage.vue
@@ -23,13 +23,31 @@
             </template>
         </div>
         <br>
-        <component :is="widgetComponent"
-                   v-if="mounted"
-                   ref="widgetRef"
-                   :widget-config-id="widgetId"
-                   :widget-key="widgetId"
-                   :currency-rates="currencyRates"
-        />
+        <div v-if="mounted"
+             class="flex gap-4"
+        >
+            <component :is="widgetComponent"
+                       ref="widgetRef"
+                       :widget-config-id="widgetId"
+                       :widget-key="widgetId"
+                       :currency-rates="currencyRates"
+                       :dashboard-options="{
+                           currency
+                       }"
+                       :inherit-options="{
+                           currency: { enabled: true },
+                           date_range: { enabled: true },
+                       }"
+            />
+            <div>
+                <p-field-group label="Currency"
+                               required
+                               inline
+                >
+                    <currency-select-dropdown @update="currency = $event" />
+                </p-field-group>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -39,10 +57,13 @@ import {
     defineComponent, reactive, toRefs, computed, onUnmounted, watch,
 } from 'vue';
 
-import { PButton, PIconButton } from '@spaceone/design-system';
+import { PButton, PFieldGroup, PIconButton } from '@spaceone/design-system';
 
 import { store } from '@/store';
 
+import { CURRENCY } from '@/store/modules/display/config';
+
+import CurrencySelectDropdown from '@/services/cost-explorer/modules/CurrencySelectDropdown.vue';
 import { getWidgetComponent, getWidgetConfig } from '@/services/dashboards/widgets/helper';
 
 interface Props {
@@ -51,7 +72,9 @@ interface Props {
 
 export default defineComponent<Props>({
     name: 'WidgetsPreviewPage',
-    components: { PIconButton, PButton },
+    components: {
+        PFieldGroup, CurrencySelectDropdown, PIconButton, PButton,
+    },
     props: {
         widgetId: {
             type: String,
@@ -66,6 +89,7 @@ export default defineComponent<Props>({
             currencyRates: computed(() => store.state.display.currencyRates),
             mounted: false,
             autoRefresh: true,
+            currency: CURRENCY.USD,
         });
 
         const { counter, pause, resume } = useInterval(1000, { controls: true });

--- a/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
@@ -29,7 +29,7 @@
 import {
     computed,
     defineExpose,
-    defineProps, nextTick, reactive, ref,
+    defineProps, nextTick, reactive, ref, toRefs,
 } from 'vue';
 
 import { PDataLoader } from '@spaceone/design-system';
@@ -58,7 +58,7 @@ const {
 } = useAmcharts5(chartContext);
 
 const state = reactive({
-    ...useWidgetState<Data[]>(props),
+    ...toRefs(useWidgetState<Data[]>(props)),
     chart: null as null|ReturnType<typeof createPieChart>,
     series: null as null|ReturnType<typeof createPieSeries>,
     groupBy: computed<GroupBy>(() => state.options.group_by ?? GROUP_BY.PROVIDER),


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- Add props binding from `WidgetPreviewPage.vue` to Widget components - `dashboardOptions`, `inheritOptions` 
- FIx to use toRefs to sustain reactivity of each of items in reactive state (`BasePie.vue`)


### Things to Talk About
