### PR TITLE
feat(variable-selector): apply context-menu-controller & bind customize page

### DIFF
--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -15,16 +15,16 @@
         <p-divider />
         <div class="dashboard-selectors">
             <div class="variable-selector-wrapper">
-                <!--                <template v-for="(name, idx) in variableState.order">-->
-                <!--                    <variable-selector-dropdown v-if="variableState.variableProperties[name].use"-->
-                <!--                                                :key="`${name}-${idx}`"-->
-                <!--                                                :variable-name="name"-->
-                <!--                                                :default-selected="variableState.variableData[name]"-->
-                <!--                                                :variable-options="variableState.variableProperties[name].options"-->
-                <!--                                                :selection-type="variableState.variableProperties[name].selection_type"-->
-                <!--                                                @change="handleVariableChange(name, $event)"-->
-                <!--                    />-->
-                <!--                </template>-->
+                <template v-for="(name, idx) in variableState.order">
+                    <variable-selector-dropdown v-if="variableState.variableProperties[name].use"
+                                                :key="`${name}-${idx}`"
+                                                :variable-name="name"
+                                                :default-selected="variableState.variableData[name]"
+                                                :variable-options="variableState.variableProperties[name].options"
+                                                :selection-type="variableState.variableProperties[name].selection_type"
+                                                @change="handleVariableChange(name, $event)"
+                    />
+                </template>
                 <!--                <variable-more-button-dropdown :variable-map="variableState.variableProperties"-->
                 <!--                                               :variable-order="variableState.order"-->
                 <!--                                               @change="handleChangeVariableUse"-->
@@ -241,10 +241,10 @@ const handleSave = async () => {
 // const handleChangeVariableUse = (variables: DashboardVariablesSchema['properties']) => {
 //     variableState.variableProperties = variables;
 // };
-// const handleVariableChange = (name: string, selected: string|string[]) => {
-//     variableState.variableData[name] = selected;
-//     console.log(variableState.variableData);
-// };
+const handleVariableChange = (name: string, selected: string|string[]) => {
+    variableState.variableData[name] = selected;
+    console.log(variableState.variableData);
+};
 
 onMounted(() => {
     getDashboardData();

--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -22,7 +22,7 @@
                                                 :default-selected="variableState.variableData[name]"
                                                 :variable-options="variableState.variableProperties[name].options"
                                                 :selection-type="variableState.variableProperties[name].selection_type"
-                                                @change="handleVariableChange(name, $event)"
+                                                @change="handleChangeVariable(name, $event)"
                     />
                 </template>
                 <!--                <variable-more-button-dropdown :variable-map="variableState.variableProperties"-->
@@ -241,9 +241,8 @@ const handleSave = async () => {
 // const handleChangeVariableUse = (variables: DashboardVariablesSchema['properties']) => {
 //     variableState.variableProperties = variables;
 // };
-const handleVariableChange = (name: string, selected: string|string[]) => {
+const handleChangeVariable = (name: string, selected: string|string[]) => {
     variableState.variableData[name] = selected;
-    console.log(variableState.variableData);
 };
 
 onMounted(() => {

--- a/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -63,20 +63,9 @@ import type { TranslateResult } from 'vue-i18n';
 import {
     PBadge, PContextMenu, PI, useContextMenuController,
 } from '@spaceone/design-system';
-import type { ContextMenuType } from '@spaceone/design-system/types/inputs/context-menu/type';
+import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
 
 import type { VariableSelectionType } from '@/services/dashboards/config';
-
-// temporary
-interface MenuItem {
-    name?: string;
-    label?: string | TranslateResult;
-    type?: ContextMenuType;
-    disabled?: boolean;
-    link?: string;
-    target?: string;
-    icon?: string;
-}
 
 interface Props {
     variableName: string;

--- a/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -141,11 +141,11 @@ const handleChangeContextMenuInput = (value: string): void => {
 };
 
 // reconvert to string | string[]
-watch(() => state.selected, () => {
+watch(() => state.selected, (_selected) => {
     let reconvertedSelected;
     if (props.selectionType === 'SINGLE') {
-        reconvertedSelected = state.selected[0].name;
-    } else reconvertedSelected = state.selected.map((d) => d.name);
+        reconvertedSelected = _selected[0].name;
+    } else reconvertedSelected = _selected.map((d) => d.name);
     emit('change', reconvertedSelected);
 });
 
@@ -215,19 +215,6 @@ onMounted(() => {
             @apply border-blue-400 bg-blue-200;
             &.is-visible {
                 @apply border-blue-600;
-            }
-        }
-    }
-
-    /* custom design-system component - p-context-menu-item */
-    :deep(.options-menu) {
-
-        .p-context-menu-item {
-            &.selected {
-                @apply bg-white;
-            }
-            &:hover {
-                @apply bg-blue-200;
             }
         }
     }

--- a/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -30,8 +30,8 @@
                 </button>
             </span>
 
-            <p-i :name="state.visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
-                 :activated="state.visibleMenu"
+            <p-i :name="visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+                 :activated="visibleMenu"
                  color="inherit"
                  class="dropdown-icon"
             />

--- a/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -38,6 +38,7 @@
         </button>
         <p-context-menu v-show="visibleMenu"
                         ref="contextMenuRef"
+                        class="options-menu"
                         searchable
                         use-fixed-menu-style
                         :style="fixedMenuStyle"
@@ -214,6 +215,19 @@ onMounted(() => {
             @apply border-blue-400 bg-blue-200;
             &.is-visible {
                 @apply border-blue-600;
+            }
+        }
+    }
+
+    /* custom design-system component - p-context-menu-item */
+    :deep(.options-menu) {
+
+        .p-context-menu-item {
+            &.selected {
+                @apply bg-white;
+            }
+            &:hover {
+                @apply bg-blue-200;
             }
         }
     }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
SSIA
- Delete button has been added.
- Since data received as props and type actually used are different, it goes through a complicated two-way conversion process in `onMounted`, `watch`.
- `MenuItem` is a temporary code that will soon be deleted.

<img width="621" alt="스크린샷 2022-12-29 오전 11 18 45" src="https://user-images.githubusercontent.com/83635051/209894799-91e226bf-3680-4d33-9e14-d49ce542700e.png">

https://user-images.githubusercontent.com/83635051/209894836-3afb2a17-df90-4c52-8402-5cf55eef1d24.mov

