### PR TITLE
fix(cost-map-widget): add getConvertedChartData and minor css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25169,7 +25169,7 @@
         "lottie-web": "^5.7.6",
         "numeral": "^2.0.6",
         "pdfmake": "^0.2.4",
-        "pinia": "*",
+        "pinia": "^2.0.28",
         "portal-vue": "^2.1.7",
         "postcss": "^8.3.1",
         "postcss-cli": "^8.3.1",

--- a/src/common/composables/amcharts5/tree-map-helper.ts
+++ b/src/common/composables/amcharts5/tree-map-helper.ts
@@ -7,8 +7,6 @@ import type { CurrencyRates } from '@/store/modules/display/type';
 
 import { currencyMoneyFormatter } from '@/lib/helper/currency-helper';
 
-import { white } from '@/styles/colors';
-
 export const createTreeMapSeries = (
     root: am5.Root,
     settings?: am5hierarchy.ITreemapSettings,
@@ -23,26 +21,29 @@ export const setTreemapTooltipText = (series: am5hierarchy.Treemap, tooltip: am5
     tooltip.label.setAll({
         fontSize: 14,
     });
-
-    const categoryFieldName = series.get('categoryField') || '';
     const valueFieldName = series.get('valueField') || '';
+    const colorFieldName = 'background_color';
 
     tooltip.label.adapters.add('text', (_, target) => {
+        const colorValue = target.dataItem?.dataContext?.[colorFieldName] || 'black';
         let value = target.dataItem?.dataContext?.[valueFieldName] || '-';
+
         if (currency) value = currencyMoneyFormatter(value, currency, currencyRate);
-        return `{${categoryFieldName}}: [bold]${value}[/] ({valuePercentTotal.formatNumber("0.00")}%)`;
+        return `[${colorValue}; fontSize: 10px]●[/] {category}: [bold]${value}[/] ({valuePercentTotal.formatNumber("0.00")}%)`;
     });
 };
 
-export const setTreemapLabelText = (series: am5hierarchy.Treemap): void => {
+export const setTreemapLabelText = (series: am5hierarchy.Treemap, settings?: am5hierarchy.ITreemapSettings): void => {
     series.labels.template.setAll({
-        fontSize: 14,
-        fill: color(white),
         text: '{category}',
         position: 'absolute',
         y: 15,
         dx: 8,
         width: new Percent(100),
+        maxWidth: 140,
+        oversizedBehavior: 'truncate',
         ellipsis: '...',
+        fontSize: 14,
+        ...settings,
     });
 };

--- a/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
+++ b/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
@@ -61,7 +61,7 @@ const CATEGORY_FIELD_NAME = GROUP_BY.PROJECT;
 const COLOR_FIELD_NAME = 'background_color';
 const TEXT_COLOR_FIELD_NAME = 'font_color';
 
-interface CostTreeMapData {
+interface CostMapData {
     project_id: string;
     value: number;
     background_color?: string;
@@ -100,9 +100,9 @@ const drawChart = (chartData) => {
     };
     const series = createTreeMapSeries(seriesSettings);
 
-    const getConvertedChartData = (rawData): CostTreeMapData[] => {
+    const getConvertedChartData = (rawData): CostMapData[] => {
         const themeColorName: WidgetTheme = props.theme ? props.theme : 'violet';
-        const results: CostTreeMapData[] = [];
+        const results: CostMapData[] = [];
         rawData.forEach((d, idx) => {
             let backgroundColor = palette[themeColorName][200];
             let fontColor;

--- a/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
+++ b/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
@@ -100,8 +100,8 @@ const drawChart = (chartData) => {
     };
     const series = createTreeMapSeries(seriesSettings);
 
-    const getConvertedChartData = (rawData): CostMapData[] => {
-        const themeColorName: WidgetTheme = props.theme ? props.theme : 'violet';
+    const setColorData = (rawData): CostMapData[] => {
+        const themeColorName: WidgetTheme = props.theme || 'violet';
         const results: CostMapData[] = [];
         rawData.forEach((d, idx) => {
             let backgroundColor = palette[themeColorName][200];
@@ -135,7 +135,7 @@ const drawChart = (chartData) => {
         });
         return results;
     };
-    state.chartData[0].children = getConvertedChartData(chartData[0].children);
+    state.chartData[0].children = setColorData(chartData[0].children);
     series.rectangles.template.adapters.add('fill', (fill, target) => target.dataItem?.dataContext?.[COLOR_FIELD_NAME]);
 
     const tooltip = createTooltip();
@@ -182,7 +182,7 @@ defineExpose({
 .chart-wrapper {
     @apply relative;
     width: 100%;
-    height: 354px;
+    height: 22.125rem;
 
     .chart {
         height: 100%;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [X] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [X] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [X] `Error / Warning / Lint / Type`

### Description
* Add `getConvertedChartData` to set background-color to each rectangle and tooltip color
* Add ellipsis to label text
* Fix chart height

![image](https://user-images.githubusercontent.com/19162140/209638345-4e7597b6-c6aa-4741-b8ac-e554c319ca23.png)

### Things to Talk About
