### PR TITLE
feat(dashboard): add `revertDashboardStore`

### DIFF
--- a/src/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue
+++ b/src/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue
@@ -48,7 +48,7 @@ import { store } from '@/store';
 import { i18n } from '@/translations';
 
 import type { Currency } from '@/store/modules/display/config';
-import { CURRENCY_SYMBOL } from '@/store/modules/display/config';
+import { CURRENCY, CURRENCY_SYMBOL } from '@/store/modules/display/config';
 
 export default {
     name: 'CurrencySelectDropdown',
@@ -61,10 +61,6 @@ export default {
             type: Boolean,
             default: false,
         },
-        defaultCurrency: {
-            type: String as PropType<Currency>,
-            default: undefined,
-        },
         currency: {
             type: String as PropType<Currency>,
             default: undefined,
@@ -72,14 +68,15 @@ export default {
     },
     setup(props, { emit }) {
         const state = reactive({
-            currency: props.currency || props.defaultCurrency || computed(() => store.state.display.currency),
+            currency: computed(() => props.currency || store.state.display.currency),
             currencyItems: computed<MenuItem[]>(() => Object.keys(store.state.display.currencyRates).map((currency) => ({
                 type: 'item',
                 name: currency,
                 label: `${CURRENCY_SYMBOL[currency]}${currency}`,
-                badge: currency === props.defaultCurrency ? i18n.t('DASHBOARDS.DETAIL.DEFAULT') : '',
+                badge: currency === DEFAULT_CURRENCY ? i18n.t('DASHBOARDS.DETAIL.DEFAULT') : '',
             }))),
         });
+        const DEFAULT_CURRENCY = CURRENCY.USD;
 
         const handleSelectCurrency = (currency: Currency) => {
             store.commit('display/setCurrency', currency);

--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -71,6 +71,7 @@
 
 <script setup lang="ts">
 import {
+    onUnmounted,
     reactive, ref, watch,
 } from 'vue';
 
@@ -112,7 +113,6 @@ const dashboardDetailState = dashboardDetailStore.state;
 
 const state = reactive({
     hasManagePermission: useManagePermissionState(),
-    //
     nameEditModalVisible: false,
     deleteModalVisible: false,
     cloneModalVisible: false,
@@ -163,7 +163,9 @@ watch(() => props.dashboardId, (_dashboardId) => {
     getDashboardData(_dashboardId);
 }, { immediate: true });
 
-
+onUnmounted(() => {
+    dashboardDetailStore.revertDashboardData();
+});
 </script>
 
 <style lang="postcss" scoped>

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -125,6 +125,10 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         state.labels = [];
     };
 
+    const revertDashboardData = () => {
+        setDashboardInfo(originState.dashboardInfo);
+    };
+
     const setDashboardInfo = (dashboardInfo: DashboardModel) => {
         originState.dashboardInfo = dashboardInfo;
 
@@ -237,6 +241,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         state,
         originState,
         validationState,
+        revertDashboardData,
         getDashboardInfo,
         setDashboardInfo,
         toggleWidgetSize,

--- a/src/services/dashboards/modules/dashboard-toolset/DashboardToolset.vue
+++ b/src/services/dashboards/modules/dashboard-toolset/DashboardToolset.vue
@@ -8,7 +8,6 @@
                                  @update:date-range="handleUpdateDateRange"
         />
         <currency-select-dropdown v-show="props.currency.enabled"
-                                  :default-currency="DEFAULT_CURRENCY"
                                   :currency="state.proxyCurrency.value"
                                   @update:currency="handleUpdateCurrency"
         />
@@ -18,8 +17,6 @@
 <script setup lang="ts">
 import { reactive } from 'vue';
 
-import { CURRENCY } from '@/store/modules/display/config';
-
 import { useProxyValue } from '@/common/composables/proxy-state';
 import CurrencySelectDropdown from '@/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue';
 
@@ -27,7 +24,6 @@ import type { DashboardSettings } from '@/services/dashboards/config';
 import DashboardDateDropdown from '@/services/dashboards/modules/dashboard-toolset/DashboardDateDropdown.vue';
 import DashboardDateRangeBadge from '@/services/dashboards/modules/dashboard-toolset/DashboardDateRangeBadge.vue';
 
-const DEFAULT_CURRENCY = CURRENCY.USD;
 
 const props = defineProps<{
     dateRange: DashboardSettings['date_range'];


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

At dashboard-detail-page, user can set currency / date-range / variables.
But those have volatility on dashboard-detail-page. 
(When leaving the page, such as going to customize page, should revert dashboard original data) 

### Things to Talk About
