### PR TITLE
feat(dashboard): replace more-menu to delete-button

### DIFF
--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -19,11 +19,14 @@
                                    width="1.5rem"
                                    height="1.5rem"
                                    :disabled="!state.hasManagePermission && state.dashboardViewer === DASHBOARD_VIEWER.PUBLIC"
-                                   @click="handleNameEditModal"
+                                   class="ml-1"
+                                   @click="handleVisibleNameEditModal"
                     />
-                    <dashboard-more-menu :dashboard-id="state.dashboardId"
-                                         :manage-disabled="!state.hasManagePermission"
-                                         :dashboard-viewer="state.dashboardViewer"
+                    <p-icon-button name="ic_trashcan"
+                                   width="1.5rem"
+                                   height="1.5rem"
+                                   :disabled="!state.hasManagePermission && state.dashboardViewer === DASHBOARD_VIEWER.PUBLIC"
+                                   @click="handleVisibleDeleteModal"
                     />
                 </span>
             </template>
@@ -51,6 +54,9 @@
                                    :dashboard-name="state.dashboardName"
                                    @confirm="handleNameUpdate"
         />
+        <dashboard-delete-modal :visible.sync="state.deleteModalVisible"
+                                :dashboard-id="props.dashboardId"
+        />
         <dashboard-clone-modal :visible.sync="state.cloneModalVisible" />
     </div>
 </template>
@@ -75,7 +81,7 @@ import { gray } from '@/styles/colors';
 import { DASHBOARD_VIEWER } from '@/services/dashboards/config';
 import type { DashboardViewer } from '@/services/dashboards/config';
 import DashboardControlButtons from '@/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue';
-import DashboardMoreMenu from '@/services/dashboards/dashboard-detail/modules/DashboardMoreMenu.vue';
+import DashboardDeleteModal from '@/services/dashboards/dashboard-detail/modules/DashboardDeleteModal.vue';
 import DashboardNameEditModal from '@/services/dashboards/dashboard-detail/modules/DashboardNameEditModal.vue';
 import DashboardRefresher from '@/services/dashboards/dashboard-detail/modules/DashboardRefresher.vue';
 import DashboardWidgetContainer from '@/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue';
@@ -100,6 +106,7 @@ const state = reactive({
     dashboardName: 'Dashboard',
     labelList: [] as Array<string>,
     nameEditModalVisible: false,
+    deleteModalVisible: false,
     cloneModalVisible: false,
     refreshInterval: '15s',
     loading: false,
@@ -119,15 +126,25 @@ const WIDGET_THEME_OPTION_MOCK = [
     { inherit: true, inherit_count: undefined },
 ];
 
-const handleNameEditModal = () => {
+// name edit
+const handleVisibleNameEditModal = () => {
     state.nameEditModalVisible = true;
 };
 const handleNameUpdate = (name: string) => {
     state.dashboardName = name;
 };
+
+// delete dashboard
+const handleVisibleDeleteModal = () => {
+    state.deleteModalVisible = true;
+};
+
+// clone dashboard
 const handleVisibleCloneModal = () => {
     state.cloneModalVisible = true;
 };
+
+// else
 const handleRefresh = () => {
     widgetContainerRef.value?.refreshAllWidget();
 };

--- a/src/services/dashboards/dashboard-detail/modules/DashboardDeleteModal.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardDeleteModal.vue
@@ -1,0 +1,76 @@
+<template>
+    <delete-modal :header-title="$t('DASHBOARDS.FORM.DELETE_TITLE')"
+                  :visible.sync="proxyVisible"
+                  :loading="loading"
+                  @confirm="handleDeleteDashboardConfirm"
+    />
+</template>
+<script lang="ts">
+import type { SetupContext } from 'vue';
+import { reactive, toRefs } from 'vue';
+
+import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+
+import { SpaceRouter } from '@/router';
+import { store } from '@/store';
+import { i18n } from '@/translations';
+
+import DeleteModal from '@/common/components/modals/DeleteModal.vue';
+import ErrorHandler from '@/common/composables/error/errorHandler';
+import { useProxyValue } from '@/common/composables/proxy-state';
+
+import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
+
+
+export default {
+    name: 'DashboardDeleteModal',
+    components: {
+        DeleteModal,
+    },
+    props: {
+        visible: {
+            type: Boolean,
+            default: false,
+            required: true,
+        },
+        dashboardId: {
+            type: String,
+            default: undefined,
+            required: true,
+        },
+    },
+    setup(props, { emit }: SetupContext) {
+        const state = reactive({
+            proxyVisible: useProxyValue('visible', props, emit),
+            loading: false,
+        });
+        const isProjectDashboard = Boolean(props.dashboardId.startsWith('project'));
+
+
+        const handleDeleteDashboardConfirm = async () => {
+            try {
+                state.loading = true;
+                if (isProjectDashboard) {
+                    await SpaceConnector.clientV2.dashboard.projectDashboard.delete({
+                        project_dashboard_id: props.dashboardId,
+                    });
+                    await store.dispatch('dashboard/loadProjectDashboard');
+                } else {
+                    await SpaceConnector.clientV2.dashboard.domainDashboard.delete({
+                        domain_dashboard_id: props.dashboardId,
+                    });
+                    await store.dispatch('dashboard/loadDomainDashboard');
+                }
+                await SpaceRouter.router.replace({ name: DASHBOARDS_ROUTE.ALL._NAME });
+            } catch (e) {
+                ErrorHandler.handleRequestError(e, i18n.t('DASHBOARDS.FORM.ALT_E_DELETE_DASHBOARD'));
+            } finally {
+                state.loading = false;
+                state.proxyVisible = false;
+            }
+        };
+
+        return { ...toRefs(state), handleDeleteDashboardConfirm };
+    },
+};
+</script>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

was: More menu, includes `delete` / `set as home dashboard`
now: Delete icon button

`set as home dashboard` feature is decided to not provide in this dashboard

![스크린샷 2022-12-21 오후 4 34 26](https://user-images.githubusercontent.com/29014433/208846893-f2ed3608-586d-4779-a873-169e6bf5abe3.png)


### Things to Talk About
