### PR TITLE
fix(dashboard): put projectId to store

### DIFF
--- a/src/services/dashboards/config.ts
+++ b/src/services/dashboards/config.ts
@@ -20,14 +20,14 @@ export const refreshIntervalOptionList = Object.keys(REFRESH_INTERVAL_OPTIONS_MA
 export const DASHBOARD_SCOPE = {
     DOMAIN: 'domain',
     PROJECT: 'project',
-};
-export type DashboardScope = keyof typeof DASHBOARD_SCOPE;
+} as const;
+export type DashboardScope = typeof DASHBOARD_SCOPE[keyof typeof DASHBOARD_SCOPE];
 
 export const DASHBOARD_VIEWER = {
     PUBLIC: 'PUBLIC',
     PRIVATE: 'PRIVATE',
-};
-export type DashboardViewer = keyof typeof DASHBOARD_VIEWER;
+} as const;
+export type DashboardViewer = typeof DASHBOARD_VIEWER[keyof typeof DASHBOARD_VIEWER];
 
 
 export const GRANULARITY = {

--- a/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -53,6 +53,7 @@ import type { DashboardModel } from '@/services/dashboards/model';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 import type { ProjectItemResp } from '@/services/project/type';
 
+
 export default {
     name: 'CreateDashboardPage',
     components: {
@@ -86,11 +87,25 @@ export default {
 
         const state = reactive({
             dashboardScope: DASHBOARD_SCOPE.DOMAIN as DashboardScope,
-            dashboardViewerType: DASHBOARD_VIEWER.PUBLIC as DashboardViewer,
+            dashboardViewerType: DASHBOARD_VIEWER.PRIVATE as DashboardViewer,
         });
 
         const handleClickCreate = () => {
-            dashboardDetailStore.setDashboardInfo(dashboardTemplate.value);
+            let _dashboardTemplate;
+            if (state.dashboardScope === DASHBOARD_SCOPE.PROJECT) {
+                _dashboardTemplate = {
+                    ...dashboardTemplate.value,
+                    viewers: state.dashboardViewerType,
+                    project_id: dashboardProject.value?.id ?? '',
+                };
+            } else {
+                _dashboardTemplate = {
+                    ...dashboardTemplate.value,
+                    viewers: state.dashboardViewerType,
+                };
+            }
+
+            dashboardDetailStore.setDashboardInfo(_dashboardTemplate);
             SpaceRouter.router.push({ name: DASHBOARDS_ROUTE.CUSTOMIZE._NAME, params: { dashboardScope: state.dashboardScope } });
         };
 

--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -6,7 +6,7 @@
         />
         <div class="filters-box">
             <dashboard-labels editable
-                              :label-list="dashboardDetailState.labelList"
+                              :label-list="dashboardDetailState.labels"
                               @update:labelList="handleUpdateLabelList"
             />
             <dashboard-toolset :date-range.sync="dashboardDetailState.settings.date_range"
@@ -112,6 +112,19 @@ const dashboardDetailState = dashboardDetailStore.state;
 
 const state = reactive({
     refreshInterval: undefined,
+    apiParam: computed<Partial<DashboardConfig>>(() => ({
+        name: dashboardDetailState.dashboardName,
+        labels: dashboardDetailState.labels,
+        settings: dashboardDetailState.settings,
+        layouts: [dashboardDetailState.dashboardWidgetInfoList.map((widget) => {
+            const result: Partial<DashboardContainerWidgetInfo> = { ...widget };
+            delete result.widgetKey;
+            return result as DashboardLayoutWidgetInfo;
+        })],
+        // TODO: add other params
+        // variables:
+        // variables_schema:
+    })),
 });
 const vm = getCurrentInstance()?.proxy as Vue;
 const variableState = reactive({
@@ -208,12 +221,12 @@ const updateDashboardData = async () => {
         if (dashboardDetailState.isProjectDashboard) {
             await SpaceConnector.clientV2.dashboard.projectDashboard.update({
                 project_dashboard_id: props.dashboardId,
-                ...param,
+                ...state.apiParam,
             });
         } else {
             await SpaceConnector.clientV2.dashboard.domainDashboard.update({
                 domain_dashboard_id: props.dashboardId,
-                ...param,
+                ...state.apiParam,
             });
         }
         await SpaceRouter.router.push({
@@ -228,16 +241,38 @@ const updateDashboardData = async () => {
         ErrorHandler.handleRequestError(e, i18n.t('DASHBOARDS.CUSTOMIZE.ALT_E_UPDATE_DASHBOARD'));
     }
 };
+const createDashboard = async () => {
+    try {
+        let _dashboardId = '';
+        if (dashboardDetailState.isProjectDashboard) {
+            const result = await SpaceConnector.clientV2.dashboard.projectDashboard.create(state.apiParam);
+            _dashboardId = result.project.project_dashboard_id;
+        } else {
+            const result = await SpaceConnector.clientV2.dashboard.domainDashboard.create(state.apiParam);
+            _dashboardId = result.domain.domain_dashboard_id;
+        }
+        await SpaceRouter.router.push({
+            name: DASHBOARDS_ROUTE.DETAIL._NAME,
+            params: {
+                dashboardId: _dashboardId,
+                dashboardScope: dashboardDetailState.isProjectDashboard ? DASHBOARD_SCOPE.PROJECT : DASHBOARD_SCOPE.DOMAIN,
+            },
+        });
+    } catch (e) {
+        ErrorHandler.handleRequestError(e, i18n.t('DASHBOARDS.CUSTOMIZE.ALT_E_UPDATE_DASHBOARD'));
+    }
+};
 
 /* Event */
 const handleUpdateDashboardName = (name: string) => {
     dashboardDetailState.dashboardName = name;
 };
-const handleUpdateLabelList = (labelList: Array<string>) => {
-    dashboardDetailState.labelList = labelList;
+const handleUpdateLabelList = (labels: Array<string>) => {
+    dashboardDetailState.labels = [...labels];
 };
 const handleSave = async () => {
-    await updateDashboardData();
+    if (dashboardDetailState.dashboardId) await updateDashboardData();
+    if (dashboardDetailState.dashboardId === undefined) await createDashboard();
 };
 const handleChangeVariable = (variables: DashboardVariablesSchema['properties'], order?: string[]) => {
     variableState.variableProperties = variables;

--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -121,9 +121,11 @@ const state = reactive({
             delete result.widgetKey;
             return result as DashboardLayoutWidgetInfo;
         })],
-        // TODO: add other params
-        // variables:
-        // variables_schema:
+        variables: variableState.variableData,
+        variables_schema: {
+            properties: variableState.variableProperties,
+            order: variableState.order,
+        },
     })),
 });
 const vm = getCurrentInstance()?.proxy as Vue;
@@ -203,21 +205,6 @@ const getDashboardData = async () => {
 };
 const updateDashboardData = async () => {
     try {
-        const param: Partial<DashboardConfig> = {
-            name: dashboardDetailState.dashboardName,
-            labels: dashboardDetailState.labelList,
-            settings: dashboardDetailState.settings,
-            layouts: [dashboardDetailState.dashboardWidgetInfoList.map((widget) => {
-                const result: Partial<DashboardContainerWidgetInfo> = { ...widget };
-                delete result.widgetKey;
-                return result as DashboardLayoutWidgetInfo;
-            })],
-            variables: variableState.variableData,
-            variables_schema: {
-                properties: variableState.variableProperties,
-                order: variableState.order,
-            },
-        };
         if (dashboardDetailState.isProjectDashboard) {
             await SpaceConnector.clientV2.dashboard.projectDashboard.update({
                 project_dashboard_id: props.dashboardId,
@@ -232,8 +219,7 @@ const updateDashboardData = async () => {
         await SpaceRouter.router.push({
             name: DASHBOARDS_ROUTE.DETAIL._NAME,
             params: {
-                // FIXME:: change dashboardId when creating dashboard
-                dashboardId: props?.dashboardId ?? '',
+                dashboardId: props.dashboardId as string,
                 dashboardScope: dashboardDetailState.isProjectDashboard ? DASHBOARD_SCOPE.PROJECT : DASHBOARD_SCOPE.DOMAIN,
             },
         });

--- a/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
@@ -58,7 +58,10 @@ const handleClickTitle = () => {
 };
 const handleInput = (e: InputEvent | string, type: 'INPUT' | 'TEXT_INPUT') => {
     if (type === 'INPUT') state.nameInput = ((e as InputEvent).target as HTMLInputElement).value;
-    if (type === 'TEXT_INPUT') state.nameInput = (e as string);
+    if (type === 'TEXT_INPUT') {
+        state.nameInput = (e as string);
+        state.name = state.nameInput;
+    }
 };
 const handleEscape = () => {
     state.editMode = false;
@@ -83,6 +86,6 @@ const handleEnter = () => {
     text-decoration: underline;
 }
 .p-text-input {
-    width: 80%;
+    width: calc(100% - 2.25rem);
 }
 </style>

--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -38,7 +38,7 @@
             </template>
         </p-page-title>
         <div class="filter-box">
-            <dashboard-labels :label-list="dashboardDetailState.labelList" />
+            <dashboard-labels :label-list="dashboardDetailState.labels" />
             <dashboard-toolset :enable-currency="dashboardDetailState.enableCurrency"
                                :currency.sync="dashboardDetailState.currency"
                                :enable-date-range="dashboardDetailState.enableDateRange"

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, UnwrapRef } from 'vue';
 import {
     computed, reactive,
 } from 'vue';
@@ -11,7 +11,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
 
-
 import { store } from '@/store';
 
 import type { Currency } from '@/store/modules/display/config';
@@ -22,7 +21,7 @@ import type {
 } from '@/services/dashboards/config';
 import { DASHBOARD_VIEWER } from '@/services/dashboards/config';
 import type { DashboardContainerWidgetInfo } from '@/services/dashboards/dashboard-detail/lib/type';
-import type { DashboardModel } from '@/services/dashboards/model';
+import type { DashboardModel, ProjectDashboardModel } from '@/services/dashboards/model';
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/config';
 import { getWidgetConfig } from '@/services/dashboards/widgets/widget-helper';
 
@@ -32,11 +31,11 @@ interface WidgetDataMap {
 
 interface DashboardDetailInfoStoreState {
     loadingDashboard: boolean;
-    dashboardId: string;
+    dashboardId: string | undefined;
+    projectId: string;
     isProjectDashboard: ComputedRef<boolean>;
     dashboardInfo: DashboardModel|null;
     dashboardViewer: ComputedRef<DashboardViewer>;
-    labelList: string[];
     dashboardName: string;
     enableCurrency: boolean;
     currency: Currency;
@@ -51,15 +50,19 @@ interface DashboardDetailInfoStoreState {
     loadingWidgets: boolean;
     widgetDataMap: WidgetDataMap;
 }
+
 export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', () => {
     const state = reactive<DashboardDetailInfoStoreState>({
         loadingDashboard: false,
         dashboardId: '',
-        isProjectDashboard: computed<boolean>(() => state.dashboardId?.startsWith('project')),
+        projectId: '',
+        isProjectDashboard: computed<boolean>(() => {
+            if (state.projectId) return true;
+            return !!state.dashboardId?.startsWith('project');
+        }),
         dashboardViewer: computed<DashboardViewer>(() => state.dashboardInfo?.viewers ?? DASHBOARD_VIEWER.PRIVATE),
         dashboardInfo: null,
         dashboardName: '',
-        labelList: [],
         enableCurrency: false,
         currency: CURRENCY.USD,
         enableDateRange: false,
@@ -85,7 +88,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         dashboardWidgetInfoList: [],
         loadingWidgets: false,
         widgetDataMap: {},
-    });
+    }) as UnwrapRef<DashboardDetailInfoStoreState>;
 
     const resetDashboardSettings = () => {
         state.dateRange = {
@@ -108,7 +111,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
     const resetDashboardData = () => {
         state.dashboardInfo = null;
         state.dashboardName = '';
-        state.labelList = [];
+        state.projectId = '';
         state.enableCurrency = false;
         state.currency = CURRENCY.USD;
         state.enableDateRange = false;
@@ -136,6 +139,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
     const setDashboardInfo = (dashboardInfo: DashboardModel) => {
         state.dashboardInfo = dashboardInfo;
         state.dashboardName = dashboardInfo.name;
+        state.projectId = (dashboardInfo as ProjectDashboardModel).project_id ?? '';
 
         state.enableCurrency = dashboardInfo.settings?.currency?.enabled ?? false;
         state.currency = dashboardInfo.settings.currency?.value ?? CURRENCY.USD;
@@ -230,3 +234,4 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         updateWidgetInfo,
     };
 });
+

--- a/src/services/dashboards/model.ts
+++ b/src/services/dashboards/model.ts
@@ -14,8 +14,8 @@ export interface DomainDashboardModel extends DashboardConfig {
 
 export interface ProjectDashboardModel extends DashboardConfig {
     project_dashboard_id: string;
-    viewers: DashboardViewer;
     project_id: string;
+    viewers: DashboardViewer;
     tags: Tags;
     user_id: string;
     domain_id: string;
@@ -24,6 +24,3 @@ export interface ProjectDashboardModel extends DashboardConfig {
 }
 
 export type DashboardModel = DomainDashboardModel | ProjectDashboardModel;
-
-
-


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

I need `project_id` for `dashboardScope`.
Because when creating dashboard through customize-page, there is no way to know `dashboardScope`.

`create()` api is not tested yet.

### Things to Talk About

Sorry for unkind mixed codes..