### PR TITLE
feat(cost-analysis): refine query options when saving and setting states

### DIFF
--- a/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
+++ b/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
@@ -70,16 +70,16 @@ export default {
             costExplorerStore.commit('costAnalysis/setSelectedQueryId', queryId);
         };
 
-        const setQueryOptions = (options?: Partial<CostQuerySetOption>) => {
+        const setQueryOptions = (options?: CostQuerySetOption) => {
             if (options) costExplorerStore.dispatch('costAnalysis/setQueryOptions', options);
             else costExplorerStore.dispatch('costAnalysis/initCostAnalysisStoreState');
         };
 
-        const getQueryOptionsFromUrlQuery = (urlQuery: CostAnalysisPageUrlQuery): Partial<CostQuerySetOption> => ({
+        const getQueryOptionsFromUrlQuery = (urlQuery: CostAnalysisPageUrlQuery): CostQuerySetOption => ({
             granularity: queryStringToString(urlQuery.granularity) as Granularity,
             stack: queryStringToBoolean(urlQuery.stack),
             group_by: queryStringToArray(urlQuery.group_by),
-            period: queryStringToObject(urlQuery.period),
+            period: queryStringToObject(urlQuery.period) ?? {},
             filters: queryStringToObject(urlQuery.filters),
         });
 

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
@@ -192,7 +192,7 @@ export default {
             costExplorerStore.commit('costAnalysis/setSelectedQueryId', queryId);
         };
 
-        const setQueryOptions = (options?: Partial<CostQuerySetOption>) => {
+        const setQueryOptions = (options?: CostQuerySetOption) => {
             if (options) costExplorerStore.dispatch('costAnalysis/setQueryOptions', options);
             else costExplorerStore.dispatch('costAnalysis/initCostAnalysisStoreState');
         };

--- a/src/services/cost-explorer/store/cost-analysis/actions.ts
+++ b/src/services/cost-explorer/store/cost-analysis/actions.ts
@@ -6,10 +6,14 @@ import { store } from '@/store';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
-import { GRANULARITY } from '@/services/cost-explorer/lib/config';
-import { convertFiltersInToNewType, getInitialDates } from '@/services/cost-explorer/lib/helper';
+import { GRANULARITY, GROUP_BY, MORE_GROUP_BY } from '@/services/cost-explorer/lib/config';
+import {
+    convertFiltersInToNewType,
+    getInitialDates,
+    getRefinedCostQueryOptions,
+} from '@/services/cost-explorer/lib/helper';
 import type { CostAnalysisStoreState } from '@/services/cost-explorer/store/cost-analysis/type';
-import type { CostQuerySetModel, CostQuerySetOption } from '@/services/cost-explorer/type';
+import type { CostQuerySetModel, CostQuerySetOption, MoreGroupByItem } from '@/services/cost-explorer/type';
 
 export const initCostAnalysisStoreState: Action<CostAnalysisStoreState, any> = ({ commit }): void => {
     commit('setGranularity', GRANULARITY.ACCUMULATED);
@@ -21,12 +25,44 @@ export const initCostAnalysisStoreState: Action<CostAnalysisStoreState, any> = (
     commit('setFilters', {});
 };
 
-export const setQueryOptions: Action<CostAnalysisStoreState, any> = ({ commit }, options: Partial<CostQuerySetOption>): void => {
-    if (options.granularity) commit('setGranularity', options.granularity);
-    if (typeof options.stack === 'boolean') commit('setStack', options.stack);
-    if (options.group_by?.length) commit('setGroupBy', options.group_by);
-    if (options.primary_group_by) commit('setPrimaryGroupBy', options.primary_group_by); // will be deprecated(< v1.10.5)
-    if (options.more_group_by?.length) commit('setMoreGroupBy', options.more_group_by); // will be deprecated(< v1.10.5)
+const defaultGroupBySet = new Set<string>(Object.values(GROUP_BY));
+const moreGroupByCategorySet = new Set(Object.values(MORE_GROUP_BY));
+/**
+ * @description Set store states from saved query or from url query
+ */
+export const setQueryOptions: Action<CostAnalysisStoreState, any> = ({ commit }, options: CostQuerySetOption): void => {
+    const refinedOptions = getRefinedCostQueryOptions(options);
+
+    if (refinedOptions.granularity) commit('setGranularity', refinedOptions.granularity);
+    if (typeof refinedOptions.stack === 'boolean') commit('setStack', refinedOptions.stack);
+
+    const refinedDefaultGroupBy: string[] = [];
+    const moreGroupByItems: MoreGroupByItem[] = [];
+    const refinedGroupBy = refinedOptions.group_by?.filter((d) => {
+        // Get only what belongs to the default groupBy
+        if (defaultGroupBySet.has(d)) {
+            refinedDefaultGroupBy.push(d);
+            return true;
+        }
+
+        // moreGroupBy is saved as a string in the form of 'category.key' when stored in group_by of the query option.
+        // So to convert back to moreGroupByItem, separate category and key.
+        // In this process, get only items belonging to the given moreGroupBy category.
+        const dotIndex = d.indexOf('.');
+        if (dotIndex > 0) {
+            const category = d.slice(0, dotIndex);
+            if (category && moreGroupByCategorySet.has(category)) {
+                moreGroupByItems.push({ category, key: d.slice(dotIndex + 1), selected: true });
+                return true;
+            }
+        }
+
+        return false;
+    });
+    commit('setGroupBy', refinedDefaultGroupBy);
+    commit('setPrimaryGroupBy', refinedGroupBy?.[0]); // The first item of group_by is primaryGroupBy
+    commit('setMoreGroupBy', moreGroupByItems);
+
     if (options.period) commit('setPeriod', { start: options.period.start, end: options.period.end });
     if (options.filters) {
         commit('setFilters', convertFiltersInToNewType(options.filters));
@@ -53,7 +89,7 @@ export const saveQuery: Action<CostAnalysisStoreState, any> = async ({ state, co
             granularity, stack, period,
             groupBy, filters, primaryGroupBy, moreGroupBy,
         } = state;
-        const options: CostQuerySetOption = {
+        const options = getRefinedCostQueryOptions({
             granularity,
             stack,
             period,
@@ -61,7 +97,7 @@ export const saveQuery: Action<CostAnalysisStoreState, any> = async ({ state, co
             primary_group_by: primaryGroupBy, // will be deprecated(< v1.10.5)
             more_group_by: moreGroupBy, // will be deprecated(< v1.10.5)
             filters,
-        };
+        });
         const updatedQueryData = await SpaceConnector.client.costAnalysis.costQuerySet.create({
             name,
             options,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

#### Background
CostAnalysisPage has store states.
All values marked with red boxes in the image below are managed by the store state.

![스크린샷 2022-12-09 오후 7 24 10](https://user-images.githubusercontent.com/26986739/206681627-a431e1f1-d092-421d-a403-fbe0d1916611.png)

All values are reflected in the url query whenever the user changes them.
Also, users can save them as saved queries.
![image](https://user-images.githubusercontent.com/26986739/206682431-b28618eb-cf01-48dc-987b-bdb8de62c9cf.png)

When entering this page, the query must be parsed from the URL and reflected in the store state.
Also, even if a saved query is loaded, the query must be parsed and reflected in the store state.

#### What's on this PR
Url query & saved query options' structure are the same.
But the store state structure is different from them.
**This PR updated the converter between them**
(URL Query & Saved Query <--------> Store States)

| UI | URL Query | Saved Query | Store States | Description |
| - | - | - | - | - |
| Granularity | granularity | granularity | granularity | - |
| Stack | stack | stack | stack | - |
| Period | period | period | period | - |
| Filter | filters | filters | filters | - |
| Group By | group_by(string[]) | group_by(string[]) | groupBy(GroupBy[]) | Among the group_by items, only those reserved as default items are accepted. |
| More Group By | - |  - | moreGroupBy(MoreGroupByItem[]) |  `MoreGroupByItem: { category: string; key: string; selected?: boolean; }`. The moreGroupBy items are reflected in the form of '{category}.{key}' when reflected in group_by. Therefore, when retrieving the moreGroupBy list from the group_by list, items starting with the reserved category are retrieved from each string. | 
| Primary Group By | - | - | primaryGroupBy(string) | The first item of group_by is considered primaryGroupBy. |


### Things to Talk About
