### PR TITLE
feat(dashboard-LNB): set project dashboard LNB group

### DIFF
--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -112,7 +112,7 @@ export default defineComponent({
             const result = [] as LNBMenu[];
 
             // The mapped group items are in the form of an array along with the title, and each item is mapped to LNBItem type and pushed to result.
-            Object.keys(groupProjectDashboardMap).forEach((d) => {
+            Object.keys(dashboardItemsWithGroup).forEach((d) => {
                 result.push([
                     {
                         type: MENU_ITEM_TYPE.TITLE,

--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -69,9 +69,9 @@ export default defineComponent({
                 },
                 favoriteType: FAVORITE_TYPE.DASHBOARD,
             }))),
-            projectDashboardList: computed(() => store.state.dashboard.projectItems),
-            projectList: computed(() => store.state.reference.project.items),
-            projectMenuSet: computed<LNBMenu[]>(() => mashUpProjectGroup(state.projectList)),
+            projectDashboardList: computed<ProjectDashboardItem[]>(() => store.state.dashboard.projectItems),
+            projectItems: computed(() => store.state.reference.project.items),
+            projectMenuSet: computed<LNBMenu[]>(() => mashUpProjectGroup(state.projectDashboardList)),
             menuSet: computed<LNBMenu[]>(() => [
                 {
                     type: 'item',
@@ -89,20 +89,29 @@ export default defineComponent({
             ]),
         });
 
-        const mashUpProjectGroup = (dashboardList: ProjectDashboardItem[]): LNBMenu[] => {
+        const mashUpProjectGroup = (dashboardList: ProjectDashboardItem[] = []): LNBMenu[] => {
             const noGroupList = [] as ProjectDashboardItem[];
             const groupProjectDashboardMap = {} as Record<string, ProjectDashboardItem[]>;
+            // Since all lnbitem do not have groups, and even if they do have groups, they are not sorted.
+            // Items with groups are converted to map format, and if there are no groups, they are put in noGroupList.
             dashboardList.forEach((d) => {
-                if (state.projectList[d.project_id]) {
-                    if (groupProjectDashboardMap[state.projectList[d.project_id].data.groupInfo.name]) {
-                        groupProjectDashboardMap[state.projectList[d.project_id].data.groupInfo.name].push(d);
+                // With group
+                if (state.projectItems[d.project_id]) {
+                    if (groupProjectDashboardMap[state.projectItems[d.project_id].data.groupInfo.name]) {
+                        groupProjectDashboardMap[state.projectItems[d.project_id].data.groupInfo.name].push(d);
                     } else {
-                        groupProjectDashboardMap[state.projectList[d.project_id].data.groupInfo.name] = [d];
+                        groupProjectDashboardMap[state.projectItems[d.project_id].data.groupInfo.name] = [d];
                     }
                 }
+
+                // No-group
                 noGroupList.push(d);
             });
+
+            // Result to return
             const result = [] as LNBMenu[];
+
+            // The mapped group items are in the form of an array along with the title, and each item is mapped to LNBItem type and pushed to result.
             Object.keys(groupProjectDashboardMap).forEach((d) => {
                 result.push([
                     {
@@ -125,6 +134,8 @@ export default defineComponent({
                     })),
                 ]);
             });
+
+            // No-group items are mapped to LNBItem type and pushed to result.
             result.push(
                 ...noGroupList.map((board) => ({
                     type: MENU_ITEM_TYPE.ITEM,
@@ -139,6 +150,8 @@ export default defineComponent({
                     favoriteType: FAVORITE_TYPE.DASHBOARD,
                 })),
             );
+
+            // Return LNBMenu type as (LNBItem | LNBItem[])[]
             return result;
         };
 

--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -47,7 +47,7 @@ export default defineComponent({
             showFavoriteOnly: false,
             header: computed(() => i18n.t(MENU_INFO_MAP[MENU_ID.DASHBOARDS].translationId)),
             favoriteItemMap: computed(() => {
-                const stateName = FAVORITE_TYPE_TO_STATE_NAME[FAVORITE_TYPE.MENU];
+                const stateName = FAVORITE_TYPE_TO_STATE_NAME[FAVORITE_TYPE.DASHBOARD];
                 const result: Record<string, FavoriteConfig> = {};
                 if (stateName) {
                     store.state.favorite[stateName]?.forEach((d) => {
@@ -66,6 +66,7 @@ export default defineComponent({
                         dashboardId: d.domain_dashboard_id,
                     },
                 },
+                favoriteType: FAVORITE_TYPE.DASHBOARD,
             }))),
             projectMenuSet: computed<LNBItem[]>(() => store.state.dashboard.projectItems.map((d) => ({
                 type: 'item',
@@ -77,6 +78,7 @@ export default defineComponent({
                         dashboardId: d.project_dashboard_id,
                     },
                 },
+                favoriteType: FAVORITE_TYPE.DASHBOARD,
             }))),
             // projectMenuSet: computed<LNBItem[][]>(() => {
             //     const result = [] as LNBItem[][];

--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -26,7 +26,7 @@ import { PIconButton } from '@spaceone/design-system';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
-import type { ProjectDashboardItem } from '@/store/modules/dashboard/type';
+import type { ProjectDashboardModel } from '@/store/modules/dashboard/type';
 import type { FavoriteConfig } from '@/store/modules/favorite/type';
 import { FAVORITE_TYPE, FAVORITE_TYPE_TO_STATE_NAME } from '@/store/modules/favorite/type';
 
@@ -69,7 +69,7 @@ export default defineComponent({
                 },
                 favoriteType: FAVORITE_TYPE.DASHBOARD,
             }))),
-            projectDashboardList: computed<ProjectDashboardItem[]>(() => store.state.dashboard.projectItems),
+            projectDashboardList: computed<ProjectDashboardModel[]>(() => store.state.dashboard.projectItems),
             projectItems: computed(() => store.state.reference.project.items),
             projectMenuSet: computed<LNBMenu[]>(() => mashUpProjectGroup(state.projectDashboardList)),
             menuSet: computed<LNBMenu[]>(() => [
@@ -89,9 +89,9 @@ export default defineComponent({
             ]),
         });
 
-        const mashUpProjectGroup = (dashboardList: ProjectDashboardItem[] = []): LNBMenu[] => {
-            const dashboardItemsWithoutGroup = [] as ProjectDashboardItem[];
-            const dashboardItemsWithGroup = {} as Record<string, ProjectDashboardItem[]>;
+        const mashUpProjectGroup = (dashboardList: ProjectDashboardModel[] = []): LNBMenu[] => {
+            const dashboardItemsWithoutGroup = [] as ProjectDashboardModel[];
+            const dashboardItemsWithGroup = {} as Record<string, ProjectDashboardModel[]>;
             // Since all lnbitem do not have groups, and even if they do have groups, they are not sorted.
             // Items with groups are converted to map format, and if there are no groups, they are put in noGroupList.
             dashboardList.forEach((d) => {

--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -90,23 +90,22 @@ export default defineComponent({
         });
 
         const mashUpProjectGroup = (dashboardList: ProjectDashboardItem[] = []): LNBMenu[] => {
-            const noGroupList = [] as ProjectDashboardItem[];
-            const groupProjectDashboardMap = {} as Record<string, ProjectDashboardItem[]>;
+            const dashboardItemsWithoutGroup = [] as ProjectDashboardItem[];
+            const dashboardItemsWithGroup = {} as Record<string, ProjectDashboardItem[]>;
             // Since all lnbitem do not have groups, and even if they do have groups, they are not sorted.
             // Items with groups are converted to map format, and if there are no groups, they are put in noGroupList.
             dashboardList.forEach((d) => {
                 // With group
                 const groupId: string|undefined = state.projectItems[d.project_id]?.data.groupInfo.name;
                 if (groupId) {
-                   if (groupProjectDashboardMap[groupId]) {
-                      groupProjectDashboardMap[groupId].push(d);
-                  } else {
-                      groupProjectDashboardMap[groupId] = [d];
-                  }
+                    if (dashboardItemsWithGroup[groupId]) {
+                        dashboardItemsWithGroup[groupId].push(d);
+                    } else {
+                        dashboardItemsWithGroup[groupId] = [d];
+                    }
                 }
-               
                 // No-group
-                noGroupList.push(d);
+                dashboardItemsWithoutGroup.push(d);
             });
 
             // Result to return
@@ -121,7 +120,7 @@ export default defineComponent({
                         id: d,
                         foldable: true,
                     },
-                    ...groupProjectDashboardMap[d].map((board) => ({
+                    ...dashboardItemsWithGroup[d].map((board) => ({
                         type: MENU_ITEM_TYPE.ITEM,
                         id: board.project_dashboard_id,
                         label: board.name,
@@ -138,7 +137,7 @@ export default defineComponent({
 
             // No-group items are mapped to LNBItem type and pushed to result.
             result.push(
-                ...noGroupList.map((board) => ({
+                ...dashboardItemsWithoutGroup.map((board) => ({
                     type: MENU_ITEM_TYPE.ITEM,
                     id: board.project_dashboard_id,
                     label: board.name,

--- a/src/services/dashboards/DashboardsLNB.vue
+++ b/src/services/dashboards/DashboardsLNB.vue
@@ -96,14 +96,15 @@ export default defineComponent({
             // Items with groups are converted to map format, and if there are no groups, they are put in noGroupList.
             dashboardList.forEach((d) => {
                 // With group
-                if (state.projectItems[d.project_id]) {
-                    if (groupProjectDashboardMap[state.projectItems[d.project_id].data.groupInfo.name]) {
-                        groupProjectDashboardMap[state.projectItems[d.project_id].data.groupInfo.name].push(d);
-                    } else {
-                        groupProjectDashboardMap[state.projectItems[d.project_id].data.groupInfo.name] = [d];
-                    }
+                const groupId: string|undefined = state.projectItems[d.project_id]?.data.groupInfo.name;
+                if (groupId) {
+                   if (groupProjectDashboardMap[groupId]) {
+                      groupProjectDashboardMap[groupId].push(d);
+                  } else {
+                      groupProjectDashboardMap[groupId] = [d];
+                  }
                 }
-
+               
                 // No-group
                 noGroupList.push(d);
             });

--- a/src/services/dashboards/all-dashboards/modules/DashboardBoardList.vue
+++ b/src/services/dashboards/all-dashboards/modules/DashboardBoardList.vue
@@ -68,6 +68,7 @@ import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
 import type { ConsoleFilter } from '@/query/type';
+import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
@@ -80,6 +81,8 @@ import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 import DeleteModal from '@/common/components/modals/DeleteModal.vue';
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteButton.vue';
+
+import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
 const PAGE_SIZE = 10;
 
@@ -172,7 +175,12 @@ export default defineComponent<DashboardBoardListProps>({
             {
                 iconName: 'ic_edit',
                 tooltipText: i18n.t('Edit'),
-                eventAction: () => console.log('edit!'),
+                eventAction: () => {
+                    SpaceRouter.router.push({
+                        name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME,
+                        params: { id: dashboardId },
+                    });
+                },
             },
             {
                 iconName: 'ic_duplicate',

--- a/src/services/dashboards/all-dashboards/modules/DashboardBoardList.vue
+++ b/src/services/dashboards/all-dashboards/modules/DashboardBoardList.vue
@@ -72,7 +72,7 @@ import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
-import type { DashboardItem, ScopeType } from '@/store/modules/dashboard/type';
+import type { DashboardModel, ScopeType } from '@/store/modules/dashboard/type';
 import { SCOPE_TYPE } from '@/store/modules/dashboard/type';
 import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
 
@@ -90,7 +90,7 @@ interface DashboardBoardListProps {
     scopeType: ScopeType;
     fieldTitle: string;
     // TODO: implementation
-    dashboardList: DashboardItem[];
+    dashboardList: DashboardModel[];
 }
 
 export default defineComponent<DashboardBoardListProps>({
@@ -113,7 +113,7 @@ export default defineComponent<DashboardBoardListProps>({
             default: undefined,
         },
         dashboardList: {
-            type: Array as PropType<DashboardItem[]>,
+            type: Array as PropType<DashboardModel[]>,
             default: () => [],
         },
     },

--- a/src/store/modules/dashboard/actions.ts
+++ b/src/store/modules/dashboard/actions.ts
@@ -7,7 +7,6 @@ import type { DashboardState } from '@/store/modules/dashboard/type';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
-// TODO: implementation
 export const loadDomainDashboard: Action<DashboardState, any> = async ({ commit }): Promise<void> => {
     try {
         const { results, total_count } = await SpaceConnector.clientV2.dashboard.domainDashboard.list({});
@@ -30,7 +29,6 @@ export const loadProjectDashboard: Action<DashboardState, any> = async ({ commit
         ErrorHandler.handleError(e);
     }
 };
-
 
 export const setSearchFilters: Action<DashboardState, any> = ({ commit }, searchFilters: ConsoleFilter[] = []): void => {
     commit('setSearchFilters', searchFilters);

--- a/src/store/modules/dashboard/getters.ts
+++ b/src/store/modules/dashboard/getters.ts
@@ -3,7 +3,7 @@ import type { Getter } from 'vuex';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 
-import type { DashboardItem, DashboardState } from '@/store/modules/dashboard/type';
+import type { DashboardModel, DashboardState } from '@/store/modules/dashboard/type';
 
 export const getDashboardCount: Getter<DashboardState, any> = (state): any => {
     const domainItemCount = state.domainItemCount;
@@ -13,7 +13,7 @@ export const getDashboardCount: Getter<DashboardState, any> = (state): any => {
 export const getDomainItems: Getter<DashboardState, any> = (state): any => getItems(state.domainItems ?? [], state.searchFilters, state.viewers);
 export const getProjectItems: Getter<DashboardState, any> = (state): any => getItems(state.projectItems ?? [], state.searchFilters, state.viewers);
 
-const getItems = (items: DashboardItem[], filters: ConsoleFilter[], viewers: string): DashboardItem[] => {
+const getItems = (items: DashboardModel[], filters: ConsoleFilter[], viewers: string): DashboardModel[] => {
     let result = items;
     if (viewers && viewers !== 'ALL') {
         result = result.filter((d) => d.viewers === viewers);

--- a/src/store/modules/dashboard/type.ts
+++ b/src/store/modules/dashboard/type.ts
@@ -15,8 +15,8 @@ export const SCOPE_TYPE = {
 export type ScopeType = typeof SCOPE_TYPE[keyof typeof SCOPE_TYPE];
 
 export interface DashboardState {
-    domainItems: DomainDashboardItem[];
-    projectItems: ProjectDashboardItem[];
+    domainItems: DomainDashboardModel[];
+    projectItems: ProjectDashboardModel[];
     searchFilters: ConsoleFilter[];
     viewers: string;
     scope: string;
@@ -24,7 +24,7 @@ export interface DashboardState {
     projectItemCount: number;
 }
 
-export interface DashboardItem {
+export interface DashboardModel {
     name: string;
     viewers: ViewersType;
     version: number;
@@ -40,10 +40,10 @@ export interface DashboardItem {
     updated_at: string;
 }
 
-export interface DomainDashboardItem extends DashboardItem {
+export interface DomainDashboardModel extends DashboardModel {
     domain_dashboard_id: string;
 }
-export interface ProjectDashboardItem extends DashboardItem {
+export interface ProjectDashboardModel extends DashboardModel {
     project_dashboard_id: string;
     project_id: string;
 }

--- a/src/store/modules/dashboard/type.ts
+++ b/src/store/modules/dashboard/type.ts
@@ -45,5 +45,6 @@ export interface DomainDashboardItem extends DashboardItem {
 }
 export interface ProjectDashboardItem extends DashboardItem {
     project_dashboard_id: string;
+    project_id: string;
 }
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
First, just link Dashboard favorite. Not that difficult.

**Second, difficult things..**
Dashboard project LNB items have to be grouped, but that data don't have project-group data.
So, project data in reference store was imported and processed by mash-up.

 Description
 - Project LNB item may or may not have a group.
 - So, no-group items just need to be converted to LNBItem.
 - Group items should be sorted by group compared to reference store's project-id and converted to LNBItem.
 - And two data need to be merged.
 - Please check `mashUpProjectGroup` function.

![image](https://user-images.githubusercontent.com/83635051/207278504-e5ce8b42-ff29-4a5d-b215-bc4b8d1a349d.png)


### **Plz check files changed**