### PR TITLE
feat(variable-more-dropdown): refactor more-dropdown

### DIFF
--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -22,10 +22,7 @@
                                                 :property-name="propertyName"
                     />
                 </template>
-                <variable-more-button-dropdown :variables="variableState.variableProperties"
-                                               :variable-order="variableState.order"
-                                               @change="handleChangeVariable"
-                />
+                <variable-more-button-dropdown />
                 <button class="reset-button"
                         @click="handleResetVariables"
                 >
@@ -223,6 +220,7 @@ const handleChangeVariable = (variables: DashboardVariablesSchema['properties'],
 };
 
 const resetVariablesSchema = () => {
+    // TODO: refactor after store is changed
     const originProperties = variableState.originVariablesSchema.properties;
     // variableState.order is current variable properties' name list
     // result of reset should reflect updated variables schema.
@@ -233,6 +231,7 @@ const resetVariablesSchema = () => {
 };
 
 const resetVariables = () => {
+    // TODO: refactor after store is changed
     const originProperties = variableState.originVariablesSchema.properties;
     const originOrder = variableState.originVariablesSchema.order;
     const originVariables = variableState.originVariables;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- Refactor more-dropdown, now more-dropdown accesses store directly without using props from customize page.
- Variable's use change has to be reflected after dropdown is closed, so changed selected items are temporarily saved in `selectedForUpdate`. 