### PR TITLE
fix(cost-dashboard): fix custom widget image broken

### DIFF
--- a/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CostDashboardCustomizeCustomWidgetTab.vue
+++ b/src/services/cost-explorer/cost-dashboard/cost-dashboard-customize/modules/CostDashboardCustomizeCustomWidgetTab.vue
@@ -23,7 +23,7 @@
                         </div>
                         <div class="card-content">
                             <img class="card-image"
-                                 :src="require(`@/assets/images/${getChartTypeImageFileName(widget.options.chart_type)}.svg`)"
+                                 :src="widgetCardImageList[idx].value.default"
                             >
                         </div>
                     </li>
@@ -125,6 +125,7 @@ export default {
             allPage: computed(() => Math.ceil(state.totalCount / PAGE_SIZE) || 1),
             thisPage: 1,
             userId: computed(() => store.state.user.userId),
+            widgetCardImageList: [],
         });
 
         /* Api */
@@ -187,8 +188,15 @@ export default {
         };
         const getChartTypeImageFileName = (chartType: ChartType) => chartTypeItemMap[chartType].imageFileName;
 
-        (() => {
-            listCustomWidget();
+        const getWidgetCardImageList = async (): Promise<void> => {
+            state.widgetCardImageList = await Promise.allSettled(
+                state.widgetList.map((d) => import(`../../../../../assets/images/${getChartTypeImageFileName(d.options.chart_type)}.svg`)),
+            );
+        };
+
+        (async () => {
+            await listCustomWidget();
+            await getWidgetCardImageList();
         })();
 
         watch(() => state.selectedQuery, (selectedQuery) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description

Resolve `require` error.

![스크린샷 2022-12-06 오후 5 17 44](https://user-images.githubusercontent.com/29014433/205857409-d94f9011-7656-412e-bb93-0ec382111171.png)


### Things to Talk About

It looks like there are lots of errors (developer mode console) at cost dashboard customize.
We need to check it soon.