### PR TITLE
feat(dashboard-pdf-export): connect pdf overlay to dashboardDetailPage

### DIFF
--- a/src/common/components/buttons/PdfDownloadButton.vue
+++ b/src/common/components/buttons/PdfDownloadButton.vue
@@ -15,7 +15,7 @@
                       style-type="tertiary"
                       @click="$emit('click', $event)"
             >
-                PDF
+                {{ title }}
             </p-button>
             <template #content>
                 <i18n class="popover-content"
@@ -45,14 +45,16 @@
                       style-type="tertiary"
                       @click="$emit('click', $event)"
             >
-                PDF
+                {{ title }}
             </p-button>
         </template>
     </span>
 </template>
 
 <script lang="ts">
+import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
+import type { TranslateResult } from 'vue-i18n';
 
 import { PPopover, PIconButton, PButton } from '@spaceone/design-system';
 
@@ -74,6 +76,10 @@ export default defineComponent<Props>({
         iconOnly: {
             type: Boolean,
             default: false,
+        },
+        title: {
+            type: String as PropType<string|TranslateResult>,
+            default: 'PDF',
         },
     },
     setup() {

--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -31,7 +31,9 @@
                 </span>
             </template>
             <template #extra>
-                <dashboard-control-buttons @update:visible-clone-modal="handleVisibleCloneModal" />
+                <dashboard-control-buttons :dashboard-name="state.dashboardName"
+                                           @update:visible-clone-modal="handleVisibleCloneModal"
+                />
             </template>
         </p-page-title>
         <div class="filter-box">

--- a/src/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue
@@ -6,30 +6,67 @@
         >
             {{ $t('DASHBOARDS.DETAIL.CUSTOMIZE') }}
         </p-button>
-        <p-button icon-left="ic_download"
-                  style-type="tertiary"
-        >
-            {{ $t('DASHBOARDS.DETAIL.EXPORT') }}
-        </p-button>
+        <pdf-download-button :title="$t('DASHBOARDS.DETAIL.EXPORT')"
+                             @click="handleVisiblePdfDownloadOverlay"
+        />
         <p-button icon-left="ic_duplicate"
                   style-type="tertiary"
                   @click="handleVisibleCloneModal"
         >
             {{ $t('DASHBOARDS.DETAIL.CLONE') }}
         </p-button>
+        <pdf-download-overlay v-model="state.visiblePdfDownload"
+                              :items="state.previewItems"
+                              :file-name="state.pdfFileName"
+        >
+            <dashboard-detail-preview v-if="params?.dashboardId"
+                                      :dashboard-id="params?.dashboardId"
+                                      @rendered="handlePreviewRendered"
+            />
+        </pdf-download-overlay>
     </div>
 </template>
 
 <script setup lang="ts">
-import { PButton } from '@spaceone/design-system';
+import { computed, reactive } from 'vue';
+import { useRoute } from 'vue-router/composables';
 
+import { PButton } from '@spaceone/design-system';
+import dayjs from 'dayjs';
+
+import PdfDownloadButton from '@/common/components/buttons/PdfDownloadButton.vue';
+import type { Item } from '@/common/components/layouts/PdfDownloadOverlay/PdfDownloadOverlay.vue';
+import PdfDownloadOverlay from '@/common/components/layouts/PdfDownloadOverlay/PdfDownloadOverlay.vue';
+
+import DashboardDetailPreview from '@/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
-const emit = defineEmits(['update:visible-clone-modal']);
+const emit = defineEmits(['update:visible-clone-modal', 'update:visible-pdf-download-overlay']);
 
 const handleVisibleCloneModal = () => {
     emit('update:visible-clone-modal');
 };
+
+const props = defineProps<{
+    dashboardName?: string;
+}>();
+
+const { params } = useRoute();
+
+const state = reactive({
+    visiblePdfDownload: false,
+    previewItems: [] as Item[],
+    pdfFileName: computed<string>(() => `${props.dashboardName ?? 'Cost_Dashboard'}_${dayjs().format('YYYYMMDD')}`),
+});
+
+const handlePreviewRendered = (elements) => {
+    state.previewItems = elements.map((element) => ({ element: (element?.$el ?? element), type: 'image' } as Item));
+};
+
+const handleVisiblePdfDownloadOverlay = () => {
+    state.visiblePdfDownload = true;
+};
+
 </script>
 
 <style lang="postcss">

--- a/src/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue
@@ -1,3 +1,4 @@
+<!--This component is temporary code for the pdf converting test. -->
 <template>
     <div ref="dashboardRef"
          class="dashboard-detail-preview"

--- a/src/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue
@@ -1,0 +1,133 @@
+<template>
+    <div ref="dashboardRef"
+         class="dashboard-detail-preview"
+    >
+        <p-page-title ref="dashboardTitleRef"
+                      :title="state.dashboardName"
+        >
+            <template #extra>
+                <dashboard-toolset />
+            </template>
+        </p-page-title>
+        <div class="filter-box">
+            <div>Applied Filters</div> <dashboard-labels :label-list="state.labelList" />
+        </div>
+        <div class="divider" />
+        <dashboard-widget-container
+            :dashboard-widget-layouts="state.dashboardWidgetLayouts"
+            :loading.sync="state.loading"
+            @rendered="handleAllRendered"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import type Vue from 'vue';
+import {
+    reactive, computed, watch, onMounted, ref,
+} from 'vue';
+
+import { PPageTitle } from '@spaceone/design-system';
+
+import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+
+import ErrorHandler from '@/common/composables/error/errorHandler';
+import { useManagePermissionState } from '@/common/composables/page-manage-permission';
+
+import { DASHBOARD_VIEWER } from '@/services/dashboards/config';
+import type { DashboardViewer } from '@/services/dashboards/config';
+import DashboardWidgetContainer from '@/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue';
+import { DASHBOARD_TEMPLATES } from '@/services/dashboards/default-dashboard/template-list';
+import type { DashboardModel, DomainDashboardModel, ProjectDashboardModel } from '@/services/dashboards/model';
+import DashboardLabels from '@/services/dashboards/modules/dashboard-label/DashboardLabels.vue';
+import DashboardToolset from '@/services/dashboards/modules/dashboard-toolset/DashboardToolset.vue';
+import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/config';
+
+
+interface Props {
+    dashboardId: string;
+}
+const props = defineProps<Props>();
+
+const dashboardRef = ref<HTMLElement|null>(null);
+const dashboardTitleRef = ref<Vue|null>(null);
+
+const state = reactive({
+    hasManagePermission: useManagePermissionState(),
+    dashboardInfo: DASHBOARD_TEMPLATES.monthlyCostSummary as DashboardModel, // TODO: should be changed to api data
+    dashboardViewer: computed<DashboardViewer>(() => state.dashboardInfo?.viewers ?? DASHBOARD_VIEWER.PRIVATE),
+    dashboardName: '',
+    labelList: computed<string[]>(() => state.dashboardInfo?.labels ?? []),
+    dashboardWidgetLayouts: computed<DashboardLayoutWidgetInfo[][]>(() => state.dashboardInfo?.layouts ?? []),
+    //
+    nameEditModalVisible: false,
+    deleteModalVisible: false,
+    cloneModalVisible: false,
+    refreshInterval: '15s',
+    loading: true,
+    widgetElementList: null as HTMLElement[]|null,
+    isPageMounted: false,
+    isWidgetsRendered: false,
+    isAllRendered: computed<boolean>(() => {
+        if (!state.isPageMounted) return false;
+        if (state.widgetElementList === null) return false;
+        return state.isWidgetsRendered;
+    }),
+});
+
+const emit = defineEmits(['rendered']);
+
+const isProjectDashboard = Boolean(props.dashboardId.startsWith('project'));
+
+const getDashboardData = async () => {
+    try {
+        let result: ProjectDashboardModel|DomainDashboardModel;
+        if (isProjectDashboard) {
+            result = await SpaceConnector.clientV2.dashboard.projectDashboard.get({ project_dashboard_id: props.dashboardId });
+        } else {
+            result = await SpaceConnector.clientV2.dashboard.domainDashboard.get({ project_dashboard_id: props.dashboardId });
+        }
+        // state.dashboardInfo = result;
+        state.dashboardName = result.name;
+    } catch (e) {
+        state.dashboardInfo = {};
+        ErrorHandler.handleError(e);
+    }
+};
+
+const handleAllRendered = (widgetElement:HTMLElement[]) => {
+    state.widgetElementList = widgetElement;
+    state.isWidgetsRendered = true;
+};
+
+
+watch(() => state.isAllRendered, async (isAllRendered) => {
+    if (isAllRendered) {
+        await setTimeout(() => {
+            emit('rendered', [dashboardTitleRef.value, ...state.widgetElementList]);
+        }, 10000);
+    }
+});
+onMounted(() => {
+    state.isPageMounted = true;
+});
+// INIT
+(async () => {
+    await getDashboardData();
+})();
+</script>
+
+<style lang="postcss" scoped>
+.dashboard-title-icon-buttons-wrapper {
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-left: 0.25rem;
+}
+.divider {
+    @apply mt-4 mb-6;
+}
+.filter-box {
+    @apply flex justify-between items-center mb-4;
+}
+</style>

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -158,6 +158,9 @@ export default defineComponent<Props>({
         expose({
             refreshAllWidget,
         });
+        onMounted(() => {
+            emit('rendered', state.widgetRef);
+        });
         return {
             containerRef,
             ...toRefs(state),

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -146,6 +146,7 @@ export default defineComponent<Props>({
             state.widgetWidthList = widgetWidthAssigner(state.widgetSizeList, refineContainerWidth(containerWidth));
         });
 
+        // for PDF export - start
         const refreshAllWidget = async () => {
             const promises: (()=>void)[] = [];
             state.widgetRef.forEach((d:any) => {
@@ -161,6 +162,8 @@ export default defineComponent<Props>({
         onMounted(() => {
             emit('rendered', state.widgetRef);
         });
+        // for PDF export - end
+
         return {
             containerRef,
             ...toRefs(state),


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
![image](https://user-images.githubusercontent.com/50662170/209278735-439d4f33-c039-4b10-aab3-df54744233c1.png)

First of all, I only connected the pdfExport button.
the preview component has been created and additional application is required after configuring the detail page later.

### Things to Talk About
I'm thinking about how to configure widget placement for pdf..