### PR TITLE
fix(vertical-page-layout): fix overflow property for search scroll event

### DIFF
--- a/src/common/modules/page-layouts/VerticalPageLayout.vue
+++ b/src/common/modules/page-layouts/VerticalPageLayout.vue
@@ -87,6 +87,7 @@ export default {
     display: flex;
     flex-direction: column;
     justify-content: stretch;
+    overflow-y: scroll;
 
     .header {
         @apply flex justify-between;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
'scroll event(for hide contextMenu)' did not work intermittently on components using the existing useFixedMenu.
Even if the scroll event is bound in the VerticalPageLayout of each existing PageContainer, it does not work, so I modified it.


### Things to Talk About
