### PR TITLE
feat(widget-frame): connect widgetFrame width

### DIFF
--- a/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -77,6 +77,7 @@ import { getUUID } from '@/lib/component-util/getUUID';
 import DeleteModal from '@/common/components/modals/DeleteModal.vue';
 import { useI18nDayjs } from '@/common/composables/i18n-dayjs';
 
+import { WIDGET_FRAME_WIDTH_RANGE_LIST } from '@/services/dashboards/dashboard-detail/lib/config';
 import type { WidgetOptions, WidgetSize } from '@/services/dashboards/widgets/config';
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/config';
 
@@ -124,7 +125,7 @@ export default defineComponent<Props>({
         // FIXME:: width should be -= 16 because of margin.
         width: {
             type: Number,
-            default: 320, // default width of sm size
+            default: WIDGET_FRAME_WIDTH_RANGE_LIST.SM[0],
         },
         widgetLink: {
             type: String,

--- a/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="widget-frame"
          :class="{ full: isFull, 'edit-mode': editMode }"
-         :style="{ width: isFull ? '100%' : width }"
+         :style="{ width: `${width}px` }"
     >
         <div class="widget-header">
             <h3 class="title">
@@ -83,7 +83,7 @@ import { WIDGET_SIZE } from '@/services/dashboards/widgets/config';
 interface Props {
     title: TranslateResult;
     size: WidgetSize;
-    width: string;
+    width: number;
     widgetLink?: string;
     widgetRoute?: Route;
     dateRange?: WidgetOptions['date_range'];
@@ -121,9 +121,10 @@ export default defineComponent<Props>({
             type: String as PropType<WidgetSize>,
             default: WIDGET_SIZE.md,
         },
+        // FIXME:: width should be -= 16 because of margin.
         width: {
-            type: String,
-            default: '30rem', // default width of md size
+            type: Number,
+            default: 320, // default width of sm size
         },
         widgetLink: {
             type: String,
@@ -231,6 +232,7 @@ export default defineComponent<Props>({
 <style lang="postcss" scoped>
 .widget-frame {
     height: 29rem;
+    margin: 0.5rem;
 
     @apply border rounded-lg bg-white;
     border-color: theme('colors.gray.200');


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- I've connected widgetFrame width. It is pretty cool 

![스크린샷 2022-11-28 오후 4 15 51](https://user-images.githubusercontent.com/29014433/204216754-aaf6db8b-8519-48a4-bf5e-3ad14bf341fe.png)

- I've changed `eventlistener('resize')` to `resizeObserver`. Becuase, `eventlistener('resize')` cannot detect width changes caused by LNB

### Things to Talk About

There is needed some margins between widgetFrame. (`margin: 8px`).
So, I need to minus 16px (8px * 2).
But I am confusing that which stage (widgetFrameContainer? widgetFrae?) to perform minus.
