### PR TITLE
fix(base-trend-widget): refreshRoot() when refresh widget

### DIFF
--- a/src/common/composables/amcharts5/index.ts
+++ b/src/common/composables/amcharts5/index.ts
@@ -51,6 +51,13 @@ export const useAmcharts5 = (
         root: undefined as undefined | Root,
     });
 
+    const refreshRoot = () => {
+        disposeRoot();
+        const root = am5.Root.new(state.chartContext as HTMLElement);
+        state.root = root;
+        initRoot(root);
+    };
+
     const initRoot = (root: Root) => {
         root.setThemes([am5themes_Animated.new(root), Amcharts5GlobalTheme.new(root)]);
         root.utc = true;
@@ -94,6 +101,7 @@ export const useAmcharts5 = (
 
     return {
         root: toRef(state, 'root'),
+        refreshRoot,
         disposeRoot,
         clearChildrenOfRoot,
         //


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
There's some bug in tooltip of amcharts5. ([Tooltips staying after clear](https://github.com/amcharts/amcharts5/issues/593))
**You have to `refreshRoot()` when refresh widget!**