### PR TITLE
feat(core-lib): add client2 for serviceApiV2 in SpaceConnector & update usages

### DIFF
--- a/packages/cloudforet/core-lib/__tests__/space-connector/__tests__/index.test.ts
+++ b/packages/cloudforet/core-lib/__tests__/space-connector/__tests__/index.test.ts
@@ -1,10 +1,11 @@
 import { SpaceConnector } from '@/space-connector';
+import TokenAPI from '@/space-connector/token-api';
 
 describe('SpaceConnector', () => {
-    const endpoint = 'https://localhost:3000';
-
+    const endpoints = ['https://localhost:3000', 'https://localhost:3001'];
+    const tokenApi = new TokenAPI(endpoints[0], () => { console.log('session expired!'); });
     test('init SpaceConnector', () => {
-        SpaceConnector.init(endpoint);
+        SpaceConnector.init(endpoints, tokenApi);
         expect(typeof SpaceConnector.client).toBe('object');
     });
 });

--- a/packages/cloudforet/core-lib/src/space-connector/index.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/index.ts
@@ -34,23 +34,28 @@ export class SpaceConnector {
 
     private readonly serviceApi: ServiceAPI;
 
+    private readonly serviceApiV2: ServiceAPI;
+
     private readonly tokenApi: TokenAPI;
 
     private _client: any = {};
+
+    private _clientV2: any = {};
 
     private mockInfo: MockInfo;
 
     private readonly afterCallApiMap: AfterCallApiMap;
 
     constructor(
-        endpoint: string,
+        endpoints: string[],
         tokenApi: TokenAPI,
         mockInfo: MockInfo,
         afterCallApiMap: AfterCallApiMap,
     ) {
         this.mockInfo = mockInfo;
         this.tokenApi = tokenApi;
-        this.serviceApi = new ServiceAPI(endpoint, this.tokenApi);
+        this.serviceApi = new ServiceAPI(endpoints[0], this.tokenApi);
+        this.serviceApiV2 = new ServiceAPI(endpoints[1], this.tokenApi);
         this.afterCallApiMap = afterCallApiMap;
         this.setApiTokenCheckInterval();
     }
@@ -67,10 +72,13 @@ export class SpaceConnector {
         }
     }
 
-    static async init(endpoint: string, tokenApi: TokenAPI, mockInfo: MockInfo = {}, afterCallApiMap: AfterCallApiMap = {}): Promise<void> {
+    static async init(endpoints: string[], tokenApi: TokenAPI, mockInfo: MockInfo = {}, afterCallApiMap: AfterCallApiMap = {}): Promise<void> {
         if (!SpaceConnector.instance) {
-            SpaceConnector.instance = new SpaceConnector(endpoint, tokenApi, mockInfo, afterCallApiMap);
-            await SpaceConnector.instance.loadAPI();
+            SpaceConnector.instance = new SpaceConnector(endpoints, tokenApi, mockInfo, afterCallApiMap);
+            await Promise.allSettled([
+                SpaceConnector.instance.loadAPI(1),
+                SpaceConnector.instance.loadAPI(2),
+            ]);
         }
     }
 
@@ -78,7 +86,14 @@ export class SpaceConnector {
         if (SpaceConnector.instance) {
             return SpaceConnector.instance._client;
         }
-        throw new Error('Not initialized SpaceONE client!');
+        throw new Error('Not initialized client!');
+    }
+
+    static get clientV2(): any {
+        if (SpaceConnector.instance) {
+            return SpaceConnector.instance._clientV2;
+        }
+        throw new Error('Not initialized client V2!');
     }
 
     static setToken(accessToken: string, refreshToken: string): void {
@@ -99,28 +114,35 @@ export class SpaceConnector {
         return TokenAPI.checkToken();
     }
 
-    protected async loadAPI(): Promise<void> {
+    protected async loadAPI(version: number): Promise<void> {
         try {
             let reflectionApi;
-            if (this.mockInfo.reflection && this.mockInfo.endpoint) {
+            const mockEndpoint = this.mockInfo.endpoints?.[version - 1];
+            if (this.mockInfo.reflection && mockEndpoint) {
                 reflectionApi = axios.create({
                     headers: { 'Content-Type': 'application/json' },
-                    baseURL: this.mockInfo.endpoint,
+                    baseURL: mockEndpoint,
                 });
             } else {
-                reflectionApi = this.serviceApi.instance;
+                reflectionApi = version === 2 ? this.serviceApiV2.instance : this.serviceApi.instance;
             }
-            const response: AxiosPostResponse = await reflectionApi.post(API_REFLECTION_URL);
+
+            let response: AxiosPostResponse;
+            if (version === 2) {
+                response = await reflectionApi.get(API_REFLECTION_URL);
+            } else {
+                response = await reflectionApi.post(API_REFLECTION_URL);
+            }
             response.data.apis.forEach((apiInfo: APIInfo) => {
-                this.bindAPIHandler(apiInfo);
+                this.bindAPIHandler(apiInfo, version);
             });
         } catch (e: any) {
-            throw new Error(`SpaceONE Client LoadAPI Error: ${e.message}`);
+            throw new Error(`Api Client LoadAPI Error: ${e.message}`);
         }
     }
 
-    protected bindAPIHandler(apiInfo: APIInfo): void {
-        let currentPath = this._client;
+    protected bindAPIHandler(apiInfo: APIInfo, version: number): void {
+        let currentPath = version === 2 ? this._clientV2 : this._client;
         let apiInfoArr = apiInfo.path.split('/');
         apiInfoArr = apiInfoArr.filter(Boolean);
 
@@ -130,7 +152,7 @@ export class SpaceConnector {
                 // Bind APIHandler if last index
                 if ((apiInfoArr.length - 1) === idx) {
                     const afterCall = this.afterCallApiMap[apiInfo.path];
-                    currentPath[objCamel] = this.APIHandler(apiInfo.path, afterCall);
+                    currentPath[objCamel] = this.APIHandler(apiInfo.path, afterCall, version);
                 } else {
                     currentPath[objCamel] = {};
                 }
@@ -139,20 +161,22 @@ export class SpaceConnector {
         });
     }
 
-    protected APIHandler(path: string, afterCall: AfterCallApi) {
-        if (this.mockInfo.endpoint) {
+    protected APIHandler(path: string, afterCall: AfterCallApi, version: number) {
+        const mockEndpoint = this.mockInfo.endpoints?.[version - 1];
+        const serviceApi = version === 2 ? this.serviceApiV2 : this.serviceApi;
+        if (mockEndpoint) {
             return async (params: object = {}, config: MockRequestConfig = DEFAULT_MOCK_CONFIG): Promise<any> => {
                 const mockConfig = { ...config };
                 let url = path;
 
                 if (this.mockInfo.all || mockConfig.mockMode) {
-                    mockConfig.baseURL = this.mockInfo.endpoint;
+                    mockConfig.baseURL = mockEndpoint;
                     if (mockConfig.mockPath) {
                         url += mockConfig.mockPath;
                     }
                 }
 
-                const response: AxiosPostResponse = await this.serviceApi.instance.post(url, params, mockConfig);
+                const response: AxiosPostResponse = await serviceApi.instance.post(url, params, mockConfig);
 
                 if (afterCall) afterCall(response.data);
 
@@ -160,7 +184,7 @@ export class SpaceConnector {
             };
         }
         return async (params: object = {}, config?: AxiosRequestConfig): Promise<any> => {
-            const response: AxiosPostResponse = await this.serviceApi.instance.post(path, params, config);
+            const response: AxiosPostResponse = await serviceApi.instance.post(path, params, config);
 
             if (afterCall) afterCall(response.data);
 

--- a/packages/cloudforet/core-lib/src/space-connector/index.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/index.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { camelCase } from 'lodash';
 
 import type {
-    SessionTimeoutCallback, APIInfo, MockInfo, AxiosPostResponse,
+    APIInfo, MockInfo, AxiosPostResponse,
 } from '@/space-connector/type';
 
 import ServiceAPI from './service-api';
@@ -44,12 +44,12 @@ export class SpaceConnector {
 
     constructor(
         endpoint: string,
-        sessionTimeoutCallback: SessionTimeoutCallback = () => undefined,
+        tokenApi: TokenAPI,
         mockInfo: MockInfo,
         afterCallApiMap: AfterCallApiMap,
     ) {
         this.mockInfo = mockInfo;
-        this.tokenApi = TokenAPI.getInstance(endpoint, sessionTimeoutCallback);
+        this.tokenApi = tokenApi;
         this.serviceApi = new ServiceAPI(endpoint, this.tokenApi);
         this.afterCallApiMap = afterCallApiMap;
         this.setApiTokenCheckInterval();
@@ -67,9 +67,9 @@ export class SpaceConnector {
         }
     }
 
-    static async init(endpoint: string, sessionTimeoutCallback?: SessionTimeoutCallback, mockInfo: MockInfo = {}, afterCallApiMap: AfterCallApiMap = {}): Promise<void> {
+    static async init(endpoint: string, tokenApi: TokenAPI, mockInfo: MockInfo = {}, afterCallApiMap: AfterCallApiMap = {}): Promise<void> {
         if (!SpaceConnector.instance) {
-            SpaceConnector.instance = new SpaceConnector(endpoint, sessionTimeoutCallback, mockInfo, afterCallApiMap);
+            SpaceConnector.instance = new SpaceConnector(endpoint, tokenApi, mockInfo, afterCallApiMap);
             await SpaceConnector.instance.loadAPI();
         }
     }

--- a/packages/cloudforet/core-lib/src/space-connector/type.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/type.ts
@@ -88,6 +88,6 @@ export interface Query {
 
 export interface MockInfo {
     all?: boolean;
-    endpoint?: string;
+    endpoints?: string[];
     reflection?: boolean;
 }

--- a/public/config/default.json
+++ b/public/config/default.json
@@ -2,6 +2,9 @@
   "CONSOLE_API": {
     "ENDPOINT": "https://console.api.dev.spaceone.dev"
   },
+  "CONSOLE_API_V2": {
+    "ENDPOINT": "https://console-v2.api.dev.spaceone.dev"
+  },
   "GTAG_ID": "DISABLED",
   "GTM_ID": "DISABLED",
   "DOMAIN_NAME": null,

--- a/src/lib/site-initializer/api-client.ts
+++ b/src/lib/site-initializer/api-client.ts
@@ -1,5 +1,7 @@
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+import TokenAPI from '@cloudforet/core-lib/space-connector/token-api';
 import type { MockInfo } from '@cloudforet/core-lib/space-connector/type';
+
 
 const getAfterCallApiMap = (store) => ({
     '/inventory/cloud-service-type/create': (data) => { store.dispatch('reference/cloudServiceType/sync', data); },
@@ -33,17 +35,19 @@ const getSessionTimeoutCallback = (store) => () => {
     store.dispatch('user/setIsSessionExpired', true);
     store.dispatch('error/showSessionExpiredError');
 };
-const getApiEndpoint = (config) => config.get('CONSOLE_API.ENDPOINT');
+const getApiEndpoints = (config) => [config.get('CONSOLE_API.ENDPOINT'), config.get('CONSOLE_API_V2.ENDPOINT')];
 const getMockInfo = (config): MockInfo => ({
-    endpoint: config.get('MOCK.ENDPOINT'),
+    endpoints: [config.get('MOCK.ENDPOINT')],
     all: config.get('MOCK.ALL'),
     reflection: config.get('MOCK.REFLECTION'),
 });
 
 export const initApiClient = async (store, config) => {
+    const endpoints = getApiEndpoints(config);
+    const tokenApi = new TokenAPI(endpoints[0], getSessionTimeoutCallback(store));
     await SpaceConnector.init(
-        getApiEndpoint(config),
-        getSessionTimeoutCallback(store),
+        endpoints,
+        tokenApi,
         getMockInfo(config),
         getAfterCallApiMap(store),
     );


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- Add SpaceConnector client2 for serviceApiV2
- Add CONSOLE_API_V2 to default config

![image](https://user-images.githubusercontent.com/26986739/204450176-9a5b7a27-812a-4b2f-844c-8f9a8ab558f7.png)


### Things to Talk About
