### PR TITLE
fix(widget-helper): add `getWidgetInheritOptionsErrorMap()`

### DIFF
--- a/src/services/dashboards/dashboard-customize/modules/DashboardAddDefaultWidgetRightArea.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardAddDefaultWidgetRightArea.vue
@@ -341,8 +341,8 @@ export default defineComponent<Props>({
                 }
             });
             Object.entries(_inheritOptions).forEach(([optionKey, optionValue]) => {
-                _formData[`filters.${optionKey}`] = optionValue?.variable_info?.key;
-                _inheritItemMap[`filters.${optionKey}`] = optionValue?.enabled;
+                _formData[optionKey] = optionValue?.variable_info?.key;
+                _inheritItemMap[optionKey] = optionValue?.enabled;
             });
             return { schemaFormData: _formData, inheritItemMap: _inheritItemMap };
         };

--- a/src/services/dashboards/dashboard-customize/stores/widget-form.ts
+++ b/src/services/dashboards/dashboard-customize/stores/widget-form.ts
@@ -48,7 +48,7 @@ export const useWidgetFormStore = defineStore('widget-form', () => {
             const _propertyName = key.replace('filters.', '');
             if (inheritItemMap[key]) {
                 if (!val) return;
-                inheritOptions[_propertyName] = {
+                inheritOptions[key] = {
                     enabled: true,
                     variable_info: {
                         key: val as string,
@@ -62,7 +62,7 @@ export const useWidgetFormStore = defineStore('widget-form', () => {
                     });
                 } else if (val) widgetFiltersMap[_propertyName].push({ k: _propertyName, v: val, o: '' });
             } else {
-                widgetOptions[_propertyName] = val;
+                widgetOptions[key] = val;
             }
         });
         widgetOptions.filters = widgetFiltersMap;

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -55,8 +55,9 @@ import type { WidgetTheme } from '@/services/dashboards/widgets/_configs/view-co
 import {
     getWidgetComponent,
     getWidgetConfig,
-    getWidgetInheritOptionsErrorMap,
 } from '@/services/dashboards/widgets/_helpers/widget-helper';
+import { getWidgetInheritOptionsErrorMap } from '@/services/dashboards/widgets/_helpers/widget-validation-helper';
+
 
 interface Props {
     editMode?: boolean;

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -55,7 +55,7 @@ import type { WidgetTheme } from '@/services/dashboards/widgets/_configs/view-co
 import {
     getWidgetComponent,
     getWidgetConfig,
-    getWidgetSchemaErrorMap,
+    getWidgetInheritOptionsErrorMap,
 } from '@/services/dashboards/widgets/_helpers/widget-helper';
 
 interface Props {
@@ -143,7 +143,7 @@ export default defineComponent<Props>({
             const _widgetValidMap: Record<string, boolean> = {};
             state.widgetInfoList.forEach((widgetInfo: DashboardLayoutWidgetInfo) => {
                 const _widgetConfig = state.widgetConfigMap[widgetInfo.widget_key];
-                const _widgetSchemaErrorMap = getWidgetSchemaErrorMap(
+                const _widgetSchemaErrorMap = getWidgetInheritOptionsErrorMap(
                     widgetInfo.inherit_options,
                     _widgetConfig.options_schema.schema,
                     dashboardDetailState.variables,

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -23,7 +23,6 @@
                        :currency-rates="currencyRates"
                        :edit-mode="editMode"
                        :all-reference-type-info="allReferenceTypeInfo"
-                       @validate="handleValidate($event, widget.widget_key)"
             />
         </template>
     </div>
@@ -36,7 +35,7 @@ import {
     defineComponent, reactive, toRefs, ref, onMounted, watch, onBeforeUnmount, computed,
 } from 'vue';
 
-import { flattenDeep } from 'lodash';
+import { flattenDeep, isEmpty } from 'lodash';
 
 import { store } from '@/store';
 
@@ -50,9 +49,14 @@ import { widgetWidthAssigner } from '@/services/dashboards/dashboard-detail/lib/
 import { useDashboardDetailInfoStore } from '@/services/dashboards/dashboard-detail/store/dashboard-detail-info';
 import type {
     WidgetSize, WidgetConfig, WidgetExpose, WidgetProps,
+    DashboardLayoutWidgetInfo,
 } from '@/services/dashboards/widgets/_configs/config';
 import type { WidgetTheme } from '@/services/dashboards/widgets/_configs/view-config';
-import { getWidgetComponent, getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
+import {
+    getWidgetComponent,
+    getWidgetConfig,
+    getWidgetSchemaErrorMap,
+} from '@/services/dashboards/widgets/_helpers/widget-helper';
 
 interface Props {
     editMode?: boolean;
@@ -77,16 +81,24 @@ export default defineComponent<Props>({
     setup(props, { expose }: SetupContext) {
         const dashboardDetailStore = useDashboardDetailInfoStore();
         const dashboardDetailState = dashboardDetailStore.state;
+        const dashboardDetailValidationState = dashboardDetailStore.validationState;
 
         const state = reactive({
             dashboardId: computed(() => dashboardDetailState.dashboardId),
-            widgetInfoList: computed(() => dashboardDetailState.dashboardWidgetInfoList),
+            widgetInfoList: computed<DashboardLayoutWidgetInfo[]>(() => dashboardDetailState.dashboardWidgetInfoList),
             dashboardVariables: computed(() => dashboardDetailState.variables),
             dashboardVariablesSchema: computed(() => dashboardDetailState.variablesSchema),
             dashboardSettings: computed(() => dashboardDetailState.settings),
             widgetDataMap: computed({
                 get() { return dashboardDetailState.widgetDataMap; },
                 set(val) { dashboardDetailState.widgetDataMap = val; },
+            }),
+            widgetConfigMap: computed<Record<string, WidgetConfig>>(() => {
+                const _configMap: Record<string, WidgetConfig> = {};
+                state.widgetInfoList.forEach((d) => {
+                    _configMap[d.widget_key] = getWidgetConfig(d.widget_name);
+                });
+                return _configMap;
             }),
             // width
             containerWidth: WIDGET_CONTAINER_MIN_WIDTH,
@@ -95,9 +107,8 @@ export default defineComponent<Props>({
             // theme
             widgetThemeList: computed<Array<WidgetTheme | undefined>>(() => {
                 const widgetThemeOptions: Array<WidgetConfig['theme']> = [];
-                state.widgetInfoList.forEach((widget) => {
-                    const widgetConfig = getWidgetConfig(widget.widget_name);
-                    widgetThemeOptions.push(widgetConfig.theme);
+                state.widgetInfoList.forEach((widgetInfo) => {
+                    widgetThemeOptions.push(state.widgetConfigMap[widgetInfo.widget_key].theme);
                 });
                 return widgetThemeAssigner(widgetThemeOptions);
             }),
@@ -128,6 +139,21 @@ export default defineComponent<Props>({
             }
         };
 
+        const validateAllWidget = () => {
+            const _widgetValidMap: Record<string, boolean> = {};
+            state.widgetInfoList.forEach((widgetInfo: DashboardLayoutWidgetInfo) => {
+                const _widgetConfig = state.widgetConfigMap[widgetInfo.widget_key];
+                const _widgetSchemaErrorMap = getWidgetSchemaErrorMap(
+                    widgetInfo.inherit_options,
+                    _widgetConfig.options_schema.schema,
+                    dashboardDetailState.variables,
+                    dashboardDetailState.variablesSchema,
+                );
+                _widgetValidMap[widgetInfo.widget_key] = isEmpty(_widgetSchemaErrorMap);
+            });
+            dashboardDetailValidationState.widgetValidMap = _widgetValidMap;
+        };
+
         let timer: undefined|number;
         const handleResizeObserve = () => {
             // timeouts for throttle
@@ -137,9 +163,6 @@ export default defineComponent<Props>({
                 state.containerWidth = refineContainerWidth(containerRef.value?.clientWidth);
                 // for less throttle, change below timeout ms
             }, 500);
-        };
-        const handleValidate = (isValid: boolean, widgetKey: string) => {
-            dashboardDetailStore.updateWidgetValidation(isValid, widgetKey);
         };
 
         const observeInstance = new ResizeObserver(handleResizeObserve);
@@ -161,6 +184,9 @@ export default defineComponent<Props>({
             });
             state.initiatedWidgetMap = initiatedWidgetMap;
         }, { immediate: true, deep: true });
+        watch(() => state.dashboardVariablesSchema, () => {
+            if (props.editMode) validateAllWidget();
+        }, { immediate: true });
 
 
         const refreshAllWidget = async () => {
@@ -196,7 +222,6 @@ export default defineComponent<Props>({
             ...toRefs(state),
             getWidgetComponent,
             handleIntersectionObserver,
-            handleValidate,
         };
     },
 });

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -115,6 +115,9 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         state.variables = {};
         state.variablesSchema = { properties: {}, order: [] };
         state.labels = [];
+        //
+        validationState.isNameValid = undefined;
+        validationState.widgetValidMap = {};
     };
 
     const revertDashboardData = () => {

--- a/src/services/dashboards/widgets/_helpers/widget-helper.ts
+++ b/src/services/dashboards/widgets/_helpers/widget-helper.ts
@@ -83,7 +83,7 @@ export const getWidgetComponent = (widgetConfigId: string): AsyncComponent => {
     return widgetComponent;
 };
 
-export const getWidgetSchemaErrorMap = (
+export const getWidgetInheritOptionsErrorMap = (
     inheritOptions?: InheritOptions,
     widgetOptionsSchema?: WidgetOptionsSchema['schema'],
     dashboardVariables?: DashboardVariables,

--- a/src/services/dashboards/widgets/_helpers/widget-helper.ts
+++ b/src/services/dashboards/widgets/_helpers/widget-helper.ts
@@ -1,20 +1,11 @@
 import type { AsyncComponent } from 'vue';
-import type { TranslateResult } from 'vue-i18n';
 
-import { isEmpty, mergeWith } from 'lodash';
+import { mergeWith } from 'lodash';
 
-import { i18n } from '@/translations';
-
-import type { DashboardVariables, DashboardVariablesSchema } from '@/services/dashboards/config';
 import type {
     BaseConfigInfo, WidgetConfig,
-    InheritOptions, WidgetOptionsSchema,
 } from '@/services/dashboards/widgets/_configs/config';
 import { BASE_WIDGET_CONFIGS, CONSOLE_WIDGET_CONFIGS } from '@/services/dashboards/widgets/_configs/widget-list-config';
-
-interface InheritOptionsErrorMap {
-    [propertyName: string]: TranslateResult;
-}
 
 const mergeCustomizer = (val1, val2) => {
     if (Array.isArray(val1)) return [...new Set(val1.concat(val2))];
@@ -81,32 +72,4 @@ export const getWidgetComponent = (widgetConfigId: string): AsyncComponent => {
     if (!widgetComponent) throw new Error(`No matching widget component found. ${widgetComponent} does not exist.`);
 
     return widgetComponent;
-};
-
-export const getWidgetInheritOptionsErrorMap = (
-    inheritOptions?: InheritOptions,
-    widgetOptionsSchema?: WidgetOptionsSchema['schema'],
-    dashboardVariables?: DashboardVariables,
-    dashboardVariablesSchema?: DashboardVariablesSchema,
-): InheritOptionsErrorMap => {
-    if (!inheritOptions || isEmpty(inheritOptions)) {
-        return {};
-    }
-    const errorMap: InheritOptionsErrorMap = {};
-    Object.entries(inheritOptions).forEach(([propertyName, inheritOption]) => {
-        if (!inheritOption?.enabled) return;
-
-        const variableKey = inheritOption?.variable_info?.key;
-        if (!variableKey || !dashboardVariablesSchema?.properties?.[variableKey] || !dashboardVariables?.[variableKey]) {
-            errorMap[propertyName] = i18n.t('This property does not exist on the dashboard variables.');
-            return;
-        }
-
-        const variableType = dashboardVariablesSchema.properties[variableKey].selection_type === 'MULTI' ? 'array' : 'string';
-        const widgetPropertyType = widgetOptionsSchema.properties[propertyName].type;
-        if (variableType !== widgetPropertyType) {
-            errorMap[propertyName] = i18n.t('This property has a different type from the dashboard variable.');
-        }
-    });
-    return errorMap;
 };

--- a/src/services/dashboards/widgets/_helpers/widget-validation-helper.ts
+++ b/src/services/dashboards/widgets/_helpers/widget-validation-helper.ts
@@ -1,0 +1,41 @@
+import type { TranslateResult } from 'vue-i18n';
+
+import { isEmpty } from 'lodash';
+
+import { i18n } from '@/translations';
+
+import type { DashboardVariables, DashboardVariablesSchema } from '@/services/dashboards/config';
+import type { InheritOptions, WidgetOptionsSchema } from '@/services/dashboards/widgets/_configs/config';
+
+
+interface InheritOptionsErrorMap {
+    [propertyName: string]: TranslateResult;
+}
+
+export const getWidgetInheritOptionsErrorMap = (
+    inheritOptions?: InheritOptions,
+    widgetOptionsSchema?: WidgetOptionsSchema['schema'],
+    dashboardVariables?: DashboardVariables,
+    dashboardVariablesSchema?: DashboardVariablesSchema,
+): InheritOptionsErrorMap => {
+    if (!inheritOptions || isEmpty(inheritOptions)) {
+        return {};
+    }
+    const errorMap: InheritOptionsErrorMap = {};
+    Object.entries(inheritOptions).forEach(([propertyName, inheritOption]) => {
+        if (!inheritOption?.enabled) return;
+
+        const variableKey = inheritOption?.variable_info?.key;
+        if (!variableKey || !dashboardVariablesSchema?.properties?.[variableKey] || !dashboardVariables?.[variableKey]) {
+            errorMap[propertyName] = i18n.t('This property does not exist on the dashboard variables.');
+            return;
+        }
+
+        const variableType = dashboardVariablesSchema.properties[variableKey].selection_type === 'MULTI' ? 'array' : 'string';
+        const widgetPropertyType = widgetOptionsSchema.properties[propertyName].type;
+        if (variableType !== widgetPropertyType) {
+            errorMap[propertyName] = i18n.t('This property has a different type from the dashboard variable.');
+        }
+    });
+    return errorMap;
+};


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
`getWidgetInheritOptionsErrorMap()` is comming!💗
With this helper, you can get **error message map** of specific widget! like...
```typescript
{
  'filters.provider': 'This property does not exist on the dashboard variables.',
  'filters.project_id': 'This property has a different type from the dashboard variable.',
}
```