### PR TITLE
refactor(dashboard): rename 'duplicate' to 'clone'

### DIFF
--- a/src/services/cost-explorer/cost-dashboard/modules/CostDashboardMoreMenu.vue
+++ b/src/services/cost-explorer/cost-dashboard/modules/CostDashboardMoreMenu.vue
@@ -80,16 +80,16 @@ export default {
             moreMenuItems: computed(() => {
                 const menuItems = cloneDeep(defaultMenuItems.value);
                 if (state.homeDashboardId === props.dashboardId) {
-                    menuItems[1].disabled = true;
-                    menuItems[2].disabled = true;
+                    menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
+                    menuItems.find((d) => d.name === MENU.SET_HOME)!.disabled = true;
                     return menuItems;
                 }
                 if (state.dashboardType === DASHBOARD_TYPE.PUBLIC && props.manageDisabled) {
                     if (state.homeDashboardId === props.dashboardId) {
-                        menuItems[1].disabled = true;
-                        menuItems[2].disabled = true;
+                        menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
+                        menuItems.find((d) => d.name === MENU.SET_HOME)!.disabled = true;
                     }
-                    menuItems[1].disabled = true;
+                    menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
                     return menuItems;
                 }
                 return defaultMenuItems.value;

--- a/src/services/cost-explorer/cost-dashboard/modules/CostDashboardMoreMenu.vue
+++ b/src/services/cost-explorer/cost-dashboard/modules/CostDashboardMoreMenu.vue
@@ -80,12 +80,14 @@ export default {
             moreMenuItems: computed(() => {
                 const menuItems = cloneDeep(defaultMenuItems.value);
                 if (state.homeDashboardId === props.dashboardId) {
+                    // below find() never be undefined
                     menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
                     menuItems.find((d) => d.name === MENU.SET_HOME)!.disabled = true;
                     return menuItems;
                 }
                 if (state.dashboardType === DASHBOARD_TYPE.PUBLIC && props.manageDisabled) {
                     if (state.homeDashboardId === props.dashboardId) {
+                        // below find() never be undefined
                         menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
                         menuItems.find((d) => d.name === MENU.SET_HOME)!.disabled = true;
                     }

--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -23,11 +23,12 @@
                     <dashboard-more-menu dashboard-id="dashboard-xxx"
                                          :dashboard="{ public_dashboard_id: 'dashboard-xxx' }"
                                          :manage-disabled="false"
+                                         dashboard-type="PUBLIC"
                     />
                 </span>
             </template>
             <template #extra>
-                <dashboard-control-buttons />
+                <dashboard-control-buttons @update:visible-clone-modal="handleVisibleCloneModal" />
             </template>
         </p-page-title>
         <div class="flex justify-between mt-4">
@@ -45,6 +46,7 @@
                                    :dashboard-name="state.dashboardName"
                                    @confirm="handleNameUpdate"
         />
+        <dashboard-clone-modal :visible.sync="state.cloneModalVisible" />
     </div>
 </template>
 
@@ -63,6 +65,7 @@ import { gray } from '@/styles/colors';
 
 import { DASHBOARD_VIEWER_PUBLIC } from '@/services/dashboards/dashboard-create/config';
 import type { DashboardViewerType } from '@/services/dashboards/dashboard-create/type';
+import DashboardCloneModal from '@/services/dashboards/dashboard-detail/modules/DashboardCloneModal.vue';
 import DashboardControlButtons from '@/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue';
 import DashboardMoreMenu from '@/services/dashboards/dashboard-detail/modules/DashboardMoreMenu.vue';
 import DashboardNameEditModal from '@/services/dashboards/dashboard-detail/modules/DashboardNameEditModal.vue';
@@ -71,15 +74,17 @@ import DashboardWidgetContainer from '@/services/dashboards/dashboard-detail/mod
 import DashboardLabels from '@/services/dashboards/modules/dashboard-label/DashboardLabels.vue';
 import DashboardToolset from '@/services/dashboards/modules/dashboard-toolset/DashboardToolset.vue';
 
+
 const PUBLIC_ICON_COLOR = gray[500];
 
-
+const LABEL_LIST_MOCK = [{ label: 'THIS' }, { label: 'LABELS ARE' }, { label: 'MOCK' }];
 const state = reactive({
     dashboardType: DASHBOARD_VIEWER_PUBLIC as DashboardViewerType,
     dashboardId: 'dashboard-idxxx',
     dashboardName: 'Dashboard XXX',
-    labelList: [] as Array<{label: string}>,
+    labelList: LABEL_LIST_MOCK as Array<{label: string}>,
     nameEditModalVisible: false,
+    cloneModalVisible: false,
 });
 
 const WIDGET_SIZE_MOCK = ['md', 'md', 'sm', 'md', 'lg', 'sm'];
@@ -97,6 +102,9 @@ const handleNameEditModal = () => {
 };
 const handleNameUpdate = (name: string) => {
     state.dashboardName = name;
+};
+const handleVisibleCloneModal = () => {
+    state.cloneModalVisible = true;
 };
 </script>
 

--- a/src/services/dashboards/dashboard-detail/modules/DashboardCloneModal.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardCloneModal.vue
@@ -1,10 +1,10 @@
 <template>
     <!--    song-lang-->
     <p-button-modal :visible="proxyVisible"
-                    header-title="Duplicate Dashboard"
+                    header-title="Clone Dashboard"
                     size="sm"
                     :disabled="!isAllValid"
-                    class="dashboard-duplicate-modal"
+                    class="dashboard-clone-modal"
                     @confirm="handleConfirm"
                     @update:visible="handleUpdateVisible"
     >
@@ -89,7 +89,7 @@ const visibilityList = [
     },
 ];
 export default defineComponent<Props>({
-    name: 'DashboardDuplicateModal',
+    name: 'DashboardCloneModal',
     components: {
         PButtonModal,
         PRadio,
@@ -187,13 +187,13 @@ export default defineComponent<Props>({
 
         const handleConfirm = async () => {
             if (!isAllValid) return;
-            const duplicatedDashboardId = visibility.value === DASHBOARD_PRIVACY_TYPE.PUBLIC ? await createPublicDashboard() : await createUserDashboard();
+            const clonedDashboardId = visibility.value === DASHBOARD_PRIVACY_TYPE.PUBLIC ? await createPublicDashboard() : await createUserDashboard();
             // TODO:: connect dashboard store
             // await costExplorerStore.dispatch('setDashboardList');
-            if (duplicatedDashboardId) {
+            if (clonedDashboardId) {
                 await SpaceRouter.router.push({
                     name: DASHBOARDS_ROUTE._NAME,
-                    params: { dashboardId: duplicatedDashboardId },
+                    params: { dashboardId: clonedDashboardId },
                 });
             }
             emit('update:visible', false);
@@ -224,7 +224,7 @@ export default defineComponent<Props>({
 });
 </script>
 <style lang="postcss" scoped>
-.dashboard-duplicate-modal {
+.dashboard-clone-modal {
     .radio-group {
         @apply inline-block;
         margin-bottom: 0.625rem;

--- a/src/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue
@@ -16,6 +16,7 @@
         <!--        song-lang-->
         <p-button icon-left="ic_duplicate"
                   style-type="tertiary"
+                  @click="handleVisibleCloneModal"
         >
             Clone
         </p-button>
@@ -26,6 +27,12 @@
 import { PButton } from '@spaceone/design-system';
 
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
+
+const emit = defineEmits(['update:visible-clone-modal']);
+
+const handleVisibleCloneModal = () => {
+    emit('update:visible-clone-modal');
+};
 </script>
 
 <style lang="postcss">

--- a/src/services/dashboards/dashboard-detail/modules/DashboardMoreMenu.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardMoreMenu.vue
@@ -62,12 +62,14 @@ const state = reactive({
     moreMenuItems: computed(() => {
         const menuItems = cloneDeep(defaultMenuItems.value);
         if (state.homeDashboardId === props.dashboardId) {
+            // below find() never be undefined
             menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
             menuItems.find((d) => d.name === MENU.SET_HOME)!.disabled = true;
             return menuItems;
         }
         if (state.dashboardType === DASHBOARD_TYPE.PUBLIC && props.manageDisabled) {
             if (state.homeDashboardId === props.dashboardId) {
+                // below find() never be undefined
                 menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
                 menuItems.find((d) => d.name === MENU.SET_HOME)!.disabled = true;
             }

--- a/src/services/dashboards/dashboard-detail/modules/DashboardMoreMenu.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardMoreMenu.vue
@@ -31,18 +31,11 @@ import type { DashboardViewerType } from '@/services/dashboards/dashboard-create
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
 
-const MENU = Object.freeze({
-    DELETE: 'delete',
-    SET_HOME: 'setHome',
-} as const);
-
-const defaultMenuItems = computed(() => [
-    // song-lang
-    { name: MENU.DELETE, label: 'Delete', disabled: false },
-    // song-lang
-    { name: MENU.SET_HOME, label: 'Set as Home Dashboard', disabled: false },
-]);
-
+type DefaultMenuItems = Array<{
+    name: typeof MENU.DELETE | typeof MENU.SET_HOME
+    label: string
+    disabled: boolean
+}>;
 
 interface DashboardMoreMenuProps {
     dashboardId: string;
@@ -51,22 +44,34 @@ interface DashboardMoreMenuProps {
     dashboard: any;
 }
 
+const MENU = Object.freeze({
+    DELETE: 'delete',
+    SET_HOME: 'setHome',
+} as const);
+
+const defaultMenuItems = computed<DefaultMenuItems>(() => [
+    // song-lang
+    { name: MENU.DELETE, label: 'Delete', disabled: false },
+    // song-lang
+    { name: MENU.SET_HOME, label: 'Set as Home Dashboard', disabled: false },
+]);
+
 const props = defineProps<DashboardMoreMenuProps>();
 
 const state = reactive({
     moreMenuItems: computed(() => {
         const menuItems = cloneDeep(defaultMenuItems.value);
         if (state.homeDashboardId === props.dashboardId) {
-            menuItems[0].disabled = true;
-            menuItems[1].disabled = true;
+            menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
+            menuItems.find((d) => d.name === MENU.SET_HOME)!.disabled = true;
             return menuItems;
         }
         if (state.dashboardType === DASHBOARD_TYPE.PUBLIC && props.manageDisabled) {
             if (state.homeDashboardId === props.dashboardId) {
-                menuItems[0].disabled = true;
-                menuItems[1].disabled = true;
+                menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
+                menuItems.find((d) => d.name === MENU.SET_HOME)!.disabled = true;
             }
-            menuItems[0].disabled = true;
+            menuItems.find((d) => d.name === MENU.DELETE)!.disabled = true;
             return menuItems;
         }
         return defaultMenuItems.value;

--- a/src/services/dashboards/dashboard-detail/modules/DashboardMoreMenu.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardMoreMenu.vue
@@ -1,16 +1,11 @@
 <template>
-    <div>
+    <div class="dashboard-more-menu">
         <p-select-dropdown class="more-button"
                            :items="state.moreMenuItems"
                            style-type="icon-button"
                            button-icon="ic_more"
                            menu-position="left"
                            @select="handleSelectMoreMenu"
-        />
-        <dashboard-duplicate-modal
-            :visible.sync="state.duplicateModalVisible"
-            :dashboard="dashboard"
-            :manage-disabled="manageDisabled"
         />
         <delete-modal :header-title="checkDeleteState.headerTitle"
                       :visible.sync="checkDeleteState.visible"
@@ -33,23 +28,15 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 
 import { DASHBOARD_TYPE } from '@/services/cost-explorer/cost-dashboard/lib/config';
 import type { DashboardViewerType } from '@/services/dashboards/dashboard-create/type';
-import DashboardDuplicateModal
-    from '@/services/dashboards/dashboard-detail/modules/DashboardDuplicateModal.vue';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
 
-
-
-
 const MENU = Object.freeze({
-    DUPLICATE: 'duplicate',
     DELETE: 'delete',
     SET_HOME: 'setHome',
 } as const);
 
 const defaultMenuItems = computed(() => [
-    // song-lang
-    { name: MENU.DUPLICATE, label: 'Duplicate', disabled: false },
     // song-lang
     { name: MENU.DELETE, label: 'Delete', disabled: false },
     // song-lang
@@ -70,16 +57,16 @@ const state = reactive({
     moreMenuItems: computed(() => {
         const menuItems = cloneDeep(defaultMenuItems.value);
         if (state.homeDashboardId === props.dashboardId) {
+            menuItems[0].disabled = true;
             menuItems[1].disabled = true;
-            menuItems[2].disabled = true;
             return menuItems;
         }
         if (state.dashboardType === DASHBOARD_TYPE.PUBLIC && props.manageDisabled) {
             if (state.homeDashboardId === props.dashboardId) {
+                menuItems[0].disabled = true;
                 menuItems[1].disabled = true;
-                menuItems[2].disabled = true;
             }
-            menuItems[1].disabled = true;
+            menuItems[0].disabled = true;
             return menuItems;
         }
         return defaultMenuItems.value;
@@ -88,7 +75,6 @@ const state = reactive({
     // homeDashboardId: computed<string|undefined>(() => costExplorerStore.getters.homeDashboardId),
     homeDashboardId: '',
     dashboardType: computed(() => (Object.prototype.hasOwnProperty.call(props.dashboard, 'public_dashboard_id') ? DASHBOARD_TYPE.PUBLIC : DASHBOARD_TYPE.USER)),
-    duplicateModalVisible: false,
 });
 
 
@@ -103,8 +89,6 @@ const handleSelectMoreMenu = (item) => {
     if (item === MENU.SET_HOME && props.dashboardId) {
         // FIXME:: connect dashboardStore
         // costExplorerStore.dispatch('setHomeDashboard', props.dashboardId);
-    } else if (item === MENU.DUPLICATE) {
-        state.duplicateModalVisible = true;
     } else if (item === MENU.DELETE) {
         checkDeleteState.visible = true;
     }
@@ -134,3 +118,9 @@ const handleDeleteDashboardConfirm = async () => {
 };
 
 </script>
+
+<style lang="postcss" scoped>
+.p-select-dropdown {
+    height: 2rem;
+}
+</style>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

https://cloudone-mz.slack.com/archives/C044D55N2V9/p1670830618334959

1. Contrary to cost-dashboard, duplicating dashboard feature would be executed by 'clone' button. (At cost-dashboard, duplicating feature has been provided by duplicate context item)
2. So I've applied it to codes and refactored names

### Things to Talk About
