### PR TITLE
fix: add 'p-data-loader' skeleton to widgets

### DIFF
--- a/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
@@ -8,6 +8,7 @@
                            :loading="state.loading"
                            :data="state.data"
                            loader-type="skeleton"
+                           :loader-backdrop-opacity="1"
                            show-data-from-scratch
             >
                 <div ref="chartContext"

--- a/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
@@ -16,6 +16,7 @@
                            :loading="state.loading"
                            :data="state.chartData"
                            loader-type="skeleton"
+                           :loader-backdrop-opacity="1"
                            show-data-from-scratch
             >
                 <div ref="chartContext"

--- a/src/services/dashboards/widgets/_components/WidgetDataTable.vue
+++ b/src/services/dashboards/widgets/_components/WidgetDataTable.vue
@@ -3,6 +3,7 @@
         <p-data-loader class="table-container"
                        :loading="props.loading"
                        :data="props.items"
+                       :loader-backdrop-opacity="1"
                        show-data-from-scratch
                        disable-empty-case
         >

--- a/src/services/dashboards/widgets/aws-cloud-front-cost/AWSCloudFrontCost.vue
+++ b/src/services/dashboards/widgets/aws-cloud-front-cost/AWSCloudFrontCost.vue
@@ -16,6 +16,7 @@
                            :loading="state.loading"
                            :data="state.data"
                            loader-type="skeleton"
+                           :loader-backdrop-opacity="1"
                            show-data-from-scratch
             >
                 <div ref="chartContext"

--- a/src/services/dashboards/widgets/aws-data-transfer-by-region/AWSDataTransferByRegion.vue
+++ b/src/services/dashboards/widgets/aws-data-transfer-by-region/AWSDataTransferByRegion.vue
@@ -14,6 +14,7 @@
                            :loading="state.loading"
                            :data="state.data"
                            loader-type="skeleton"
+                           :loader-backdrop-opacity="1"
                            show-data-from-scratch
             >
                 <div ref="chartContext"

--- a/src/services/dashboards/widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrend.vue
+++ b/src/services/dashboards/widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrend.vue
@@ -16,6 +16,7 @@
                            :loading="state.loading"
                            :data="state.chartData"
                            loader-type="skeleton"
+                           :loader-backdrop-opacity="1"
                            show-data-from-scratch
             >
                 <div ref="chartContext"

--- a/src/services/dashboards/widgets/budget-status/BudgetStatus.vue
+++ b/src/services/dashboards/widgets/budget-status/BudgetStatus.vue
@@ -5,6 +5,7 @@
     >
         <p-data-loader :loading="state.loading"
                        class="chart-wrapper"
+                       :loader-backdrop-opacity="1"
         >
             <template #loader>
                 <p-skeleton height="100%" />

--- a/src/services/dashboards/widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
+++ b/src/services/dashboards/widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
@@ -4,7 +4,12 @@
                   no-height-limit
                   @refresh="handleRefresh"
     >
-        <div class="budget-usage-summary">
+        <p-data-loader class="budget-usage-summary"
+                       :loading="state.loading"
+                       :data="state.data"
+                       :loader-backdrop-opacity="1"
+                       loader-type="skeleton"
+        >
             <div class="budget">
                 <p class="budget-label">
                     {{ $t('DASHBOARDS.WIDGET.BUDGET_USAGE_SUMMARY.TOTAL_SPENT') }}
@@ -28,20 +33,31 @@
                 </div>
             </div>
             <div class="chart-wrapper">
-                <p-data-loader class="chart-loader"
-                               :loading="state.loading"
-                               :data="state.data"
-                               loader-type="skeleton"
-                               show-data-from-scratch
+                <div ref="chartContext"
+                     class="chart"
                 >
-                    <div ref="chartContext"
-                         class="chart"
-                    >
-                        <span class="budget-usage">{{ state.spentBudgetRate }}%</span>
-                    </div>
-                </p-data-loader>
+                    <span class="budget-usage">{{ state.spentBudgetRate }}%</span>
+                </div>
             </div>
-        </div>
+
+            <template #loader>
+                <div v-for="(_, idx) in state.skeletons"
+                     :key="`skeleton-${idx}`"
+                     class="skeleton-wrapper mt-4"
+                >
+                    <p-skeleton width="10rem"
+                                height="1.875rem"
+                                class="mb-1"
+                    />
+                    <p-skeleton width="7.5rem"
+                                height="1.5rem"
+                    />
+                </div>
+                <p-skeleton width="9rem"
+                            height="100%"
+                />
+            </template>
+        </p-data-loader>
     </widget-frame>
 </template>
 
@@ -53,7 +69,7 @@ import {
 } from 'vue';
 
 import { color } from '@amcharts/amcharts5';
-import { PDataLoader } from '@spaceone/design-system';
+import { PDataLoader, PSkeleton } from '@spaceone/design-system';
 import dayjs from 'dayjs';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
@@ -100,6 +116,7 @@ const {
 } = useAmcharts5(chartContext);
 const state = reactive({
     ...toRefs(useWidgetState<Data[]>(props)),
+    skeletons: [1, 2],
     chart: null as null|ReturnType<typeof createPieChart>,
     series: null as null|ReturnType<typeof createPieSeries>,
     chartData: computed(() => {
@@ -269,11 +286,11 @@ defineExpose<WidgetExpose<Data[]>>({
         }
     }
     .budget-usage {
-        @apply absolute;
+        @apply inline-block absolute;
         left: 50%;
         top: 50%;
-        z-index: 10;
         transform: translate3d(-50%, -50%, 0);
+        max-width: 65%;
     }
 }
 .chart-wrapper {
@@ -283,9 +300,6 @@ defineExpose<WidgetExpose<Data[]>>({
     .chart {
         height: 100%;
     }
-}
-.chart-loader {
-    height: 100%;
 }
 .full {
     @screen desktop {
@@ -298,6 +312,18 @@ defineExpose<WidgetExpose<Data[]>>({
         .budget-usage-summary {
             @apply block;
             height: 23.625rem;
+        }
+    }
+}
+:deep(.data-loader-container) {
+    > .loader-wrapper > .loader {
+        @apply flex-col items-start justify-start;
+    }
+    .skeleton-wrapper {
+        @apply flex flex-col;
+        &:last-of-type {
+            margin-top: 3.8125rem;
+            margin-bottom: 1.875rem;
         }
     }
 }

--- a/src/services/dashboards/widgets/cost-by-region/CostByRegion.vue
+++ b/src/services/dashboards/widgets/cost-by-region/CostByRegion.vue
@@ -7,6 +7,7 @@
             <p-data-loader class="chart-loader"
                            :loading="state.loading"
                            :data="state.chartData"
+                           :loader-backdrop-opacity="1"
                            loader-type="skeleton"
                            show-data-from-scratch
             >

--- a/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
+++ b/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
@@ -8,6 +8,7 @@
                 <p-data-loader class="chart-loader"
                                :loading="state.loading"
                                :data="state.data"
+                               :loader-backdrop-opacity="1"
                                loader-type="skeleton"
                 >
                     <div ref="chartContext"

--- a/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
+++ b/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
@@ -2,7 +2,12 @@
     <widget-frame v-bind="widgetFrameProps"
                   @refresh="handleRefresh"
     >
-        <div class="monthly-cost">
+        <p-data-loader class="monthly-cost"
+                       :loading="state.loading"
+                       :data="state.data"
+                       :loader-backdrop-opacity="1"
+                       loader-type="skeleton"
+        >
             <div class="cost">
                 <p class="cost-label">
                     {{ $t('DASHBOARDS.WIDGET.MONTHLY_COST.CURRENT_MONTH') }}
@@ -40,17 +45,28 @@
                 </div>
             </div>
             <div class="chart-wrapper">
-                <p-data-loader class="chart-loader"
-                               :loading="state.loading"
-                               :data="state.data"
-                               loader-type="skeleton"
-                >
-                    <div ref="chartContext"
-                         class="chart"
-                    />
-                </p-data-loader>
+                <div ref="chartContext"
+                     class="chart"
+                />
             </div>
-        </div>
+            <template #loader>
+                <div v-for="(_, idx) in state.skeletons"
+                     :key="`skeleton-${idx}`"
+                     class="skeleton-wrapper mt-4"
+                >
+                    <p-skeleton width="10rem"
+                                height="1.875rem"
+                                class="mb-1"
+                    />
+                    <p-skeleton width="7.5rem"
+                                height="1.5rem"
+                    />
+                </div>
+                <p-skeleton width="100%"
+                            height="100%"
+                />
+            </template>
+        </p-data-loader>
     </widget-frame>
 </template>
 
@@ -61,7 +77,7 @@ import {
 } from 'vue';
 
 import {
-    PDivider, PDataLoader, PBadge, PI,
+    PDivider, PDataLoader, PBadge, PI, PSkeleton,
 } from '@spaceone/design-system';
 import dayjs from 'dayjs';
 
@@ -97,6 +113,7 @@ const props = defineProps<WidgetProps>();
 type Data = CostAnalyzeDataModel['results'];
 const state = reactive({
     ...toRefs(useWidgetState<Data>(props)),
+    skeletons: [1, 2],
     chartData: computed(() => getRefinedXYChartData(state.data)),
     dateRange: computed<DateRange>(() => {
         const end = dayjs.utc(state.settings?.date_range?.end).format(DATE_FORMAT);
@@ -264,11 +281,20 @@ defineExpose<WidgetExpose<Data>>({
         height: 6.25rem;
         margin-top: 1.5rem;
         width: 100%;
-        .chart-loader {
+        .chart {
             height: 100%;
-            .chart {
-                height: 100%;
-            }
+        }
+    }
+}
+:deep(.data-loader-container) {
+    > .loader-wrapper > .loader {
+        @apply flex-col items-start justify-start;
+    }
+    .skeleton-wrapper {
+        @apply flex flex-col;
+        &:last-of-type {
+            margin-top: 3.8125rem;
+            margin-bottom: 1.875rem;
         }
     }
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [X] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [X] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
* add 'p-data-loader' skeleton to widgets
* add 'loader-backdrop-opacity=1' to all widgets

### Things to Talk About
