### PR TITLE
refactor: use dashboard-detail-info store in dashboard widget container

### DIFF
--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -34,12 +34,7 @@
                                         refresh-disabled
             />
         </div>
-        <dashboard-widget-container :dashboard-id="dashboardDetailState.dashboardId"
-                                    :widget-info-list="dashboardDetailState.dashboardWidgetInfoList"
-                                    :dashboard-variables="dashboardDetailState.variables"
-                                    :dashboard-settings="dashboardDetailState.settings"
-                                    edit-mode
-        />
+        <dashboard-widget-container edit-mode />
         <dashboard-customize-sidebar :widget-info-list.sync="dashboardDetailState.dashboardWidgetInfoList"
                                      :dashboard-id="props.dashboardId"
                                      :enable-date-range.sync="dashboardDetailState.settings.date_range.enabled"

--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -55,10 +55,7 @@
                                         @refresh="handleRefresh"
             />
         </div>
-        <dashboard-widget-container ref="widgetContainerRef"
-                                    :dashboard-id="dashboardDetailState.dashboardId"
-                                    :widget-info-list="dashboardDetailState.dashboardWidgetInfoList"
-        />
+        <dashboard-widget-container ref="widgetContainerRef" />
         <dashboard-name-edit-modal :visible.sync="state.nameEditModalVisible"
                                    :dashboard-id="props.dashboardId"
                                    :dashboard-name="dashboardDetailState.dashboardName"

--- a/src/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardControlButtons.vue
@@ -6,40 +6,34 @@
         >
             {{ $t('DASHBOARDS.DETAIL.CUSTOMIZE') }}
         </p-button>
-        <pdf-download-button :title="$t('DASHBOARDS.DETAIL.EXPORT')"
-                             @click="handleVisiblePdfDownloadOverlay"
-        />
+        <!--        <pdf-download-button :title="$t('DASHBOARDS.DETAIL.EXPORT')"-->
+        <!--                             @click="handleVisiblePdfDownloadOverlay"-->
+        <!--        />-->
         <p-button icon-left="ic_duplicate"
                   style-type="tertiary"
                   @click="handleVisibleCloneModal"
         >
             {{ $t('DASHBOARDS.DETAIL.CLONE') }}
         </p-button>
-        <pdf-download-overlay v-model="state.visiblePdfDownload"
-                              :items="state.previewItems"
-                              :file-name="state.pdfFileName"
-        >
-            <dashboard-detail-preview v-if="props.dashboardId"
-                                      :dashboard-id="props.dashboardId"
-                                      @rendered="handlePreviewRendered"
-            />
-        </pdf-download-overlay>
+        <!--        <pdf-download-overlay v-model="state.visiblePdfDownload"-->
+        <!--                              :items="state.previewItems"-->
+        <!--                              :file-name="state.pdfFileName"-->
+        <!--        >-->
+        <!--            <dashboard-detail-preview v-if="props.dashboardId"-->
+        <!--                                      :dashboard-id="props.dashboardId"-->
+        <!--                                      @rendered="handlePreviewRendered"-->
+        <!--            />-->
+        <!--        </pdf-download-overlay>-->
     </div>
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from 'vue';
 
 import { PButton } from '@spaceone/design-system';
-import dayjs from 'dayjs';
 
 import { SpaceRouter } from '@/router';
 
-import PdfDownloadButton from '@/common/components/buttons/PdfDownloadButton.vue';
-import type { Item } from '@/common/components/layouts/PdfDownloadOverlay/PdfDownloadOverlay.vue';
-import PdfDownloadOverlay from '@/common/components/layouts/PdfDownloadOverlay/PdfDownloadOverlay.vue';
 
-import DashboardDetailPreview from '@/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
 const emit = defineEmits(['update:visible-clone-modal', 'update:visible-pdf-download-overlay']);
@@ -53,19 +47,19 @@ const props = defineProps<{
     dashboardName?: string;
 }>();
 
-const state = reactive({
-    visiblePdfDownload: false,
-    previewItems: [] as Item[],
-    pdfFileName: computed<string>(() => `${props.dashboardName ?? 'Cost_Dashboard'}_${dayjs().format('YYYYMMDD')}`),
-});
+// const state = reactive({
+//     visiblePdfDownload: false,
+//     previewItems: [] as Item[],
+//     pdfFileName: computed<string>(() => `${props.dashboardName ?? 'Cost_Dashboard'}_${dayjs().format('YYYYMMDD')}`),
+// });
 
-const handlePreviewRendered = (elements) => {
-    state.previewItems = elements.map((element) => ({ element: (element?.$el ?? element), type: 'image' } as Item));
-};
+// const handlePreviewRendered = (elements) => {
+//     state.previewItems = elements.map((element) => ({ element: (element?.$el ?? element), type: 'image' } as Item));
+// };
 
-const handleVisiblePdfDownloadOverlay = () => {
-    state.visiblePdfDownload = true;
-};
+// const handleVisiblePdfDownloadOverlay = () => {
+//     state.visiblePdfDownload = true;
+// };
 
 const handleClickCustomize = () => {
     SpaceRouter.router.push({ name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME, params: { dashboardId: props.dashboardId } });

--- a/src/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue
@@ -14,11 +14,7 @@
             <div>Applied Filters</div> <dashboard-labels :label-list="state.labelList" />
         </div>
         <div class="divider" />
-        <dashboard-widget-container
-            :dashboard-widget-layouts="state.dashboardWidgetLayouts"
-            :loading.sync="state.loading"
-            @rendered="handleAllRendered"
-        />
+        <dashboard-widget-container @rendered="handleAllRendered" />
     </div>
 </template>
 

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -38,7 +38,7 @@ interface DashboardDetailInfoStoreState {
     enableDateRange: boolean;
     dateRange: DateRange;
     settings: DashboardSettings;
-    variables: ComputedRef<DashboardVariables>;
+    variables: DashboardVariables;
     // widget info states
     dashboardWidgetInfoList: DashboardContainerWidgetInfo[];
     loadingWidgets: boolean;
@@ -70,7 +70,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
                 value: CURRENCY.USD,
             },
         },
-        variables: computed<DashboardVariables>(() => state.dashboardInfo?.variables ?? {}),
+        variables: {},
         // widget info states
         dashboardWidgetInfoList: [],
         loadingWidgets: false,
@@ -116,6 +116,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
                 value: CURRENCY.USD,
             },
         };
+        state.variables = {};
         state.dashboardWidgetInfoList = [];
     };
 
@@ -138,6 +139,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
                 value: dashboardInfo.settings.currency?.value ?? CURRENCY.USD,
             },
         };
+        state.variables = dashboardInfo.variables ?? {};
         state.dashboardWidgetInfoList = flattenDeep(dashboardInfo?.layouts ?? []).map((info) => ({
             ...info,
             widgetKey: uuidv4(),


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- Refactor DashboardWidgetContainer.vue to use dashboard-detail-info store 
- Apply changed usage of DashboardWidgetContainer.vue to detail & customize pages
- Hide pdf export buttons


### Things to Talk About
