### PR TITLE
feat(manage-variable): bind variable schema to overlay & component separation

### DIFF
--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -22,12 +22,12 @@
                                                 :default-selected="variableState.variableData[name]"
                                                 :variable-options="variableState.variableProperties[name].options"
                                                 :selection-type="variableState.variableProperties[name].selection_type"
-                                                @change="handleChangeVariable(name, $event)"
+                                                @change="handleChangeVariableOptions(name, $event)"
                     />
                 </template>
-                <variable-more-button-dropdown :variable-map="variableState.variableProperties"
+                <variable-more-button-dropdown :variables="variableState.variableProperties"
                                                :variable-order="variableState.order"
-                                               @change="handleChangeVariableUse"
+                                               @change="handleChangeVariable"
                 />
             </div>
             <dashboard-refresh-dropdown :interval-option.sync="state.refreshInterval"
@@ -47,7 +47,11 @@
                                      :enable-currency.sync="state.dashboardSettings.currency.enabled"
                                      @save="handleSave"
         />
-        <dashboard-manage-variable-overlay :visible="variableState.showOverlay" />
+        <dashboard-manage-variable-overlay :visible="variableState.showOverlay"
+                                           :variables="variableState.variableProperties"
+                                           :order="variableState.order"
+                                           @change="handleChangeVariable"
+        />
     </div>
 </template>
 
@@ -243,10 +247,10 @@ const handleUpdateLabelList = (labelList: Array<string>) => {
 const handleSave = async () => {
     await updateDashboardData();
 };
-const handleChangeVariableUse = (variables: DashboardVariablesSchema['properties']) => {
+const handleChangeVariable = (variables: DashboardVariablesSchema['properties']) => {
     variableState.variableProperties = variables;
 };
-const handleChangeVariable = (name: string, selected: string|string[]) => {
+const handleChangeVariableOptions = (name: string, selected: string|string[]) => {
     variableState.variableData[name] = selected;
 };
 

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
@@ -7,21 +7,21 @@
                       @goBack="$router.go(-1)"
         />
         <div class="content-wrapper">
-            <p-panel-top :use-total-count="overlayState.contentStatus === 'LIST'"
+            <p-panel-top :use-total-count="contentType === 'LIST'"
                          :total-count="1"
             >
                 <template #default>
-                    {{ overlayState.titleSet[overlayState.contentStatus] }}
+                    {{ titleSet[contentType] }}
                 </template>
                 <template #extra>
                     <div class="add-button-wrapper">
-                        <p-button v-if="overlayState.contentStatus === 'LIST'"
+                        <p-button v-if="contentType === 'LIST'"
                                   icon-left="ic_plus"
                                   @click="handleChangeAddContent"
                         >
                             {{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.ADD') }}
                         </p-button>
-                        <p-button v-else-if="overlayState.contentStatus === 'EDIT'"
+                        <p-button v-else-if="contentType === 'EDIT'"
                                   icon-left="ic_trashcan"
                                   style-type="negative-secondary"
                                   @click="handleOpenDeleteModal"
@@ -31,52 +31,16 @@
                     </div>
                 </template>
             </p-panel-top>
-            <div v-if="overlayState.contentStatus === 'LIST'"
-                 class="list-wrapper"
-            >
-                <div class="variable-select-filter">
-                    <span class="filter-header">{{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_TITLE') }}</span>
-                    <p-select-status v-for="(type, idx) in variableFilterList"
-                                     :key="`variable-type-${idx}`"
-                                     :selected="selectedVariableType"
-                                     :value="type.name"
-                                     @change="handleSelectType"
-                    >
-                        {{ type.label }}
-                    </p-select-status>
-                </div>
-                <p-data-table :items="[]"
-                              :fields="variableFields"
-                >
-                    <template #col-variable_type-formvariableItemsat="{ value }">
-                        <p-badge :style-type="variableTypeBadgeStyleFormatter(value)">
-                            {{ variableType[value] }}
-                        </p-badge>
-                    </template>
-                    <template #col-use-format="{ value }">
-                        <p-toggle-button :value="value"
-                                         sync
-                        />
-                    </template>
-                    <template #col-edit-format>
-                        <button class="manage-button"
-                                @click="handleEditVariable"
-                        >
-                            <p-i name="ic_edit" />
-                            <span>{{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.EDIT') }}</span>
-                        </button>
-                    </template>
-                    <template #col-delete-format>
-                        <button class="manage-button"
-                                @click="handleDeleteVariable"
-                        >
-                            <p-i name="ic_trashcan" />
-                            <span>{{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.DELETE') }}</span>
-                        </button>
-                    </template>
-                </p-data-table>
-            </div>
-            <dashboard-manage-variable-form v-else />
+            <dashboard-manage-variable-table v-if="contentType === 'LIST'"
+                                             :content-type.sync="contentType"
+                                             :variables="variables"
+                                             :order="order"
+                                             @use-change="handleChangeVariableUse"
+                                             @delete="handleOpenDeleteModal"
+            />
+            <dashboard-manage-variable-form v-else
+                                            :content-type.sync="contentType"
+            />
         </div>
         <delete-modal :header-title="deleteModalState.headerTitle"
                       :visible.sync="deleteModalState.visible"
@@ -86,135 +50,80 @@
     </overlay-page-layout>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import {
-    computed, defineComponent, reactive, toRefs,
+    computed, reactive, toRefs,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
 
 import {
-    PDataTable,
     PPanelTop,
     PButton,
-    PBadge,
-    PToggleButton,
-    PI,
     PPageTitle,
-    PSelectStatus,
 } from '@spaceone/design-system';
+import { cloneDeep } from 'lodash';
 
 import { i18n } from '@/translations';
 
 import DeleteModal from '@/common/components/modals/DeleteModal.vue';
 import OverlayPageLayout from '@/common/modules/page-layouts/OverlayPageLayout.vue';
 
-import type { VariableType } from '@/services/dashboards/config';
+import type { DashboardVariablesSchema } from '@/services/dashboards/config';
 import DashboardManageVariableForm from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableForm.vue';
+import DashboardManageVariableTable
+    from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue';
+import type {
+    OverlayStatus,
+} from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type';
 
-type OverlayStatus = 'LIST' | 'ADD' | 'EDIT';
+interface Props {
+    visible: boolean;
+    variables: DashboardVariablesSchema['properties'];
+    order: string[];
+}
+interface EmitFn {
+    (e: 'change', value: DashboardVariablesSchema['properties']): void;
+}
 
-export default defineComponent({
-    name: 'DashboardManageVariableOverlay',
-    components: {
-        OverlayPageLayout,
-        DeleteModal,
-        PDataTable,
-        PPanelTop,
-        PButton,
-        PBadge,
-        PToggleButton,
-        PI,
-        PPageTitle,
-        PSelectStatus,
-        DashboardManageVariableForm,
-    },
-    props: {
-        visible: {
-            default: undefined,
-            type: Boolean,
-        },
-    },
-    setup() {
-        const state = reactive({
-            // TODO: implementation
-            variableFilterList: computed(() => [
-                { label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_ALL'), name: 'ALL' },
-                { label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_MANAGED'), name: 'MANAGED' },
-                { label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_CUSTOM'), name: 'CUSTOM' },
-            ]),
-            selectedVariableType: 'ALL',
-            variableFields: [
-                { name: 'name', label: 'Name' },
-                { name: 'selectionType', label: 'Selection Type' },
-                { name: 'variableType', label: 'Variable Type' },
-                { name: 'use', label: 'Use' },
-                { name: 'options', label: 'Options' },
-                { name: 'edit', label: ' ' },
-                { name: 'delete', label: ' ' },
-            ],
-            selectionType: computed(() => ({
-                SINGLE: i18n.t('Single '),
-                MULTI: i18n.t('Multi'),
-            })),
-            variableType: computed(() => ({
-                MANAGED: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_MANAGED'),
-                CUSTOM: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_CUSTOM'),
-            })),
-        });
-        const overlayState = reactive({
-            contentStatus: 'LIST' as OverlayStatus,
-            titleSet: computed<Record<OverlayStatus, TranslateResult>>(() => ({
-                LIST: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.SUB_TITLE'),
-                ADD: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.ADD'),
-                EDIT: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.SUB_TITLE_EDIT'),
-            })),
-        });
+const props = defineProps<Props>();
+const emit = defineEmits<EmitFn>();
 
-        const deleteModalState = reactive({
-            headerTitle: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.DELETE_TITLE'),
-            visible: false,
-            loading: false,
-        });
-
-        /* Helper */
-        const variableTypeBadgeStyleFormatter = (type: VariableType) => {
-            if (type === 'MANAGED') return 'gray';
-            return 'primary';
-        };
-        /* EVENT */
-        const handleOpenDeleteModal = () => {
-            deleteModalState.visible = true;
-        };
-        const handleSelectType = (selected) => {
-            state.selectedVariableType = selected;
-        };
-        const handleChangeAddContent = () => {
-            overlayState.contentStatus = 'ADD';
-        };
-        const handleAddVariable = () => {
-            console.log('Add Variable!');
-        };
-        const handleEditVariable = () => {
-            console.log('edit!');
-        };
-        const handleDeleteVariable = () => {
-            console.log('delete!');
-        };
-        return {
-            ...toRefs(state),
-            overlayState,
-            deleteModalState,
-            handleChangeAddContent,
-            handleOpenDeleteModal,
-            handleSelectType,
-            handleAddVariable,
-            variableTypeBadgeStyleFormatter,
-            handleEditVariable,
-            handleDeleteVariable,
-        };
-    },
+const state = reactive({
+    contentType: 'LIST' as OverlayStatus,
+    titleSet: computed<Record<OverlayStatus, TranslateResult>>(() => ({
+        LIST: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.SUB_TITLE'),
+        ADD: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.ADD'),
+        EDIT: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.SUB_TITLE_EDIT'),
+    })),
 });
+
+const { contentType, titleSet } = toRefs(state);
+
+const deleteModalState = reactive({
+    headerTitle: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.DELETE_TITLE'),
+    visible: false,
+    loading: false,
+    selected: '',
+});
+
+/* EVENT */
+const handleChangeAddContent = () => {
+    state.contentType = 'ADD';
+};
+const handleOpenDeleteModal = (propertyName: string) => {
+    deleteModalState.selected = propertyName;
+    deleteModalState.visible = true;
+};
+const handleDeleteVariable = () => {
+    console.log(deleteModalState.selected, 'Delete!!!!');
+};
+const handleChangeVariableUse = (name: string, value: boolean) => {
+    const properties = cloneDeep(props.variables) as DashboardVariablesSchema['properties'];
+    properties[name].use = value;
+    emit('change', properties);
+};
+
 </script>
 
 <style lang="postcss" scoped>

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableForm.vue
@@ -49,7 +49,9 @@
             </div>
         </p-field-group>
         <div class="button-wrapper">
-            <p-button style-type="tertiary">
+            <p-button style-type="tertiary"
+                      @click="handleCancel"
+            >
                 {{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.CANCEL') }}
             </p-button>
             <p-button>
@@ -59,41 +61,44 @@
     </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, reactive, toRefs } from 'vue';
+<script setup lang="ts">
+import { reactive, toRefs } from 'vue';
 import draggable from 'vuedraggable';
 
 import {
-    PButton, PFieldGroup, PIconButton, PSelectDropdown, PTextInput, PI,
+    PButton, PFieldGroup, PIconButton, PSelectDropdown, PTextInput, PI, useProxyValue,
 } from '@spaceone/design-system';
 
-export default defineComponent({
-    name: 'DashboardManageVariableForm',
-    components: {
-        PButton,
-        PFieldGroup,
-        PIconButton,
-        PSelectDropdown,
-        PTextInput,
-        PI,
-        draggable,
-    },
-    setup() {
-        const state = reactive({
-            name: '',
-            selectionType: 'MULTI',
-            options: [
-                { name: 'a', label: 'a-test' },
-                { name: 'b', label: 'b-test-test' },
-                { name: 'c', label: 'c-test-test-test' },
-            ],
-        });
+import type {
+    OverlayStatus,
+} from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type';
 
-        return {
-            ...toRefs(state),
-        };
-    },
+interface Props {
+    contentType: OverlayStatus;
+}
+interface EmitFn {
+    (e: string, value: string): void;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<EmitFn>();
+
+const state = reactive({
+    proxyContentType: useProxyValue('contentType', props, emit),
+    name: '',
+    selectionType: 'MULTI',
+    options: [
+        { name: 'a', label: 'a-test' },
+        { name: 'b', label: 'b-test-test' },
+        { name: 'c', label: 'c-test-test-test' },
+    ],
 });
+
+const { name, options } = toRefs(state);
+
+const handleCancel = () => {
+    state.proxyContentType = 'LIST';
+};
 
 </script>
 

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
@@ -1,0 +1,178 @@
+<template>
+    <div class="list-wrapper">
+        <div class="variable-select-filter">
+            <span class="filter-header">{{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_TITLE') }}</span>
+            <p-select-status v-for="(type, idx) in variableFilterList"
+                             :key="`variable-type-${idx}`"
+                             :selected="selectedVariableType"
+                             :value="type.name"
+                             @change="handleSelectType"
+            >
+                {{ type.label }}
+            </p-select-status>
+        </div>
+        <p-data-table class="variable-table"
+                      :items="orderedVariables"
+                      :fields="variableFields"
+        >
+            <template #col-selection_type-format="{ value }">
+                <span>{{ selectionType[value] }}</span>
+            </template>
+            <template #col-variable_type-format="{ value }">
+                <p-badge :style-type="variableTypeBadgeStyleFormatter(value)"
+                         outline
+                >
+                    {{ variableType[value] }}
+                </p-badge>
+            </template>
+            <template #col-use-format="{ value, item }">
+                <p-toggle-button :value="value"
+                                 sync
+                                 @change="handleToggleUse(item.propertyName, value)"
+                />
+            </template>
+            <template #col-options-format="{ value }">
+                <span>{{ value.join(', ') }}</span>
+            </template>
+            <template #col-managable-format="{ value }">
+                <template v-if="value">
+                    <p-button class="manage-button"
+                              style-type="tertiary"
+                              icon-left="ic_edit"
+                              size="sm"
+                              @click="handleEditVariable"
+                    >
+                        {{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.EDIT') }}
+                    </p-button>
+                    <p-button class="manage-button"
+                              style-type="tertiary"
+                              icon-left="ic_trashcan"
+                              size="sm"
+                              @click="handleDeleteVariable(value)"
+                    >
+                        {{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.DELETE') }}
+                    </p-button>
+                </template>
+            </template>
+        </p-data-table>
+    </div>
+</template>
+
+<script setup lang="ts">
+import {
+    computed, reactive, toRefs,
+} from 'vue';
+
+import {
+    PBadge, PDataTable, PSelectStatus, PToggleButton, useProxyValue, PButton,
+} from '@spaceone/design-system';
+
+import { i18n } from '@/translations';
+
+import type { VariableType, DashboardVariablesSchema } from '@/services/dashboards/config';
+import type {
+    OverlayStatus,
+} from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type';
+
+interface Props {
+    contentType: OverlayStatus;
+    variables: DashboardVariablesSchema['properties'];
+    order: string[];
+}
+interface EmitFn {
+    (e: string, value: string): void;
+    (e: 'delete', value: string): void;
+    (e: 'use-change', name: string, value: boolean): void;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<EmitFn>();
+
+const state = reactive({
+    proxyContentType: useProxyValue('contentType', props, emit),
+    orderedVariables: computed(() => props.order.map((d) => {
+        const currentVariable = {
+            ...props.variables[d],
+            propertyName: d,
+        };
+        if (currentVariable.variable_type === 'MANAGED') return currentVariable;
+        return {
+            ...currentVariable,
+            managable: d,
+        };
+    })),
+    variableFilterList: computed(() => [
+        { label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_ALL'), name: 'ALL' },
+        { label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_MANAGED'), name: 'MANAGED' },
+        { label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_CUSTOM'), name: 'CUSTOM' },
+    ]),
+    selectedVariableType: 'ALL',
+    variableFields: [
+        { name: 'name', label: 'Name' },
+        { name: 'selection_type', label: 'Selection Type' },
+        { name: 'variable_type', label: 'Variable Type' },
+        { name: 'use', label: 'Use' },
+        { name: 'options', label: 'Options' },
+        { name: 'managable', label: ' ' },
+    ],
+    selectionType: computed(() => ({
+        SINGLE: i18n.t('Single select'),
+        MULTI: i18n.t('Multi select'),
+    })),
+    variableType: computed(() => ({
+        MANAGED: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_MANAGED'),
+        CUSTOM: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_CUSTOM'),
+    })),
+});
+
+const {
+    orderedVariables,
+    variableFilterList,
+    selectedVariableType,
+    variableFields,
+    selectionType,
+    variableType,
+} = toRefs(state);
+
+/* Helper */
+const variableTypeBadgeStyleFormatter = (type: VariableType) => {
+    if (type === 'MANAGED') return 'gray';
+    return 'primary';
+};
+/* EVENT */
+const handleSelectType = (selected) => {
+    state.selectedVariableType = selected;
+};
+const handleEditVariable = () => {
+    state.proxyContentType = 'EDIT';
+};
+const handleDeleteVariable = (propertyName: string) => {
+    emit('delete', propertyName);
+};
+const handleToggleUse = (propertyName: string, value: boolean) => {
+    emit('use-change', propertyName, !value);
+};
+
+</script>
+
+<style lang="postcss" scoped>
+.list-wrapper {
+    .variable-select-filter {
+        @apply flex items-center;
+        height: 2.875rem;
+        gap: 1rem;
+        padding: 0.75rem 1rem;
+
+        .filter-header {
+            @apply text-gray-500;
+            font-size: 0.875rem;
+            line-height: 1.25;
+        }
+    }
+    .variable-table {
+        .manage-button {
+            margin-right: 0.375rem;
+        }
+    }
+}
+</style>

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type.ts
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type.ts
@@ -1,0 +1,1 @@
+export type OverlayStatus = 'LIST' | 'ADD' | 'EDIT';


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
SSIA
- Bind variable schema to overlay.
- Separate table from overlay, and name `DashboardManageVariableTable`.
- Some refactors - rename, table field setting... etc.


https://user-images.githubusercontent.com/83635051/210201500-54c7b00c-df83-427b-adc5-9bd77d22526e.mov

