### PR TITLE
feat: update CostAnalysisPage url query spec

### DIFF
--- a/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
+++ b/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
@@ -78,9 +78,7 @@ export default {
         const getQueryOptionsFromUrlQuery = (urlQuery: CostAnalysisPageUrlQuery): Partial<CostQuerySetOption> => ({
             granularity: queryStringToString(urlQuery.granularity) as Granularity,
             stack: queryStringToBoolean(urlQuery.stack),
-            group_by: queryStringToArray(urlQuery.groupBy),
-            primary_group_by: queryStringToString(urlQuery.primaryGroupBy) as string, // will be deprecated(< v1.10.5)
-            more_group_by: queryStringToArray(urlQuery.moreGroupBy), // will be deprecated(< v1.10.5)
+            group_by: queryStringToArray(urlQuery.group_by),
             period: queryStringToObject(urlQuery.period),
             filters: queryStringToObject(urlQuery.filters),
         });
@@ -101,15 +99,13 @@ export default {
 
         let unregisterStoreWatch;
         const registerStoreWatch = (currentQuery) => {
-            unregisterStoreWatch = watch(() => costExplorerStore.getters['costAnalysis/currentQuerySetOptions'], (options) => {
+            unregisterStoreWatch = watch(() => costExplorerStore.getters['costAnalysis/currentQuerySetOptions'], (options: CostQuerySetOption) => {
                 if (props.querySetId) return;
 
                 const newQuery: CostAnalysisPageUrlQuery = {
                     granularity: primitiveToQueryString(options.granularity),
                     stack: primitiveToQueryString(options.stack),
-                    groupBy: arrayToQueryString(options.groupBy),
-                    primaryGroupBy: primitiveToQueryString(options.primaryGroupBy), // will be deprecated(< 1.10.5)
-                    moreGroupBy: arrayToQueryString(options.moreGroupBy), // will be deprecated(< 1.10.5)
+                    group_by: arrayToQueryString(options.group_by),
                     period: objectToQueryString(options.period),
                     filters: objectToQueryString(options.filters),
                 };

--- a/src/services/cost-explorer/cost-analysis/lib/config.ts
+++ b/src/services/cost-explorer/cost-analysis/lib/config.ts
@@ -5,6 +5,6 @@ export const REQUEST_TYPE = Object.freeze({
 
 export type RequestType = typeof REQUEST_TYPE[keyof typeof REQUEST_TYPE];
 
-export const COST_ANALYSIS_PAGE_URL_QUERY_KEY = ['period', 'groupBy', 'primaryGroupBy', 'moreGroupBy', 'filters', 'stack', 'granularity'] as const;
+export const COST_ANALYSIS_PAGE_URL_QUERY_KEY = ['period', 'group_by', 'filters', 'stack', 'granularity'] as const;
 
 export type CostAnalysisPageUrlQueryKey = typeof COST_ANALYSIS_PAGE_URL_QUERY_KEY[number];

--- a/src/services/cost-explorer/cost-analysis/type.ts
+++ b/src/services/cost-explorer/cost-analysis/type.ts
@@ -2,16 +2,14 @@ import type { RouteQueryString } from '@/lib/router-query-string';
 
 import type { CostAnalysisPageUrlQueryKey } from '@/services/cost-explorer/cost-analysis/lib/config';
 import type {
-    Period, Granularity, GroupBy, CostFiltersMap, MoreGroupByItem,
+    Period, Granularity, CostFiltersMap,
 } from '@/services/cost-explorer/type';
 
 export type CostAnalysisPageUrlQuery = Partial<Record<CostAnalysisPageUrlQueryKey, RouteQueryString>>;
 
 export interface CostAnalysisPageQueryValue {
     period?: Period;
-    groupBy?: GroupBy[];
-    primaryGroupBy?: GroupBy | string;
-    moreGroupBy?: MoreGroupByItem[];
+    group_by?: string[];
     filters?: CostFiltersMap;
     stack?: boolean;
     granularity?: Granularity;

--- a/src/services/cost-explorer/store/cost-analysis/getters.ts
+++ b/src/services/cost-explorer/store/cost-analysis/getters.ts
@@ -3,10 +3,11 @@ import type { Getter } from 'vuex';
 import { orderBy } from 'lodash';
 
 import { GROUP_BY_ITEM_MAP, MORE_GROUP_BY } from '@/services/cost-explorer/lib/config';
+import { getRefinedCostQueryOptions } from '@/services/cost-explorer/lib/helper';
 import type {
     CostAnalysisStoreState, GroupByItem,
 } from '@/services/cost-explorer/store/cost-analysis/type';
-import type { CostQuerySetModel, MoreGroupByItem } from '@/services/cost-explorer/type';
+import type { CostQuerySetModel, MoreGroupByItem, CostQuerySetOption } from '@/services/cost-explorer/type';
 
 export const groupByItems: Getter<CostAnalysisStoreState, any> = ({ groupBy }): GroupByItem[] => groupBy.map((d) => GROUP_BY_ITEM_MAP[d]);
 
@@ -16,18 +17,17 @@ export const selectedQuerySet: Getter<CostAnalysisStoreState, any> = ({ selected
     return costQueryList.find((item) => item.cost_query_set_id === selectedQueryId);
 };
 
-type QuerySetOptions = Pick<CostAnalysisStoreState, 'stack'|'granularity'|'groupBy'|'primaryGroupBy'|'moreGroupBy'|'period'|'filters'>;
 export const currentQuerySetOptions: Getter<CostAnalysisStoreState, any> = ({
     stack, granularity, groupBy, primaryGroupBy, moreGroupBy, period, filters,
-}): QuerySetOptions => ({
+}): CostQuerySetOption => getRefinedCostQueryOptions({
     stack,
     granularity,
-    groupBy,
-    primaryGroupBy,
-    moreGroupBy,
+    group_by: groupBy,
+    primary_group_by: primaryGroupBy,
+    more_group_by: moreGroupBy,
     period,
     filters,
-});
+}) as CostQuerySetOption;
 
 export const orderedMoreGroupByItems: Getter<CostAnalysisStoreState, any> = ({ moreGroupBy }): MoreGroupByItem[] => {
     if (!moreGroupBy?.length) return [];


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

Changed the URL Query specification of the `CostAnalysisPage` to be the same as the CostQuerySet Options specification changed as in the [previous PR](https://github.com/cloudforet-io/console/pull/437).

### Things to Talk About
