### PR TITLE
feat(dashboard-detail-info-store): add setDashboardInfo

### DIFF
--- a/src/common/composables/breadcrumbs/index.ts
+++ b/src/common/composables/breadcrumbs/index.ts
@@ -32,8 +32,11 @@ export const useBreadcrumbs = () => {
                     location.path = path;
                 }
 
-                const label = d.meta.label;
-                if (label) {
+                if (d.meta.breadcrumbs && typeof d.meta.breadcrumbs === 'function') {
+                    const breadcrumbsFunctionResults = d.meta.breadcrumbs(vm.$route);
+                    results.push(...breadcrumbsFunctionResults);
+                } else if (d.meta.label) {
+                    const label = d.meta.label;
                     if (typeof label === 'function') {
                         const labelResult = label(vm.$route);
                         if (labelResult) results.push({ name: labelResult, to: location, copiable: d.meta.copiable });

--- a/src/services/dashboards/routes.ts
+++ b/src/services/dashboards/routes.ts
@@ -1,6 +1,10 @@
 import type { RouteConfig } from 'vue-router';
 
+import { i18n } from '@/translations';
+
 import { MENU_ID } from '@/lib/menu/config';
+
+import type { Breadcrumb } from '@/common/modules/page-layouts/type';
 
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
@@ -65,20 +69,36 @@ const dashboardsRoute: RouteConfig = {
                             component: DashboardDetailPage,
                         },
                         {
-                            path: 'customize',
-                            meta: { translationId: 'DASHBOARDS.DETAIL.CUSTOMIZE' },
-                            props: true,
-                            component: { template: '<router-view/>' },
-                            redirect: () => ({ name: DASHBOARDS_ROUTE.ALL._NAME }),
-                            children: [
-                                {
-                                    path: ':dashboardId',
-                                    name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME,
-                                    meta: { label: ({ params }) => params.dashboardId, copiable: true },
-                                    props: true,
-                                    component: DashboardCustomizePage,
+                            path: 'customize/:dashboardId?',
+                            name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME,
+                            meta: {
+                                breadcrumbs: ({ params }) => {
+                                    const breadcrumbs: Breadcrumb[] = [
+                                        {
+                                            // song-lang
+                                            name: i18n.t('Customize'),
+                                            to: {
+                                                name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME,
+                                            },
+                                        },
+                                    ];
+                                    if (params.dashboardId) {
+                                        breadcrumbs.push({
+                                            name: params.dashboardId,
+                                            to: {
+                                                name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME,
+                                                params: {
+                                                    dashboardId: params.dashboardId,
+                                                },
+                                            },
+                                            copiable: true,
+                                        });
+                                    }
+                                    return breadcrumbs;
                                 },
-                            ],
+                            },
+                            props: true,
+                            component: DashboardCustomizePage,
                         },
                     ],
                 },

--- a/src/shims-vue-router.d.ts
+++ b/src/shims-vue-router.d.ts
@@ -1,4 +1,5 @@
 declare module 'vue-router' {
+    import type { TranslateResult } from 'vue-i18n';
   import type {
       RouteConfigMultipleViews as OriginRouteConfigMultipleViews,
       RouteConfigSingleView as OriginRouteConfigSingleView,
@@ -11,14 +12,23 @@ import {
 
     import type { AccessLevel } from '@/lib/access-control/config';
 
+    import type { Breadcrumb } from '@/common/modules/page-layouts/type';
+
   interface RouteLabelFormatter {
-    (route: Route): string;
+    (route: Route): TranslateResult|TranslateResult[];
+  }
+  interface RouteTranslationIdFormatter {
+    (route: Route): string|string[];
+  }
+  interface RouteBreadcrumbsFormatter {
+      (route: Route): Breadcrumb[];
   }
   interface RouteMeta {
     lnbVisible?: boolean;
     menuId?: string;
     label?: string|RouteLabelFormatter;
-    translationId?: string|RouteLabelFormatter;
+    translationId?: string|RouteTranslationIdFormatter;
+    breadcrumbs?: RouteBreadcrumbsFormatter;
     copiable?: boolean; // for breadcrumbs
     isSignInPage?: boolean;
     accessLevel?: AccessLevel;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- Add setDashboardInfo and resetDashboardSettings to dashboard-detail-info store
- Make customize page's last breadcrumb optional
  - Update dashboards route hierarchy
  - add breadcrumbs function to router meta and use-breadcrumbs composable
  - 



### Things to Talk About
