### PR TITLE
feat(currency): add `defaultMode` in dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@amcharts/amcharts5": "^5.2.31",
         "@amcharts/amcharts5-geodata": "^5.0.6",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.461",
+        "@spaceone/design-system": "^1.1.0-beta.462",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -3865,9 +3865,9 @@
       }
     },
     "node_modules/@spaceone/design-system": {
-      "version": "1.1.0-beta.461",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.461.tgz",
-      "integrity": "sha512-bYkw5W5EZJZlUuVvIjZBMaFw/6GlYQhk+clxIp3ro7yh3nhe5vptcSenwuW24kNlnEndXznK/cqqHeJRF2KEZQ==",
+      "version": "1.1.0-beta.462",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.462.tgz",
+      "integrity": "sha512-hAFTRqJSqas3KnMWYhfuisvbnt5MvWXPQh7+Tbm4tFIkGj/3B4xs6NWHRtk/3gUOvbPXMsyBn7jZ7ikx+wp4Ew==",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -25020,9 +25020,9 @@
       }
     },
     "@spaceone/design-system": {
-      "version": "1.1.0-beta.461",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.461.tgz",
-      "integrity": "sha512-bYkw5W5EZJZlUuVvIjZBMaFw/6GlYQhk+clxIp3ro7yh3nhe5vptcSenwuW24kNlnEndXznK/cqqHeJRF2KEZQ==",
+      "version": "1.1.0-beta.462",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.462.tgz",
+      "integrity": "sha512-hAFTRqJSqas3KnMWYhfuisvbnt5MvWXPQh7+Tbm4tFIkGj/3B4xs6NWHRtk/3gUOvbPXMsyBn7jZ7ikx+wp4Ew==",
       "requires": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -27665,7 +27665,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.461",
+        "@spaceone/design-system": "^1.1.0-beta.462",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -30488,9 +30488,9 @@
           }
         },
         "@spaceone/design-system": {
-          "version": "1.1.0-beta.461",
-          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.461.tgz",
-          "integrity": "sha512-bYkw5W5EZJZlUuVvIjZBMaFw/6GlYQhk+clxIp3ro7yh3nhe5vptcSenwuW24kNlnEndXznK/cqqHeJRF2KEZQ==",
+          "version": "1.1.0-beta.462",
+          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.462.tgz",
+          "integrity": "sha512-hAFTRqJSqas3KnMWYhfuisvbnt5MvWXPQh7+Tbm4tFIkGj/3B4xs6NWHRtk/3gUOvbPXMsyBn7jZ7ikx+wp4Ew==",
           "requires": {
             "@amcharts/amcharts4": "^4.10.10",
             "@babel/runtime": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@amcharts/amcharts5": "^5.2.31",
     "@amcharts/amcharts5-geodata": "^5.0.6",
     "@gtm-support/vue2-gtm": "^1.3.0",
-    "@spaceone/design-system": "^1.1.0-beta.461",
+    "@spaceone/design-system": "^1.1.0-beta.462",
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-color": "^2.0.0-beta.12",
     "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue
+++ b/src/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue
@@ -35,7 +35,6 @@
 </template>
 
 <script lang="ts">
-
 import type { PropType } from 'vue';
 import {
     computed,
@@ -82,7 +81,7 @@ export default {
             }))),
         });
 
-        const handleSelectCurrency = (currency: string) => {
+        const handleSelectCurrency = (currency: Currency) => {
             store.commit('display/setCurrency', currency);
             emit('update', currency);
         };

--- a/src/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue
+++ b/src/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue
@@ -6,45 +6,83 @@
                        class="currency-select-dropdown"
                        :class="{ 'print-mode': printMode }"
                        @select="handleSelectCurrency"
-    />
+    >
+        <template v-if="defaultMode"
+                  #default="{ item }"
+        >
+            <span>
+                <span>{{ item.label }}</span>
+                <p-badge v-if="item.badge"
+                         style-type="primary3"
+                         shape="round"
+                >{{ item.badge }}</p-badge>
+            </span>
+        </template>
+        <template v-if="defaultMode"
+                  #menu-item--format="{ item }"
+        >
+            <span>
+                <span>{{ item.label }}</span>
+                <p-badge v-if="item.badge"
+                         style-type="primary3"
+                         shape="round"
+                >
+                    {{ item.badge }}
+                </p-badge>
+            </span>
+        </template>
+    </p-select-dropdown>
 </template>
 
 <script lang="ts">
 
+import type { PropType } from 'vue';
 import {
     computed,
     reactive, toRefs,
 } from 'vue';
 
-import { PSelectDropdown } from '@spaceone/design-system';
+import { PSelectDropdown, PBadge } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/dist/src/inputs/context-menu/type';
 
 import { store } from '@/store';
 
-import { CURRENCY_SYMBOL } from '@/store/modules/display/config';
+import type { Currency } from '@/store/modules/display/config';
+import { CURRENCY, CURRENCY_SYMBOL } from '@/store/modules/display/config';
 
 export default {
     name: 'CurrencySelectDropdown',
     components: {
         PSelectDropdown,
+        PBadge,
     },
     props: {
         printMode: {
             type: Boolean,
             default: false,
         },
+        defaultMode: {
+            type: Boolean,
+            default: false,
+        },
+        defaultCurrency: {
+            type: String as PropType<Currency>,
+            default: CURRENCY.USD,
+        },
     },
     setup(props, { emit }) {
         const state = reactive({
-            currency: computed(() => store.state.display.currency),
+            currency: props.defaultMode ? props.defaultCurrency : computed(() => store.state.display.currency),
             currencyItems: computed<MenuItem[]>(() => Object.keys(store.state.display.currencyRates).map((currency) => ({
                 type: 'item',
                 name: currency,
                 label: `${CURRENCY_SYMBOL[currency]}${currency}`,
+                // song-lang
+                badge: currency === props.defaultCurrency ? 'Default' : '',
             }))),
         });
 
-        const handleSelectCurrency = (currency) => {
+        const handleSelectCurrency = (currency: string) => {
             store.commit('display/setCurrency', currency);
             emit('update', currency);
         };
@@ -63,5 +101,8 @@ export default {
     .text {
         white-space: nowrap;
     }
+}
+.p-badge {
+    margin-left: 0.25rem;
 }
 </style>

--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -2,14 +2,19 @@
     <div class="dashboard-customize-page">
         CUSTOMIZE DASHBOARD
         <dashboard-date-dropdown />
+        <currency-select-dropdown default-currency-mode
+                                  default-mode
+        />
     </div>
 </template>
 
 <script lang="ts">
+import CurrencySelectDropdown from '@/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue';
+
 import DashboardDateDropdown from '@/services/dashboards/modules/dashboard-toolset/DashboardDateDropdown.vue';
 
 export default {
     name: 'DashboardCustomizePage',
-    components: { DashboardDateDropdown },
+    components: { CurrencySelectDropdown, DashboardDateDropdown },
 };
 </script>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

Add defaultMode for currency select dropdown.

There would be default currency for dashboard. So, I've made `defaultMode` with `defaultCurrency`.
With defaultMode, default Currency will be selected on the first load. 
Also, badge has added.

![스크린샷 2022-12-07 오후 5 35 06](https://user-images.githubusercontent.com/29014433/206128849-7f815ba3-f327-4dde-bb1e-494b10ad9617.png)


### Things to Talk About
