### PR TITLE
fix: add `error-mode` props to widgets

### DIFF
--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -22,6 +22,7 @@
                        :theme="widgetThemeList[idx]"
                        :currency-rates="currencyRates"
                        :edit-mode="editMode"
+                       :error-mode="!dashboardDetailValidationState.widgetValidMap[widget.widget_key]"
                        :all-reference-type-info="allReferenceTypeInfo"
             />
         </template>
@@ -221,6 +222,7 @@ export default defineComponent<Props>({
         return {
             containerRef,
             ...toRefs(state),
+            dashboardDetailValidationState,
             getWidgetComponent,
             handleIntersectionObserver,
         };

--- a/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -127,7 +127,7 @@ import { useDashboardDetailInfoStore } from '@/services/dashboards/dashboard-det
 import type { WidgetSize, DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/_configs/config';
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/_configs/config';
 
-interface Props {
+export interface WidgetFrameProps {
     title: TranslateResult;
     size: WidgetSize;
     width?: number;
@@ -159,7 +159,7 @@ interface IconConfig {
 }
 const { i18nDayjs } = useI18nDayjs();
 
-const props = withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<WidgetFrameProps>(), {
     width: undefined,
     widgetLink: undefined,
     widgetLocation: undefined,

--- a/src/services/dashboards/widgets/_configs/config.ts
+++ b/src/services/dashboards/widgets/_configs/config.ts
@@ -170,6 +170,7 @@ export interface WidgetProps {
     widgetKey: string; // unique widget key to identify widgets in layout
     currencyRates?: CurrencyRates;
     editMode?: boolean;
+    errorMode?: boolean;
     allReferenceTypeInfo: AllReferenceTypeInfo;
 }
 

--- a/src/services/dashboards/widgets/_hooks/use-widget-frame-props.ts
+++ b/src/services/dashboards/widgets/_hooks/use-widget-frame-props.ts
@@ -1,31 +1,10 @@
 import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
 
-import type { Currency } from '@/store/modules/display/config';
-
-import type { WidgetConfig, WidgetSize } from '@/services/dashboards/widgets/_configs/config';
+import type { WidgetFrameProps } from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/_configs/config';
 
-interface WidgetFrameState {
-    title: string;
-    size: WidgetSize;
-    dateRange: string;
-    currency: Currency;
-    disableFullSize: boolean;
-    isOnlyFullSize: boolean;
-    widgetConfig?: WidgetConfig;
-}
-
-interface WidgetFrameProps {
-    widgetKey: string;
-    width?: number;
-    editMode?: boolean;
-    widgetConfigId?: string;
-}
-
-type WidgetFrameBaseProps = WidgetFrameState & WidgetFrameProps;
-
-export const useWidgetFrameProps = (props: any, state: any):ComputedRef => computed<WidgetFrameBaseProps>(() => ({
+export const useWidgetFrameProps = (props: any, state: any):ComputedRef => computed<Partial<WidgetFrameProps>>(() => ({
     widgetKey: props.widgetKey,
     width: props.width,
     editMode: props.editMode,
@@ -37,4 +16,5 @@ export const useWidgetFrameProps = (props: any, state: any):ComputedRef => compu
     disableFullSize: !state.widgetConfig?.sizes.includes(WIDGET_SIZE.full),
     isOnlyFullSize: state.widgetConfig?.sizes.length === 1 && state.widgetConfig?.sizes[0] === WIDGET_SIZE.full,
     widgetLocation: state.widgetLocation,
+    errorMode: props.errorMode,
 }));


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
![스크린샷 2023-01-12 오전 11 02 10](https://user-images.githubusercontent.com/18563857/211958248-37f66124-4e64-4aa8-9105-90bd39e28331.png)
