### PR TITLE
feat: add converter for costQuerySet from older version to new one

### DIFF
--- a/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
+++ b/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
@@ -79,8 +79,8 @@ export default {
             granularity: queryStringToString(urlQuery.granularity) as Granularity,
             stack: queryStringToBoolean(urlQuery.stack),
             group_by: queryStringToArray(urlQuery.groupBy),
-            primary_group_by: queryStringToString(urlQuery.primaryGroupBy) as string,
-            more_group_by: queryStringToArray(urlQuery.moreGroupBy),
+            primary_group_by: queryStringToString(urlQuery.primaryGroupBy) as string, // will be deprecated(< v1.10.5)
+            more_group_by: queryStringToArray(urlQuery.moreGroupBy), // will be deprecated(< v1.10.5)
             period: queryStringToObject(urlQuery.period),
             filters: queryStringToObject(urlQuery.filters),
         });
@@ -108,8 +108,8 @@ export default {
                     granularity: primitiveToQueryString(options.granularity),
                     stack: primitiveToQueryString(options.stack),
                     groupBy: arrayToQueryString(options.groupBy),
-                    primaryGroupBy: primitiveToQueryString(options.primaryGroupBy),
-                    moreGroupBy: arrayToQueryString(options.moreGroupBy),
+                    primaryGroupBy: primitiveToQueryString(options.primaryGroupBy), // will be deprecated(< 1.10.5)
+                    moreGroupBy: arrayToQueryString(options.moreGroupBy), // will be deprecated(< 1.10.5)
                     period: objectToQueryString(options.period),
                     filters: objectToQueryString(options.filters),
                 };

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
@@ -258,8 +258,8 @@ export default {
                         stack,
                         period,
                         group_by: groupBy,
-                        primary_group_by: primaryGroupBy,
-                        more_group_by: moreGroupBy,
+                        primary_group_by: primaryGroupBy, // will be deprecated(< v1.10.5)
+                        more_group_by: moreGroupBy, // will be deprecated(< v1.10.5)
                         filters,
                     },
                 });

--- a/src/services/cost-explorer/lib/__tests__/helper.test.ts
+++ b/src/services/cost-explorer/lib/__tests__/helper.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect } from 'vitest';
+
+import { GROUP_BY, MORE_GROUP_BY } from '@/services/cost-explorer/lib/config';
+import { getRefinedCostQueryOptions } from '@/services/cost-explorer/lib/helper';
+import type { CostQuerySetOption } from '@/services/cost-explorer/type';
+
+const OLD_OPTIONS: Partial<CostQuerySetOption> = {
+    group_by: [GROUP_BY.PROJECT_GROUP, GROUP_BY.PROJECT],
+    primary_group_by: GROUP_BY.PROJECT,
+    more_group_by: [
+        { category: MORE_GROUP_BY.TAGS, key: 'Name', selected: true },
+        { category: MORE_GROUP_BY.TAGS, key: 'Environment', selected: false },
+        { category: MORE_GROUP_BY.ADDITIONAL_INFO, key: 'raw_usage_type', selected: false },
+    ],
+};
+
+// const NEW_OPTIONS: Partial<CostQuerySetOption> = {
+//     group_by: [GROUP_BY.PROJECT, GROUP_BY.PROJECT_GROUP, `${MORE_GROUP_BY.TAGS}.Name`],
+// };
+describe('getRefinedCostQueryOptions(): Convert old cost query options(<1.10.5) to new options(>=1.10.5)', () => {
+    const refinedOptions = getRefinedCostQueryOptions(OLD_OPTIONS);
+
+    it('Refined options doesn\'t have primary_group_by and more_group_by properties.', () => {
+        expect(refinedOptions.primary_group_by).toBeFalsy();
+        expect(refinedOptions.more_group_by).toBeFalsy();
+    });
+
+    it('Refined options\' group_by must include selected more_group_by string.', () => {
+        const refinedGroupBy = refinedOptions.group_by as string[];
+        expect(refinedGroupBy.includes(`${MORE_GROUP_BY.TAGS}.Name`)).toBeTruthy();
+    });
+
+    it('Refined options\' group_by\'s first item must be primary_group_by.', () => {
+        const refinedGroupBy = refinedOptions.group_by as string[];
+        expect(refinedGroupBy[0] === OLD_OPTIONS.primary_group_by).toBeTruthy();
+    });
+});
+

--- a/src/services/cost-explorer/store/cost-analysis/actions.ts
+++ b/src/services/cost-explorer/store/cost-analysis/actions.ts
@@ -25,8 +25,8 @@ export const setQueryOptions: Action<CostAnalysisStoreState, any> = ({ commit },
     if (options.granularity) commit('setGranularity', options.granularity);
     if (typeof options.stack === 'boolean') commit('setStack', options.stack);
     if (options.group_by?.length) commit('setGroupBy', options.group_by);
-    if (options.primary_group_by) commit('setPrimaryGroupBy', options.primary_group_by);
-    if (options.more_group_by?.length) commit('setMoreGroupBy', options.more_group_by);
+    if (options.primary_group_by) commit('setPrimaryGroupBy', options.primary_group_by); // will be deprecated(< v1.10.5)
+    if (options.more_group_by?.length) commit('setMoreGroupBy', options.more_group_by); // will be deprecated(< v1.10.5)
     if (options.period) commit('setPeriod', { start: options.period.start, end: options.period.end });
     if (options.filters) {
         commit('setFilters', convertFiltersInToNewType(options.filters));
@@ -58,8 +58,8 @@ export const saveQuery: Action<CostAnalysisStoreState, any> = async ({ state, co
             stack,
             period,
             group_by: groupBy,
-            primary_group_by: primaryGroupBy,
-            more_group_by: moreGroupBy,
+            primary_group_by: primaryGroupBy, // will be deprecated(< v1.10.5)
+            more_group_by: moreGroupBy, // will be deprecated(< v1.10.5)
             filters,
         };
         const updatedQueryData = await SpaceConnector.client.costAnalysis.costQuerySet.create({

--- a/src/services/cost-explorer/type.ts
+++ b/src/services/cost-explorer/type.ts
@@ -20,9 +20,9 @@ export type Filter = typeof FILTER[keyof typeof FILTER];
 export type CostFiltersMap = Record<Filter, FilterItem[]>;
 
 export interface CostQuerySetOption {
-    group_by?: GroupBy[];
+    group_by?: string[];
     primary_group_by?: GroupBy | string; // will be deprecated(< v1.10.5)
-    more_group_by: MoreGroupByItem[]; // will be deprecated(< v1.10.5)
+    more_group_by?: MoreGroupByItem[]; // will be deprecated(< v1.10.5)
     granularity: Granularity;
     stack?: boolean;
     period: Period;

--- a/src/services/cost-explorer/type.ts
+++ b/src/services/cost-explorer/type.ts
@@ -20,7 +20,7 @@ export type Filter = typeof FILTER[keyof typeof FILTER];
 export type CostFiltersMap = Record<Filter, FilterItem[]>;
 
 export interface CostQuerySetOption {
-    group_by?: string[];
+    group_by?: Array<string|GroupBy>;
     primary_group_by?: GroupBy | string; // will be deprecated(< v1.10.5)
     more_group_by?: MoreGroupByItem[]; // will be deprecated(< v1.10.5)
     granularity: Granularity;

--- a/src/services/cost-explorer/type.ts
+++ b/src/services/cost-explorer/type.ts
@@ -21,8 +21,8 @@ export type CostFiltersMap = Record<Filter, FilterItem[]>;
 
 export interface CostQuerySetOption {
     group_by?: GroupBy[];
-    primary_group_by?: GroupBy | string;
-    more_group_by: MoreGroupByItem[];
+    primary_group_by?: GroupBy | string; // will be deprecated(< v1.10.5)
+    more_group_by: MoreGroupByItem[]; // will be deprecated(< v1.10.5)
     granularity: Granularity;
     stack?: boolean;
     period: Period;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

This is a preliminary work to remove `primary_group_by` and `more_group_by` properties from CostAnalysis `QuerySetOptions`.

### Things to Talk About
