### PR TITLE
fix: add defense code for p-button component click event

### DIFF
--- a/src/services/asset-inventory/collector/CollectorPage.vue
+++ b/src/services/asset-inventory/collector/CollectorPage.vue
@@ -8,7 +8,10 @@
         >
             <template #extra>
                 <router-link :to="{name: ASSET_INVENTORY_ROUTE.COLLECTOR.HISTORY._NAME }">
-                    <p-button style-type="tertiary">
+                    <!-- TODO: remove click binding after upgrade mirinae version. This is defense code for 1.10.4.6 -->
+                    <p-button style-type="tertiary"
+                              @click="() => {}"
+                    >
                         {{ $t('MANAGEMENT.COLLECTOR_HISTORY.MAIN.TITLE') }}
                     </p-button>
                 </router-link>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

There is a bug in p-button in mirinae. 
But to not upgrade mirinae version, This PR added some defense code.

### Things to Talk About
