### PR TITLE
fix(dashboard-customize): edit get-data scenario

### DIFF
--- a/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -143,7 +143,6 @@ const updateDashboardData = async () => {
                 domain_dashboard_id: props.dashboardId,
             });
         }
-        await dashboardDetailStore.getDashboardInfo(props.dashboardId, true);
         await SpaceRouter.router.push({
             name: DASHBOARDS_ROUTE.DETAIL._NAME,
             params: {
@@ -173,7 +172,6 @@ const createDashboard = async () => {
             });
             dashboardDetailState.dashboardId = result.domain_dashboard_id;
         }
-        await dashboardDetailStore.getDashboardInfo(dashboardDetailState.dashboardId, true);
         await SpaceRouter.router.push({
             name: DASHBOARDS_ROUTE.DETAIL._NAME,
             params: {

--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -152,9 +152,9 @@ const queryState = reactive({
 
 const widgetContainerRef = ref<typeof DashboardWidgetContainer|null>(null);
 
-const getDashboardData = async (dashboardId: string) => {
+const getDashboardData = async (dashboardId: string, force = false) => {
     try {
-        await dashboardDetailStore.getDashboardInfo(dashboardId);
+        await dashboardDetailStore.getDashboardInfo(dashboardId, force);
     } catch (e) {
         ErrorHandler.handleError(e);
         await SpaceRouter.router.push({ name: DASHBOARDS_ROUTE.ALL._NAME });
@@ -207,7 +207,7 @@ const init = async () => {
 };
 
 (async () => {
-    await getDashboardData(props.dashboardId);
+    await getDashboardData(props.dashboardId, true);
     await init();
 })();
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- New data is not fetched from customize page In `detail-customize-save` & `create-customize-save` scenario.
- Now new data is fetched by force when entering dashboard-detail page.  
