### PR TITLE
feat(widgets): use data param if exist in intWidget()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "uuid": "^8.3.0",
         "v-click-outside": "^3.0.1",
         "v-tooltip": "^2.0.2",
-        "vue": "^2.7.10",
+        "vue": "^2.7.14",
         "vue-focus": "^2.1.0",
         "vue-fragment": "^1.5.1",
         "vue-gtag": "^1.6.2",
@@ -19400,11 +19400,11 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.10.tgz",
-      "integrity": "sha512-HmFC70qarSHPXcKtW8U8fgIkF6JGvjEmDiVInTkKZP0gIlEPhlVlcJJLkdGIDiNkIeA2zJPQTWJUI4iWe+AVfg==",
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.10",
+        "@vue/compiler-sfc": "2.7.14",
         "csstype": "^3.1.0"
       }
     },
@@ -19668,9 +19668,9 @@
       }
     },
     "node_modules/vue/node_modules/@vue/compiler-sfc": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.10.tgz",
-      "integrity": "sha512-55Shns6WPxlYsz4WX7q9ZJBL77sKE1ZAYNYStLs6GbhIOMrNtjMvzcob6gu3cGlfpCR4bT7NXgyJ3tly2+Hx8Q==",
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
       "dependencies": {
         "@babel/parser": "^7.18.4",
         "postcss": "^8.4.14",
@@ -25199,7 +25199,7 @@
         "vite-plugin-stylelint": "^3.0.8",
         "vite-plugin-vue-type-imports": "^0.2.4",
         "vitest": "^0.25.8",
-        "vue": "^2.7.10",
+        "vue": "2.7.14",
         "vue-focus": "^2.1.0",
         "vue-fragment": "^1.5.1",
         "vue-gtag": "^1.6.2",
@@ -39424,18 +39424,18 @@
           }
         },
         "vue": {
-          "version": "2.7.10",
-          "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.10.tgz",
-          "integrity": "sha512-HmFC70qarSHPXcKtW8U8fgIkF6JGvjEmDiVInTkKZP0gIlEPhlVlcJJLkdGIDiNkIeA2zJPQTWJUI4iWe+AVfg==",
+          "version": "2.7.14",
+          "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+          "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
           "requires": {
-            "@vue/compiler-sfc": "2.7.10",
+            "@vue/compiler-sfc": "2.7.14",
             "csstype": "^3.1.0"
           },
           "dependencies": {
             "@vue/compiler-sfc": {
-              "version": "2.7.10",
-              "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.10.tgz",
-              "integrity": "sha512-55Shns6WPxlYsz4WX7q9ZJBL77sKE1ZAYNYStLs6GbhIOMrNtjMvzcob6gu3cGlfpCR4bT7NXgyJ3tly2+Hx8Q==",
+              "version": "2.7.14",
+              "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+              "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
               "requires": {
                 "@babel/parser": "^7.18.4",
                 "postcss": "^8.4.14",
@@ -49161,18 +49161,18 @@
       }
     },
     "vue": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.10.tgz",
-      "integrity": "sha512-HmFC70qarSHPXcKtW8U8fgIkF6JGvjEmDiVInTkKZP0gIlEPhlVlcJJLkdGIDiNkIeA2zJPQTWJUI4iWe+AVfg==",
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
       "requires": {
-        "@vue/compiler-sfc": "2.7.10",
+        "@vue/compiler-sfc": "2.7.14",
         "csstype": "^3.1.0"
       },
       "dependencies": {
         "@vue/compiler-sfc": {
-          "version": "2.7.10",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.10.tgz",
-          "integrity": "sha512-55Shns6WPxlYsz4WX7q9ZJBL77sKE1ZAYNYStLs6GbhIOMrNtjMvzcob6gu3cGlfpCR4bT7NXgyJ3tly2+Hx8Q==",
+          "version": "2.7.14",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+          "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
           "requires": {
             "@babel/parser": "^7.18.4",
             "postcss": "^8.4.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "vite-plugin-stylelint": "^3.0.8",
         "vite-plugin-vue-type-imports": "^0.2.4",
         "vitest": "^0.25.8",
-        "vue-template-compiler": "^2.7.10",
+        "vue-template-compiler": "^2.7.14",
         "yorkie": "^2.0.0"
       },
       "engines": {
@@ -19659,9 +19659,9 @@
       }
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.10.tgz",
-      "integrity": "sha512-QO+8R9YRq1Gudm8ZMdo/lImZLJVUIAM8c07Vp84ojdDAf8HmPJc7XB556PcXV218k2AkKznsRz6xB5uOjAC4EQ==",
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
       "dependencies": {
         "de-indent": "^1.0.2",
         "he": "^1.2.0"
@@ -25199,14 +25199,14 @@
         "vite-plugin-stylelint": "^3.0.8",
         "vite-plugin-vue-type-imports": "^0.2.4",
         "vitest": "^0.25.8",
-        "vue": "2.7.14",
+        "vue": "^2.7.14",
         "vue-focus": "^2.1.0",
         "vue-fragment": "^1.5.1",
         "vue-gtag": "^1.6.2",
         "vue-i18n": "^8.11.2",
         "vue-router": "^3.6.5",
         "vue-selecto": "^1.6.4",
-        "vue-template-compiler": "^2.7.10",
+        "vue-template-compiler": "2.7.14",
         "vuedraggable": "^2.24.1",
         "vuex": "^3.6.2",
         "webfontloader": "^1.6.28",
@@ -39619,9 +39619,9 @@
           }
         },
         "vue-template-compiler": {
-          "version": "2.7.10",
-          "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.10.tgz",
-          "integrity": "sha512-QO+8R9YRq1Gudm8ZMdo/lImZLJVUIAM8c07Vp84ojdDAf8HmPJc7XB556PcXV218k2AkKznsRz6xB5uOjAC4EQ==",
+          "version": "2.7.14",
+          "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+          "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
           "requires": {
             "de-indent": "^1.0.2",
             "he": "^1.2.0"
@@ -49356,9 +49356,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.10.tgz",
-      "integrity": "sha512-QO+8R9YRq1Gudm8ZMdo/lImZLJVUIAM8c07Vp84ojdDAf8HmPJc7XB556PcXV218k2AkKznsRz6xB5uOjAC4EQ==",
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
       "requires": {
         "de-indent": "^1.0.2",
         "he": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "uuid": "^8.3.0",
     "v-click-outside": "^3.0.1",
     "v-tooltip": "^2.0.2",
-    "vue": "^2.7.10",
+    "vue": "^2.7.14",
     "vue-focus": "^2.1.0",
     "vue-fragment": "^1.5.1",
     "vue-gtag": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "vite-plugin-stylelint": "^3.0.8",
     "vite-plugin-vue-type-imports": "^0.2.4",
     "vitest": "^0.25.8",
-    "vue-template-compiler": "^2.7.10",
+    "vue-template-compiler": "^2.7.14",
     "yorkie": "^2.0.0"
   },
   "browserslist": [

--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -34,7 +34,9 @@
                                         refresh-disabled
             />
         </div>
-        <dashboard-widget-container edit-mode />
+        <dashboard-widget-container edit-mode
+                                    reuse-previous-data
+        />
         <dashboard-customize-sidebar :widget-info-list.sync="dashboardDetailState.dashboardWidgetInfoList"
                                      :dashboard-id="props.dashboardId"
                                      :enable-date-range.sync="dashboardDetailState.settings.date_range.enabled"

--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -194,7 +194,7 @@ const updateDashboardData = async () => {
             name: DASHBOARDS_ROUTE.DETAIL._NAME,
             params: {
                 dashboardId: props.dashboardId,
-                dashboardScope: state.isProjectDashboard ? DASHBOARD_SCOPE.PROJECT : DASHBOARD_SCOPE.DOMAIN,
+                dashboardScope: dashboardDetailState.isProjectDashboard ? DASHBOARD_SCOPE.PROJECT : DASHBOARD_SCOPE.DOMAIN,
             },
         });
     } catch (e) {

--- a/src/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardDetailPreview.vue
@@ -14,7 +14,9 @@
             <div>Applied Filters</div> <dashboard-labels :label-list="state.labelList" />
         </div>
         <div class="divider" />
-        <dashboard-widget-container @rendered="handleAllRendered" />
+        <dashboard-widget-container reuse-previous-data
+                                    @rendered="handleAllRendered"
+        />
     </div>
 </template>
 

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -80,7 +80,7 @@ export default defineComponent<Props>({
             widgetInfoList: computed(() => dashboardDetailState.dashboardWidgetInfoList),
             dashboardVariables: computed(() => dashboardDetailState.variables),
             dashboardSettings: computed(() => dashboardDetailState.settings),
-            widgetDataMap: computed<Record<string, boolean>>({
+            widgetDataMap: computed({
                 get() { return dashboardDetailState.widgetDataMap; },
                 set(val) { dashboardDetailState.widgetDataMap = val; },
             }),
@@ -156,16 +156,16 @@ export default defineComponent<Props>({
 
 
         const refreshAllWidget = async () => {
-            const promises: WidgetExpose['refreshWidget'][] = [];
+            const refreshWidgetPromises: WidgetExpose['refreshWidget'][] = [];
 
             const filteredRefs = state.widgetRef.filter((comp: WidgetComponent|null) => {
                 if (!comp || typeof comp.refreshWidget() !== 'function') return false;
                 if (!state.initiatedWidgetMap[comp.$el?.id]) return false;
-                promises.push(comp.refreshWidget);
+                refreshWidgetPromises.push(comp.refreshWidget);
                 return true;
             });
 
-            const results = await Promise.allSettled(promises);
+            const results = await Promise.allSettled(refreshWidgetPromises);
 
             results.forEach((result, idx) => {
                 if (result.status === 'fulfilled') {

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -110,7 +110,7 @@ export default defineComponent<Props>({
             return containerWidth - (containerWidth % 80);
         };
 
-        const handleIntersectionObserver = ([{ isIntersecting, target }]) => {
+        const handleIntersectionObserver = async ([{ isIntersecting, target }]) => {
             if (state.initiatedWidgetMap[target.id]) return;
             if (isIntersecting) {
                 const targetWidgetRef: WidgetComponent|null = state.widgetRef.find((d) => d?.$el?.id === target.id);

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -28,7 +28,7 @@
 
 <script lang="ts">
 import { vIntersectionObserver } from '@vueuse/components';
-import type { DirectiveFunction, SetupContext } from 'vue';
+import type { ComponentPublicInstance, DirectiveFunction, SetupContext } from 'vue';
 import {
     defineComponent, reactive, toRefs, ref, onMounted, watch, onBeforeUnmount, computed,
 } from 'vue';
@@ -45,19 +45,18 @@ import {
 import { widgetThemeAssigner } from '@/services/dashboards/dashboard-detail/lib/theme-helper';
 import { widgetWidthAssigner } from '@/services/dashboards/dashboard-detail/lib/width-helper';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/dashboard-detail/store/dashboard-detail-info';
-import AWSCloudFrontCost from '@/services/dashboards/widgets/aws-cloud-front-cost/AWSCloudFrontCost.vue';
-import type { WidgetSize, WidgetConfig } from '@/services/dashboards/widgets/config';
+import type {
+    WidgetSize, WidgetConfig, WidgetExpose, WidgetProps,
+} from '@/services/dashboards/widgets/config';
 import type { WidgetTheme } from '@/services/dashboards/widgets/view-config';
 import { getWidgetComponent, getWidgetConfig } from '@/services/dashboards/widgets/widget-helper';
 
 interface Props {
     editMode?: boolean;
 }
+type WidgetComponent = ComponentPublicInstance<WidgetProps, WidgetExpose>;
 export default defineComponent<Props>({
     name: 'DashboardWidgetContainer',
-    components: {
-        AWSCloudFrontCost,
-    },
     directives: {
         intersectionObserver: vIntersectionObserver as DirectiveFunction,
     },
@@ -67,14 +66,19 @@ export default defineComponent<Props>({
             default: false,
         },
     },
-    setup(props, { emit, expose }: SetupContext) {
+    setup(props, { expose }: SetupContext) {
         const dashboardDetailStore = useDashboardDetailInfoStore();
         const dashboardDetailState = dashboardDetailStore.state;
 
         const state = reactive({
+            dashboardId: computed(() => dashboardDetailState.dashboardId),
             widgetInfoList: computed(() => dashboardDetailState.dashboardWidgetInfoList),
             dashboardVariables: computed(() => dashboardDetailState.variables),
             dashboardSettings: computed(() => dashboardDetailState.settings),
+            widgetDataMap: computed<Record<string, boolean>>({
+                get() { return dashboardDetailState.widgetDataMap; },
+                set(val) { dashboardDetailState.widgetDataMap = val; },
+            }),
             // width
             containerWidth: WIDGET_CONTAINER_MIN_WIDTH,
             widgetSizeList: [] as WidgetSize[],
@@ -88,8 +92,8 @@ export default defineComponent<Props>({
                 });
                 return widgetThemeAssigner(widgetThemeOptions);
             }),
-            widgetRef: [] as Array<InstanceType<typeof AWSCloudFrontCost>>,
-            initiatedWidgetMap: {} as {[widgetKey: string]: boolean},
+            widgetRef: [] as Array<WidgetComponent|null>,
+            initiatedWidgetMap: {} as Record<string, any>,
             allReferenceTypeInfo: computed<AllReferenceTypeInfo>(() => store.getters['reference/allReferenceTypeInfo']),
         });
         const containerRef = ref<HTMLElement|null>(null);
@@ -104,9 +108,12 @@ export default defineComponent<Props>({
         const handleIntersectionObserver = ([{ isIntersecting, target }]) => {
             if (state.initiatedWidgetMap[target.id]) return;
             if (isIntersecting) {
-                state.initiatedWidgetMap[target.id] = true;
-                const targetWidgetRef = state.widgetRef.filter((d) => d.$el.id === target.id)[0];
-                if (typeof targetWidgetRef.initWidget === 'function') targetWidgetRef.initWidget();
+                const targetWidgetRef: WidgetComponent|null = state.widgetRef.find((d) => d?.$el?.id === target.id);
+                if (typeof targetWidgetRef?.initWidget === 'function') {
+                    const data = await targetWidgetRef.initWidget(state.widgetDataMap[target.id]);
+                    state.widgetDataMap[target.id] = data;
+                    state.initiatedWidgetMap[target.id] = data;
+                }
             }
         };
 
@@ -141,22 +148,34 @@ export default defineComponent<Props>({
             state.initiatedWidgetMap = initiatedWidgetMap;
         }, { immediate: true, deep: true });
 
-        // for PDF export - start
+
         const refreshAllWidget = async () => {
-            const promises: (()=>void)[] = [];
-            state.widgetRef.forEach((d:any) => {
-                if (typeof d?.refreshWidget === 'function' && state.initiatedWidgetMap[d.$el.id]) promises.push(d?.refreshWidget());
+            const promises: WidgetExpose['refreshWidget'][] = [];
+
+            const filteredRefs = state.widgetRef.filter((comp: WidgetComponent|null) => {
+                if (!comp || typeof comp.refreshWidget() !== 'function') return false;
+                if (!state.initiatedWidgetMap[comp.$el?.id]) return false;
+                promises.push(comp.refreshWidget);
+                return true;
             });
-            await Promise.allSettled(promises);
+
+            const results = await Promise.allSettled(promises);
+
+            results.forEach((result, idx) => {
+                if (result.status === 'fulfilled') {
+                    const widgetKey = filteredRefs[idx]?.$el?.id;
+                    state.widgetDataMap[widgetKey] = result.value;
+                }
+            });
         };
         expose({
             refreshAllWidget,
         });
         onMounted(async () => {
             await store.dispatch('reference/loadAll');
-            emit('rendered', state.widgetRef);
+            // for PDF export
+            // emit('rendered', state.widgetRef);
         });
-        // for PDF export - end
 
         return {
             containerRef,

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -53,6 +53,7 @@ import { getWidgetComponent, getWidgetConfig } from '@/services/dashboards/widge
 
 interface Props {
     editMode?: boolean;
+    reusePreviousData?: boolean;
 }
 type WidgetComponent = ComponentPublicInstance<WidgetProps, WidgetExpose>;
 export default defineComponent<Props>({
@@ -62,6 +63,10 @@ export default defineComponent<Props>({
     },
     props: {
         editMode: {
+            type: Boolean,
+            default: false,
+        },
+        reusePreviousData: {
             type: Boolean,
             default: false,
         },
@@ -110,7 +115,8 @@ export default defineComponent<Props>({
             if (isIntersecting) {
                 const targetWidgetRef: WidgetComponent|null = state.widgetRef.find((d) => d?.$el?.id === target.id);
                 if (typeof targetWidgetRef?.initWidget === 'function') {
-                    const data = await targetWidgetRef.initWidget(state.widgetDataMap[target.id]);
+                    const prevData = props.reusePreviousData ? state.widgetDataMap[target.id] : undefined;
+                    const data = await targetWidgetRef.initWidget(prevData);
                     state.widgetDataMap[target.id] = data;
                     state.initiatedWidgetMap[target.id] = data;
                 }

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -27,8 +27,9 @@ import { WIDGET_SIZE } from '@/services/dashboards/widgets/config';
 import { getWidgetConfig } from '@/services/dashboards/widgets/widget-helper';
 
 interface WidgetDataMap {
-[widgetKey: string]: any;
+    [widgetKey: string]: any;
 }
+
 interface DashboardDetailInfoStoreState {
     loadingDashboard: boolean;
     dashboardId: string;

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -26,7 +26,9 @@ import type { DashboardModel } from '@/services/dashboards/model';
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/config';
 import { getWidgetConfig } from '@/services/dashboards/widgets/widget-helper';
 
-
+interface WidgetDataMap {
+[widgetKey: string]: any;
+}
 interface DashboardDetailInfoStoreState {
     loadingDashboard: boolean;
     dashboardId: string;
@@ -44,6 +46,7 @@ interface DashboardDetailInfoStoreState {
     // widget info states
     dashboardWidgetInfoList: DashboardContainerWidgetInfo[];
     loadingWidgets: boolean;
+    widgetDataMap: WidgetDataMap;
 }
 export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', () => {
     const state = reactive<DashboardDetailInfoStoreState>({
@@ -76,6 +79,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         // widget info states
         dashboardWidgetInfoList: [],
         loadingWidgets: false,
+        widgetDataMap: {},
     });
 
     const resetDashboardSettings = () => {
@@ -146,6 +150,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
             ...info,
             widgetKey: uuidv4(),
         }));
+        state.widgetDataMap = {};
     };
 
     const getDashboardData = async (dashboardId: string) => {
@@ -181,6 +186,14 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
             return info;
         });
     };
+    const initiateAllWidgets = () => {
+        const widgetDataMap = {};
+        state.dashboardWidgetInfoList.forEach((widget) => {
+            widgetDataMap[widget.widgetKey] = state.widgetDataMap[widget.widgetKey];
+        });
+        state.widgetDataMap = widgetDataMap;
+    };
+
     store.dispatch('reference/loadAll');
 
     return {
@@ -189,5 +202,6 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         resetDashboardSettings,
         setDashboardInfo,
         toggleWidgetSize,
+        initiateAllWidgets,
     };
 });

--- a/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
@@ -52,8 +52,8 @@ import { useAmcharts5 } from '@/common/composables/amcharts5';
 import type { Field } from '@/services/dashboards/widgets/_components/type';
 import WidgetDataTable from '@/services/dashboards/widgets/_components/WidgetDataTable.vue';
 import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
-import type { GroupBy, WidgetProps } from '@/services/dashboards/widgets/config';
 import { CHART_TYPE } from '@/services/dashboards/widgets/config';
+import type { GroupBy, WidgetExpose, WidgetProps } from '@/services/dashboards/widgets/config';
 import type { Legend } from '@/services/dashboards/widgets/type';
 import { useWidgetFrameProps } from '@/services/dashboards/widgets/use-widget-frame-props';
 import { useWidgetLifecycle } from '@/services/dashboards/widgets/use-widget-lifecycle';
@@ -176,28 +176,30 @@ const handleToggleLegend = (index) => {
     toggleSeries(state.chart, index);
 };
 
-const initWidget = async () => {
+const initWidget = async (data?: Data[]): Promise<Data[]> => {
     state.loading = true;
-    state.data = await fetchData();
+    state.data = data ?? await fetchData();
     await nextTick();
     drawChart(state.chartData);
     state.loading = false;
+    return state.data;
 };
 
-const refreshWidget = async () => {
+const refreshWidget = async (): Promise<Data[]> => {
     state.loading = true;
     state.data = await fetchData();
     await nextTick();
     refreshRoot();
     drawChart(state.chartData);
     state.loading = false;
+    return state.data;
 };
 
 useWidgetLifecycle({
     disposeWidget: disposeRoot,
 });
 
-defineExpose({
+defineExpose<WidgetExpose<Data[]>>({
     initWidget,
     refreshWidget,
 });

--- a/src/services/dashboards/widgets/aws-cloud-front-cost/AWSCloudFrontCost.vue
+++ b/src/services/dashboards/widgets/aws-cloud-front-cost/AWSCloudFrontCost.vue
@@ -46,7 +46,7 @@ import { useAmcharts5 } from '@/common/composables/amcharts5';
 import WidgetDataTable from '@/services/dashboards/widgets/_components/WidgetDataTable.vue';
 import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
 import WidgetFrameHeaderDropdown from '@/services/dashboards/widgets/_components/WidgetFrameHeaderDropdown.vue';
-import type { WidgetProps } from '@/services/dashboards/widgets/config';
+import type { WidgetExpose, WidgetProps } from '@/services/dashboards/widgets/config';
 import { GROUP_BY } from '@/services/dashboards/widgets/config';
 import type { HistoryDataModel } from '@/services/dashboards/widgets/type';
 import { useWidgetFrameProps } from '@/services/dashboards/widgets/use-widget-frame-props';
@@ -127,9 +127,9 @@ const drawChart = (chartData) => {
     if (legend) legend.data.setAll(chart.series.values);
 };
 
-const initWidget = async () => {
+const initWidget = async (data?: HistoryDataModel['results']) => {
     state.loading = true;
-    state.data = await fetchData();
+    state.data = data ?? await fetchData();
     await nextTick();
     drawChart(state.data);
     state.loading = false;
@@ -154,13 +154,10 @@ useWidgetLifecycle({
     disposeWidget: disposeRoot,
 });
 
-defineExpose<{
-    initWidget:() => Promise<void>,
-    refreshWidget:() => Promise<void>
-        }>({
-            initWidget,
-            refreshWidget,
-        });
+defineExpose<WidgetExpose<HistoryDataModel['results']>>({
+    initWidget,
+    refreshWidget,
+});
 </script>
 <style lang="postcss" scoped>
 .aws-cloud-front-cost {

--- a/src/services/dashboards/widgets/budget-usage-with-forecast/BudgetUsageWithForecastWidget.vue
+++ b/src/services/dashboards/widgets/budget-usage-with-forecast/BudgetUsageWithForecastWidget.vue
@@ -32,7 +32,7 @@ import {
 import type { Field } from '@/services/dashboards/widgets/_components/type';
 import WidgetDataTable from '@/services/dashboards/widgets/_components/WidgetDataTable.vue';
 import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
-import type { WidgetProps } from '@/services/dashboards/widgets/config';
+import type { WidgetExpose, WidgetProps } from '@/services/dashboards/widgets/config';
 // import { GROUP_BY } from '@/services/dashboards/widgets/config';
 import { useWidgetFrameProps } from '@/services/dashboards/widgets/use-widget-frame-props';
 // eslint-disable-next-line import/no-cycle
@@ -86,19 +86,21 @@ const fetchData = async (): Promise<Data[]> => new Promise((resolve) => {
 
 const getPercentage = (item: Data) => item.total_spent / item.total_budget * 100;
 
-const initWidget = async () => {
+const initWidget = async (data?: Data[]) => {
     state.loading = true;
-    state.data = await fetchData();
+    state.data = data ?? await fetchData();
     state.loading = false;
+    return state.data;
 };
 
 const refreshWidget = async () => {
     state.loading = true;
     state.data = await fetchData();
     state.loading = false;
+    return state.data;
 };
 
-defineExpose({
+defineExpose<WidgetExpose<Data[]>>({
     initWidget,
     refreshWidget,
 });

--- a/src/services/dashboards/widgets/config.ts
+++ b/src/services/dashboards/widgets/config.ts
@@ -166,3 +166,8 @@ export interface WidgetProps {
     editMode?: boolean;
     allReferenceTypeInfo: AllReferenceTypeInfo;
 }
+
+export interface WidgetExpose<Data = any> {
+    initWidget: (data?: Data) => Promise<Data>;
+    refreshWidget: () => Promise<Data>;
+}

--- a/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
+++ b/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
@@ -37,7 +37,7 @@ import {
 } from '@/styles/colors';
 
 import WidgetFrame from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
-import type { WidgetProps } from '@/services/dashboards/widgets/config';
+import type { WidgetProps, WidgetExpose } from '@/services/dashboards/widgets/config';
 import { GROUP_BY } from '@/services/dashboards/widgets/config';
 import { useWidgetFrameProps } from '@/services/dashboards/widgets/use-widget-frame-props';
 import { useWidgetLifecycle } from '@/services/dashboards/widgets/use-widget-lifecycle';
@@ -76,7 +76,7 @@ const {
 } = useAmcharts5(chartContext);
 
 const state = reactive({
-    ...toRefs(useWidgetState(props)),
+    ...toRefs(useWidgetState<CostMapData>(props)),
     chartData: computed(() => {
         if (!state.data) return [];
         return state.data;
@@ -154,6 +154,7 @@ const initWidget = async () => {
     await nextTick();
     drawChart(state.data);
     state.loading = false;
+    return state.data;
 };
 
 const refreshWidget = async () => {
@@ -163,13 +164,14 @@ const refreshWidget = async () => {
     refreshRoot();
     drawChart(state.chartData);
     state.loading = false;
+    return state.data;
 };
 
 useWidgetLifecycle({
     disposeWidget: disposeRoot,
 });
 
-defineExpose({
+defineExpose<WidgetExpose<CostMapData>>({
     initWidget,
     refreshWidget,
 });

--- a/src/services/dashboards/widgets/type.ts
+++ b/src/services/dashboards/widgets/type.ts
@@ -1,3 +1,5 @@
+import type { TranslateResult } from 'vue-i18n';
+
 export interface HistoryDataModel {
     more?: boolean;
     results: Array<{
@@ -16,6 +18,6 @@ export interface XYChartData {
 
 export interface Legend {
     name: string;
-    label?: string;
+    label?: TranslateResult;
     disabled?: boolean;
 }

--- a/src/services/dashboards/widgets/use-widget-state.ts
+++ b/src/services/dashboards/widgets/use-widget-state.ts
@@ -1,3 +1,4 @@
+import type { ComputedRef } from 'vue';
 import {
     computed, reactive,
 } from 'vue';
@@ -5,6 +6,7 @@ import {
 import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
 import { merge } from 'lodash';
 
+import type { Currency } from '@/store/modules/display/config';
 import { CURRENCY } from '@/store/modules/display/config';
 
 import {
@@ -56,10 +58,24 @@ const getColorSet = (theme: WidgetTheme, colorSetType: WidgetColorSetType = 'bas
     return colorSet;
 };
 
+export interface WidgetState<Data = any> {
+    widgetConfig: ComputedRef<WidgetConfig>;
+    title: ComputedRef<string>;
+    options: ComputedRef<WidgetOptions>;
+    currency: ComputedRef<Currency>;
+    disableFullSize: ComputedRef<boolean>;
+    size: ComputedRef<WidgetSize>;
+    loading: boolean;
+    settings: ComputedRef<DashboardSettings>;
+    data: undefined|Data;
+    colorSet: ComputedRef<string[]>;
+    selectorItems: ComputedRef<MenuItem[]>;
+    selectedSelectorType: undefined;
+}
 export function useWidgetState<Data = any>(
     props: WidgetProps,
 ) {
-    const state = reactive({
+    const state = reactive<WidgetState<Data>>({
         widgetConfig: computed<WidgetConfig>(() => getWidgetConfig(props.widgetConfigId)),
         title: computed<string>(() => props.title ?? state.widgetConfig.title),
         options: computed<WidgetOptions>(() => getRefinedOptions(


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- Upgrade vue version
- Update initWidget() type
- Add WidgetExpose type for defineExpose generic type
- Add data types to all widgets

#### Important Features
- Add widgetDataMap state to dashboard-detail-info store 
- Update DashboardWidgetContainer to use dashboard-detail-info store
- Update DashboardWidgetContainer to give data parameter when calling initWidget() of each widget from widgetDataMap store state
- Add reusePreviousData prop to DashboardWidgetContainer to decide whether to reuse previous data if exists.



### Things to Talk About
