### PR TITLE
fix(widget): add component & use `BaseTrendWidget` as child component

### DIFF
--- a/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
@@ -4,6 +4,13 @@
                   :width="props.width"
                   class="base-trend-widget"
     >
+        <template v-for="(_, slot) of $scopedSlots"
+                  #[slot]="scope"
+        >
+            <slot :name="slot"
+                  v-bind="scope"
+            />
+        </template>
         <div class="chart-wrapper">
             <p-data-loader class="chart-loader"
                            :loading="state.loading"

--- a/src/services/dashboards/widgets/_components/WidgetFrameHeaderDropdown.vue
+++ b/src/services/dashboards/widgets/_components/WidgetFrameHeaderDropdown.vue
@@ -1,0 +1,26 @@
+<template>
+    <p-select-dropdown :selected="selected"
+                       :items="props.items"
+                       style-type="transparent"
+                       class="widget-frame-header-dropdown"
+                       @select="handleSelectItem"
+    />
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+
+import { PSelectDropdown } from '@spaceone/design-system';
+import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
+
+interface Props {
+    items: MenuItem[];
+    selected: string;
+}
+const props = defineProps<Props>();
+const emit = defineEmits(['select']);
+
+const handleSelectItem = (selected: string) => {
+    emit('select', selected);
+};
+</script>

--- a/src/services/dashboards/widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrend.vue
+++ b/src/services/dashboards/widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrend.vue
@@ -1,0 +1,51 @@
+<template>
+    <base-trend-widget ref="widgetRef"
+                       v-bind="$props"
+    >
+        <template #header-right>
+            <widget-frame-header-dropdown :items="state.items"
+                                          :selected="state.selected"
+                                          @select="handleSelect"
+            />
+        </template>
+    </base-trend-widget>
+</template>
+
+<script setup lang="ts">
+import {
+    computed, defineExpose, defineProps, reactive, ref, toRefs,
+} from 'vue';
+
+import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
+
+import BaseTrendWidget from '@/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue';
+import WidgetFrameHeaderDropdown from '@/services/dashboards/widgets/_components/WidgetFrameHeaderDropdown.vue';
+import type { WidgetProps } from '@/services/dashboards/widgets/config';
+// eslint-disable-next-line import/no-cycle
+import { useWidgetState } from '@/services/dashboards/widgets/use-widget-state';
+
+const props = defineProps<WidgetProps>();
+const state = reactive({
+    ...toRefs(useWidgetState(props)),
+    items: computed<MenuItem[]>(() => ([
+        { type: 'item', name: 'cost', label: 'Cost' }, // TODO: i18n?
+        { type: 'item', name: 'size', label: 'Size' },
+    ])),
+    selected: 'cost',
+});
+const widgetRef = ref<any>(null);
+
+const refreshWidget = () => {
+    if (widgetRef.value) widgetRef.value.refreshWidget();
+};
+const handleSelect = (selected) => {
+    if (state.selected !== selected) {
+        state.selected = selected;
+        refreshWidget();
+    }
+};
+
+defineExpose({
+    refreshWidget,
+});
+</script>

--- a/src/services/dashboards/widgets/aws-data-transfer-cost-trend/widget-config.ts
+++ b/src/services/dashboards/widgets/aws-data-transfer-cost-trend/widget-config.ts
@@ -3,7 +3,9 @@ import { CHART_TYPE } from '@/services/dashboards/widgets/config';
 
 const awsDataTransferCostTrendWidgetConfig: WidgetConfig = {
     widget_config_id: 'awsDataTransferCostTrend',
-    base_configs: [{ config_id: 'baseTrend' }],
+    widget_component: () => ({
+        component: import('@/services/dashboards/widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrend.vue'),
+    }),
     title: 'AWS Data-Transfer Cost Trend',
     labels: ['Cost'],
     description: {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- craete `WidgetFrameHeaderDropdown`
- use `BaseTrendWidget` as a child component in 'awsDataTransferCostTrend'

![스크린샷 2022-11-30 오후 9 29 37](https://user-images.githubusercontent.com/18563857/204803646-174984f8-0090-4bbd-aec3-081c5caeeb1a.png)