### PR TITLE
feat: add DashboardContainerWidgetInfo that has widgetKey

### DIFF
--- a/src/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue
@@ -84,11 +84,11 @@ import { useProxyValue } from '@/common/composables/proxy-state';
 
 import { DASHBOARD_SCOPE } from '@/services/dashboards/config';
 import DashboardAddWidgetModal from '@/services/dashboards/dashboard-customize/modules/DashboardAddWidgetModal.vue';
+import type { DashboardContainerWidgetInfo } from '@/services/dashboards/dashboard-detail/lib/type';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
-import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/config';
 
 interface Props {
-    widgetInfoList: DashboardLayoutWidgetInfo[];
+    widgetInfoList: DashboardContainerWidgetInfo[];
     dashboardId: string;
 }
 
@@ -127,7 +127,7 @@ const handleClickCancelButton = () => {
 const handleClickSaveButton = () => {
     emit('save');
 };
-const handleAddWidget = (newWidget: DashboardLayoutWidgetInfo) => {
+const handleAddWidget = (newWidget: DashboardContainerWidgetInfo) => {
     state.proxyWidgetInfoList = state.proxyWidgetInfoList.concat([newWidget]);
 };
 

--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -57,8 +57,8 @@
         </div>
         <dashboard-widget-container
             ref="widgetContainerRef"
+            :dashboard-id="props.dashboardId"
             :widget-info-list="state.dashboardWidgetInfoList"
-            :all-reference-type-info="state.allReferenceTypeInfo"
         />
         <dashboard-name-edit-modal :visible.sync="state.nameEditModalVisible"
                                    :dashboard-id="props.dashboardId"
@@ -74,7 +74,7 @@
 
 <script setup lang="ts">
 import {
-    reactive, ref, computed, watch, onMounted,
+    reactive, ref, computed, watch,
 } from 'vue';
 
 import {
@@ -86,12 +86,10 @@ import { flattenDeep } from 'lodash';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
 import { SpaceRouter } from '@/router';
-import { store } from '@/store';
 
 import type { Currency } from '@/store/modules/display/config';
 import { CURRENCY } from '@/store/modules/display/config';
 import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
-import type { AllReferenceTypeInfo } from '@/store/modules/reference/type';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import { useManagePermissionState } from '@/common/composables/page-manage-permission';
@@ -101,6 +99,7 @@ import { gray } from '@/styles/colors';
 
 import { DASHBOARD_VIEWER } from '@/services/dashboards/config';
 import type { DashboardViewer, DateRange } from '@/services/dashboards/config';
+import type { DashboardContainerWidgetInfo } from '@/services/dashboards/dashboard-detail/lib/type';
 import DashboardControlButtons from '@/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue';
 import DashboardDeleteModal from '@/services/dashboards/dashboard-detail/modules/DashboardDeleteModal.vue';
 import DashboardNameEditModal from '@/services/dashboards/dashboard-detail/modules/DashboardNameEditModal.vue';
@@ -111,7 +110,6 @@ import DashboardToolset from '@/services/dashboards/modules/dashboard-toolset/Da
 import DashboardCloneModal from '@/services/dashboards/modules/DashboardCloneModal.vue';
 import DashboardRefreshDropdown from '@/services/dashboards/modules/DashboardRefreshDropdown.vue';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
-import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/config';
 
 const PUBLIC_ICON_COLOR = gray[500];
 
@@ -127,7 +125,7 @@ const state = reactive({
     dashboardName: '',
     isProjectDashboard: computed<boolean>(() => props.dashboardId.startsWith('project')),
     labelList: computed<string[]>(() => state.dashboardInfo?.labels ?? []),
-    dashboardWidgetInfoList: computed<DashboardLayoutWidgetInfo[]>(() => flattenDeep(state.dashboardInfo?.layouts)),
+    dashboardWidgetInfoList: computed<DashboardContainerWidgetInfo[]>(() => flattenDeep(state.dashboardInfo?.layouts)),
     enableDateRange: false,
     dateRange: {
         start: dayjs.utc().format('YYYY-MM-01'),
@@ -141,7 +139,6 @@ const state = reactive({
     cloneModalVisible: false,
     refreshInterval: '15s',
     loading: false,
-    allReferenceTypeInfo: computed<AllReferenceTypeInfo>(() => store.getters['reference/allReferenceTypeInfo']),
 });
 
 const widgetContainerRef = ref<any>(null);
@@ -198,9 +195,6 @@ watch(() => props.dashboardId, (dashboardId) => {
     if (dashboardId) getDashboardData();
 }, { immediate: true });
 
-onMounted(async () => {
-    await store.dispatch('reference/loadAll');
-});
 </script>
 
 <style lang="postcss" scoped>

--- a/src/services/dashboards/dashboard-detail/lib/type.ts
+++ b/src/services/dashboards/dashboard-detail/lib/type.ts
@@ -1,7 +1,11 @@
-import type { WidgetConfig } from '@/services/dashboards/widgets/config';
+import type { WidgetConfig, DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/config';
 import type { WidgetTheme } from '@/services/dashboards/widgets/view-config';
 
 // WIDTH
 export type WidgetThemeOption = WidgetConfig['theme'];
 // ['violet' | 'blue' | 'coral' ... | undefined]
 export type WidgetThemeAssignedList = Array<WidgetTheme | undefined>;
+
+export interface DashboardContainerWidgetInfo extends DashboardLayoutWidgetInfo {
+    widgetKey: string;
+}


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- Use DashboardContainerWidgetInfo in DashboardWidgetContainer.vue to use widgetKey as widget element's id not to initiate every time when drag & drop occurs.

https://user-images.githubusercontent.com/26986739/210030891-4a3bfe0b-72d6-4d75-ae96-91c3dbfcefa4.mov



### Things to Talk About
