### PR TITLE
fix(cost-analysis): access to element by $el in component ref

### DIFF
--- a/src/common/components/layouts/PdfDownloadOverlay/PdfDownloadOverlay.vue
+++ b/src/common/components/layouts/PdfDownloadOverlay/PdfDownloadOverlay.vue
@@ -204,60 +204,71 @@ export default defineComponent<Props>({
         };
 
         const applyTableHeaderStyle = (data: TableCell[][]): TableCell[][] => {
-            let tableData = data;
-            if (tableData[0]) {
-                tableData[0] = tableData[0].map((item) => ({
-                    text: item,
-                    style: 'tableHeader',
-                }));
-                // check if no items
-                if (!tableData[1]) {
-                    const colsLength = tableData[0].length;
-                    const emptyCell = {
-                        text: 'No Items', rowSpan: EMPTY_ROW_COUNT, colSpan: colsLength, alignment: 'center', style: 'noDataRow',
-                    };
-                    // add first row
-                    tableData.push(tableData[0].map((_, i) => {
-                        if (i === 0) return emptyCell;
-                        return '';
+            try {
+                let tableData = data;
+                if (tableData[0]) {
+                    tableData[0] = tableData[0].map((item) => ({
+                        text: item,
+                        style: 'tableHeader',
                     }));
-                    // add blank rows
-                    const fakeRows = new Array(EMPTY_ROW_COUNT - 1).fill(new Array(colsLength).fill(''));
-                    tableData = tableData.concat(fakeRows);
+                    // check if no items
+                    if (!tableData[1]) {
+                        const colsLength = tableData[0].length;
+                        const emptyCell = {
+                            text: 'No Items', rowSpan: EMPTY_ROW_COUNT, colSpan: colsLength, alignment: 'center', style: 'noDataRow',
+                        };
+                        // add first row
+                        tableData.push(tableData[0].map((_, i) => {
+                            if (i === 0) return emptyCell;
+                            return '';
+                        }));
+                        // add blank rows
+                        const fakeRows = new Array(EMPTY_ROW_COUNT - 1).fill(new Array(colsLength).fill(''));
+                        tableData = tableData.concat(fakeRows);
+                    }
                 }
+                return tableData;
+            } catch (e) {
+                console.error(e);
+                return [[]];
             }
-            return tableData;
         };
 
         const createContentWithItem = async ({ element, type, tableData }: Item): Promise<Content> => {
-            if (type === 'data-table' && tableData) {
-                if (!tableData.body) throw Error('[PdfDownloadOverlay] data-table type item must have data.');
-                const tableBody = applyTableHeaderStyle(tableData.body);
+            try {
+                if (type === 'data-table' && tableData) {
+                    if (!tableData.body) throw Error('[PdfDownloadOverlay] data-table type item must have data.');
+                    const tableBody = applyTableHeaderStyle(tableData.body);
 
-                return tableData.body.length ? {
-                    pageBreak: 'before',
-                    table: {
-                        headerRows: 1,
-                        widths: tableData.widths,
-                        body: tableBody,
-                    },
-                    fillColor: white,
-                    margin: [0, 4],
-                    layout: 'DataTable',
-                } : {} as Content;
-            }
+                    return tableData.body.length ? {
+                        pageBreak: 'before',
+                        table: {
+                            headerRows: 1,
+                            widths: tableData.widths,
+                            body: tableBody,
+                        },
+                        fillColor: white,
+                        margin: [0, 4],
+                        layout: 'DataTable',
+                    } : {} as Content;
+                }
 
-            // 'image' is default type
-            if (!element) throw Error('[PdfDownloadOverlay] image type item must have element.');
-            const imageUrl = await toPng(element);
-            if (!imageUrl.split(':')[1]?.split(',')[1]) {
-                return {} as Content;
+                // 'image' is default type
+                if (!element) throw Error('[PdfDownloadOverlay] image type item must have element.');
+                console.log('element', element);
+                const imageUrl = await toPng(element);
+                if (!imageUrl.split(':')[1]?.split(',')[1]) {
+                    return {} as Content;
+                }
+                return {
+                    image: imageUrl,
+                    width: state.paperSizeInfo.width - (PAGE_PADDING * 2),
+                    style: 'imageRowWrapper',
+                };
+            } catch (e) {
+                console.error(e);
+                return '';
             }
-            return {
-                image: imageUrl,
-                width: state.paperSizeInfo.width - (PAGE_PADDING * 2),
-                style: 'imageRowWrapper',
-            };
         };
 
         const makeTableLayouts = () => ({

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChart.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChart.vue
@@ -116,7 +116,7 @@ export default {
             legends: [] as Legend[],
             chartData: [] as Array<XYChartData|PieChartData>,
             chart: null as XYChart | PieChart | null,
-            queryRef: null as null|HTMLElement,
+            queryRef: null as null|Vue,
             chartRef: null as null|HTMLElement,
         });
 
@@ -173,7 +173,13 @@ export default {
             }
         };
         const handleChartRendered = () => {
-            if (state.chartRef && state.queryRef) emit('rendered', [state.queryRef, state.chartRef]);
+            if (state.chartRef && state.queryRef?.$el) {
+                const elements: Element[] = [
+                    state.queryRef.$el,
+                    state.chartRef,
+                ];
+                emit('rendered', elements);
+            }
         };
 
         watch([() => state.granularity, () => state.period, () => state.primaryGroupBy, () => state.filters], ([granularity, period, groupBy]) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

There was critical bug in Cost Analysis pdf download.

- CostAnalysisChart component emitted 'rendered' event with parameters that includes Vue component, not HTML element. 
So I this PR fixed it to event parameters include only elements.

- To fix this bug, it was pretty hard. Error messages from PdfDownloadOverlay component was not helpful because try/catch statement was not written where it really needed to be written.
So this PR adds try/catch statement to PdfDownloadOverlay component's some functions.






### Things to Talk About