### PR TITLE
feat(variable-more-dropdown): apply context-menu-controller & bind variables data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@amcharts/amcharts5": "^5.2.31",
         "@amcharts/amcharts5-geodata": "^5.0.6",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.499",
+        "@spaceone/design-system": "^1.1.0-beta.500",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -3650,9 +3650,9 @@
       }
     },
     "node_modules/@spaceone/design-system": {
-      "version": "1.1.0-beta.499",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.499.tgz",
-      "integrity": "sha512-Hdl24TiHci/EmpRgAwiHrixGZn4qDfz3ampJMA1bBq907Inw4qG2C4ER5VpOH6IVWlm1dHn+b+Ir6uo+Vcrw7A==",
+      "version": "1.1.0-beta.500",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.500.tgz",
+      "integrity": "sha512-ZdeUyLc9bAyuSXnd4zOk5QvIiWn1aP9Sd9iqJKS0RUpiooTgXeDilRQjJBCinbnP/0jAoHxC4mLq2bXt/IBYWw==",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -22682,9 +22682,9 @@
       }
     },
     "@spaceone/design-system": {
-      "version": "1.1.0-beta.499",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.499.tgz",
-      "integrity": "sha512-Hdl24TiHci/EmpRgAwiHrixGZn4qDfz3ampJMA1bBq907Inw4qG2C4ER5VpOH6IVWlm1dHn+b+Ir6uo+Vcrw7A==",
+      "version": "1.1.0-beta.500",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.500.tgz",
+      "integrity": "sha512-ZdeUyLc9bAyuSXnd4zOk5QvIiWn1aP9Sd9iqJKS0RUpiooTgXeDilRQjJBCinbnP/0jAoHxC4mLq2bXt/IBYWw==",
       "requires": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -25108,7 +25108,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^1.1.0-beta.499",
+        "@spaceone/design-system": "1.1.0-beta.500",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -27778,9 +27778,9 @@
           }
         },
         "@spaceone/design-system": {
-          "version": "1.1.0-beta.499",
-          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.499.tgz",
-          "integrity": "sha512-Hdl24TiHci/EmpRgAwiHrixGZn4qDfz3ampJMA1bBq907Inw4qG2C4ER5VpOH6IVWlm1dHn+b+Ir6uo+Vcrw7A==",
+          "version": "1.1.0-beta.500",
+          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-1.1.0-beta.500.tgz",
+          "integrity": "sha512-ZdeUyLc9bAyuSXnd4zOk5QvIiWn1aP9Sd9iqJKS0RUpiooTgXeDilRQjJBCinbnP/0jAoHxC4mLq2bXt/IBYWw==",
           "requires": {
             "@amcharts/amcharts4": "^4.10.10",
             "@babel/runtime": "^7.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25108,7 +25108,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "1.1.0-beta.500",
+        "@spaceone/design-system": "^1.1.0-beta.500",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@amcharts/amcharts5": "^5.2.31",
     "@amcharts/amcharts5-geodata": "^5.0.6",
     "@gtm-support/vue2-gtm": "^1.3.0",
-    "@spaceone/design-system": "^1.1.0-beta.499",
+    "@spaceone/design-system": "^1.1.0-beta.500",
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-color": "^2.0.0-beta.12",
     "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -80,6 +80,8 @@ import DashboardManageVariableOverlay
 import DashboardCustomizePageName
     from '@/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue';
 import DashboardCustomizeSidebar from '@/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue';
+import VariableMoreButtonDropdown
+    from '@/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue';
 import VariableSelectorDropdown from '@/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue';
 import DashboardWidgetContainer from '@/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue';
 import type { DashboardModel } from '@/services/dashboards/model';

--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -25,10 +25,10 @@
                                                 @change="handleChangeVariable(name, $event)"
                     />
                 </template>
-                <!--                <variable-more-button-dropdown :variable-map="variableState.variableProperties"-->
-                <!--                                               :variable-order="variableState.order"-->
-                <!--                                               @change="handleChangeVariableUse"-->
-                <!--                />-->
+                <variable-more-button-dropdown :variable-map="variableState.variableProperties"
+                                               :variable-order="variableState.order"
+                                               @change="handleChangeVariableUse"
+                />
             </div>
             <dashboard-refresh-dropdown :interval-option.sync="state.refreshInterval"
                                         refresh-disabled
@@ -236,9 +236,9 @@ const handleUpdateLabelList = (labelList: Array<string>) => {
 const handleSave = async () => {
     await updateDashboardData();
 };
-// const handleChangeVariableUse = (variables: DashboardVariablesSchema['properties']) => {
-//     variableState.variableProperties = variables;
-// };
+const handleChangeVariableUse = (variables: DashboardVariablesSchema['properties']) => {
+    variableState.variableProperties = variables;
+};
 const handleChangeVariable = (name: string, selected: string|string[]) => {
     variableState.variableData[name] = selected;
 };

--- a/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
@@ -1,22 +1,29 @@
 <template>
-    <div class="variable-more-button">
-        <p-button icon-left="ic_plus"
+    <div v-on-click-outside="hideContextMenu"
+         class="variable-more-button-dropdown"
+         :class="{'open-menu': visibleMenu}"
+    >
+        <p-button ref="targetRef"
+                  icon-left="ic_plus"
                   style-type="highlight"
                   @click="handleClickButton"
         >
             {{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.MORE') }}
         </p-button>
-        <p-context-menu v-if="state.visibleMenu"
-                        :menu="state.variables"
-                        :selected="state.selected"
-                        multi-selectable
+        <p-context-menu v-show="visibleMenu"
+                        ref="contextMenuRef"
+                        class="variables-menu"
                         searchable
                         use-fixed-menu-style
+                        :style="fixedMenuStyle"
+                        :menu="variables"
+                        :selected.sync="selected"
+                        multi-selectable
                         show-clear-selection
-                        @select="handleVariableSelect"
         >
             <template #bottom>
-                <p-button style-type="secondary"
+                <p-button class="manage-variable-button"
+                          style-type="secondary"
                           icon-left="ic_setting"
                           @click="handleOpenOverlay"
                 >
@@ -28,13 +35,15 @@
 </template>
 
 <script lang="ts" setup>
+import { vOnClickOutside } from '@vueuse/components';
 import {
-    computed, onMounted, reactive,
+    onMounted, reactive, toRefs, watch,
 } from 'vue';
+import type { TranslateResult } from 'vue-i18n';
 
-import { PButton, PContextMenu } from '@spaceone/design-system';
+import { PButton, PContextMenu, useContextMenuController } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, forEach } from 'lodash';
 
 import { SpaceRouter } from '@/router';
 
@@ -45,29 +54,41 @@ interface Props {
     variableMap: DashboardVariablesSchema['properties'];
     variableOrder: string[];
 }
-
 interface EventEmits {
     (e: string, value: string): void;
-    (e: 'manage-more'): void;
-    (e: 'select', value: DashboardVariablesSchema['properties']): void;
+    (e: 'change', value: DashboardVariablesSchema['properties']): void;
 }
 
 const props = defineProps<Props>();
 const emit = defineEmits<EventEmits>();
 
 const state = reactive({
-    visibleMenu: false,
-    variables: computed(() => {
-        const properties = props.variableMap;
-        const menuItems = [] as any[];
-        Object.keys(properties).forEach((d) => menuItems.push({
-            name: d,
-            label: properties[d].name,
-        }));
-        return menuItems;
-    }),
-    order: computed(() => props.variableOrder),
+    targetRef: null,
+    contextMenuRef: null,
+    variables: [] as MenuItem[],
     selected: [] as MenuItem[],
+});
+
+const {
+    targetRef,
+    contextMenuRef,
+    variables,
+    selected,
+} = toRefs(state);
+
+const {
+    visibleMenu,
+    hideContextMenu,
+    showContextMenu,
+    fixedMenuStyle,
+    reorderMenuBySelection,
+    menu,
+} = useContextMenuController({
+    targetRef,
+    contextMenuRef,
+    useReorderBySelection: true,
+    useFixedStyle: true,
+    menu: variables,
 });
 
 // event
@@ -75,34 +96,57 @@ const handleOpenOverlay = () => {
     SpaceRouter.router.push({ hash: MANAGE_VARIABLES_HASH_NAME });
 };
 const handleClickButton = () => {
-    state.visibleMenu = !state.visibleMenu;
-};
-const handleVariableSelect = (item: MenuItem) => {
-    if (!item.name) return;
-    const result = cloneDeep(props.variableMap) as DashboardVariablesSchema['properties'];
-    if (props.variableMap[item.name]) {
-        result[item.name].use = !result[item.name].use;
+    if (visibleMenu.value) {
+        hideContextMenu();
+    } else {
+        reorderMenuBySelection(selected.value);
+        showContextMenu();
     }
-    emit('select', result);
 };
+
+// After context menu is hidden, update selected variable's use.
+watch(() => visibleMenu.value, () => {
+    if (visibleMenu.value) return;
+    const properties = cloneDeep(props.variableMap) as DashboardVariablesSchema['properties'];
+    props.variableOrder.forEach((d) => {
+        properties[d].use = state.selected.some((item) => item.name === d);
+    });
+    emit('change', properties);
+});
 
 onMounted(() => {
     const properties = props.variableMap;
     const defaultSelected = [] as MenuItem[];
-    Object.keys(properties).forEach((d) => {
-        if (!properties[d].use) return;
+    const defaultVariables = [] as MenuItem[];
+    props.variableOrder.forEach((d) => {
+        defaultVariables.push({
+            name: d, label: d,
+        });
+        if (!properties[d]?.use) return;
         defaultSelected.push({
             name: d,
-            label: properties[d].name,
+            label: d,
         });
     });
+    state.variables = defaultVariables;
     state.selected = defaultSelected;
 });
 
 </script>
 
 <style lang="postcss" scoped>
-.variable-more-button {
-    @apply inline-block relative;
+.variable-more-button-dropdown {
+    @apply inline-block;
+
+    &.open-menu {
+        @apply relative;
+    }
+
+    .variables-menu {
+
+        .manage-variable-button {
+            @apply w-full;
+        }
+    }
 }
 </style>

--- a/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
@@ -103,15 +103,16 @@ const handleClickButton = () => {
 };
 
 // After context menu is hidden, update selected variable's use.
-watch([visibleMenu, reorderedMenu], ([_visibleMenu, _reorderedMenu], prev) => {
+watch([visibleMenu, reorderedMenu], ([_visibleMenu]) => {
     if (_visibleMenu) {
         return;
     }
 
-    const [, prevReorderedMenu] = prev;
-    if (_reorderedMenu === prevReorderedMenu) {
-        return;
-    }
+    // TODO: refactor
+    // const [, prevReorderedMenu] = prev;
+    // if (_reorderedMenu === prevReorderedMenu) {
+    //     return;
+    // }
 
     const properties = { ...props.variableMap };
     selected.value.forEach((item) => {

--- a/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
@@ -139,7 +139,6 @@ onMounted(() => {
     state.variables = defaultVariables;
     state.selected = defaultSelected;
 });
-
 </script>
 
 <style lang="postcss" scoped>

--- a/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
@@ -62,8 +62,8 @@ const props = defineProps<Props>();
 const emit = defineEmits<EventEmits>();
 
 const state = reactive({
-    targetRef: null,
-    contextMenuRef: null,
+    targetRef: null as HTMLElement | null,
+    contextMenuRef: null as typeof PContextMenu | null,
     variables: [] as MenuItem[],
     selected: [] as MenuItem[],
 });

--- a/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -42,7 +42,7 @@
                         searchable
                         use-fixed-menu-style
                         :style="fixedMenuStyle"
-                        :menu="menu"
+                        :menu="reorderedMenu"
                         :selected.sync="selected"
                         :multi-selectable="selectionType === 'MULTI'"
                         :show-radio-icon="selectionType === 'SINGLE'"
@@ -100,16 +100,15 @@ const {
     visibleMenu,
     showContextMenu,
     hideContextMenu,
-    // focusOnContextMenu,
-    reorderMenuBySelection,
     fixedMenuStyle,
-    menu,
+    reorderedMenu,
 } = useContextMenuController({
     targetRef,
     contextMenuRef,
     useReorderBySelection: true,
     useFixedStyle: true,
-    menu: options,
+    originMenu: options,
+    selected,
 });
 
 // event
@@ -120,8 +119,7 @@ const handleChangeVisible = () => {
     if (visibleMenu.value) {
         hideContextMenu();
     } else {
-        reorderMenuBySelection(selected.value);
-        showContextMenu();
+        showContextMenu(true); // update reorderedMenu automatically
     }
 };
 // TODO: search text binding

--- a/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -82,8 +82,8 @@ const emit = defineEmits<EmitFn>();
 
 
 const state = reactive({
-    targetRef: null,
-    contextMenuRef: null,
+    targetRef: null as HTMLElement | null,
+    contextMenuRef: null as typeof PContextMenu | null,
     searchText: '',
     selected: [] as MenuItem[],
     options: [] as MenuItem[],


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
SSIA

- Use status of each variable is applied after the dropdown is hidden.
- Emits 'change' of selected according to the status of the visible menu.

https://user-images.githubusercontent.com/83635051/209916317-f4f2f053-a37e-4cdd-83d8-14f2d27db21a.mov



### Things to Talk About

As you can see from the description above, 
as `visibleMenu` changes, 'change' event is emitted even if there is no change in selected. 
Could there be a better way?