### PR TITLE
fix(use-widget-lifecycle): refresh only widget's inherit options changed

### DIFF
--- a/src/common/composables/amcharts5/index.ts
+++ b/src/common/composables/amcharts5/index.ts
@@ -38,9 +38,11 @@ export const useAmcharts5 = (
 
     const refreshRoot = () => {
         disposeRoot();
-        const root = am5.Root.new(state.chartContext as HTMLElement);
-        state.root = root;
-        initRoot(root);
+        if (state.chartContext) {
+            const root = am5.Root.new(state.chartContext as HTMLElement);
+            state.root = root;
+            initRoot(root);
+        }
     };
 
     const initRoot = (root: Root) => {

--- a/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
@@ -193,7 +193,7 @@ const refreshWidget = async (thisPage = 1): Promise<FullData> => {
     state.legends = getPieChartLegends(state.data.results, state.groupBy);
     chartHelper.refreshRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };

--- a/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
+++ b/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
@@ -240,7 +240,7 @@ const refreshWidget = async (thisPage = 1): Promise<FullData> => {
     state.legends = getXYChartLegends(state.data.results, state.groupBy, props.allReferenceTypeInfo, state.disableReferenceColor);
     chartHelper.refreshRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };

--- a/src/services/dashboards/widgets/_hooks/use-widget-lifecycle.ts
+++ b/src/services/dashboards/widgets/_hooks/use-widget-lifecycle.ts
@@ -4,7 +4,8 @@ import {
 
 import { isEqual } from 'lodash';
 
-import type { WidgetProps } from '@/services/dashboards/widgets/_configs/config';
+import type { DashboardVariables, DashboardVariablesSchema } from '@/services/dashboards/config';
+import type { InheritOptions, WidgetProps } from '@/services/dashboards/widgets/_configs/config';
 
 
 interface UseWidgetLifecycleOptions {
@@ -12,6 +13,25 @@ interface UseWidgetLifecycleOptions {
     refreshWidget: () => void;
     props: WidgetProps;
 }
+
+const checkRefreshable = (
+    inheritOptions: InheritOptions,
+    after?: DashboardVariables|DashboardVariablesSchema,
+    before?: DashboardVariables|DashboardVariablesSchema,
+    isSchema = false,
+): boolean => {
+    let _refresh = false;
+    Object.values(inheritOptions).forEach((inheritOption) => {
+        if (_refresh) return;
+        const _variableKey = inheritOption.variable_info?.key ?? '';
+        const _after = isSchema ? after?.properties?.[_variableKey] : after?.[_variableKey];
+        const _before = isSchema ? before?.properties?.[_variableKey] : before?.[_variableKey];
+        if (!_variableKey || (!_after && !_before)) return;
+        if (!isEqual(_after, _before)) _refresh = true;
+    });
+    return _refresh;
+};
+
 export const useWidgetLifecycle = ({
     disposeWidget,
     refreshWidget,
@@ -22,18 +42,12 @@ export const useWidgetLifecycle = ({
     });
     watch(() => props.dashboardVariables, (after, before) => {
         if (!props.initiated || props.errorMode || !props.inheritOptions) return;
-        let _refresh = false;
-        Object.values(props.inheritOptions).forEach((inheritOption) => {
-            if (_refresh) return;
-            const _variableKey = inheritOption.variable_info?.key;
-            if (!_variableKey || (!after?.[_variableKey]) && !before?.[_variableKey]) return;
-            const _afterVariable = after?.[_variableKey];
-            const _beforeVariable = before?.[_variableKey];
-            if (!isEqual(_afterVariable, _beforeVariable)) _refresh = true;
-        });
-        if (_refresh) refreshWidget();
+        const _isRefreshable = checkRefreshable(props.inheritOptions, after, before);
+        if (_isRefreshable) refreshWidget();
     }, { deep: true });
-    watch(() => props.dashboardVariablesSchema, () => {
-        if (props.initiated && props.editMode && !props.errorMode) refreshWidget();
+    watch(() => props.dashboardVariablesSchema, (after, before) => {
+        if (!props.initiated || props.errorMode || !props.editMode || !props.inheritOptions) return;
+        const _isRefreshable = checkRefreshable(props.inheritOptions, after, before, true);
+        if (_isRefreshable) refreshWidget();
     }, { deep: true });
 };

--- a/src/services/dashboards/widgets/_hooks/use-widget-lifecycle.ts
+++ b/src/services/dashboards/widgets/_hooks/use-widget-lifecycle.ts
@@ -2,7 +2,10 @@ import {
     onUnmounted, watch,
 } from 'vue';
 
+import { isEqual } from 'lodash';
+
 import type { WidgetProps } from '@/services/dashboards/widgets/_configs/config';
+
 
 interface UseWidgetLifecycleOptions {
     disposeWidget?: () => void;
@@ -17,9 +20,18 @@ export const useWidgetLifecycle = ({
     onUnmounted(() => {
         if (disposeWidget) disposeWidget();
     });
-    watch(() => props.dashboardVariables, () => {
-        if (props.initiated && !props.errorMode) refreshWidget();
-        // TODO: if widget has changed inherit options
+    watch(() => props.dashboardVariables, (after, before) => {
+        if (!props.initiated || props.errorMode || !props.inheritOptions) return;
+        let _refresh = false;
+        Object.values(props.inheritOptions).forEach((inheritOption) => {
+            if (_refresh) return;
+            const _variableKey = inheritOption.variable_info?.key;
+            if (!_variableKey || (!after?.[_variableKey]) && !before?.[_variableKey]) return;
+            const _afterVariable = after?.[_variableKey];
+            const _beforeVariable = before?.[_variableKey];
+            if (!isEqual(_afterVariable, _beforeVariable)) _refresh = true;
+        });
+        if (_refresh) refreshWidget();
     }, { deep: true });
     watch(() => props.dashboardVariablesSchema, () => {
         if (props.initiated && props.editMode && !props.errorMode) refreshWidget();

--- a/src/services/dashboards/widgets/aws-cloud-front-cost/AWSCloudFrontCost.vue
+++ b/src/services/dashboards/widgets/aws-cloud-front-cost/AWSCloudFrontCost.vue
@@ -256,7 +256,7 @@ const refreshWidget = async (thisPage = 1): Promise<FullData> => {
     state.legends = getXYChartLegends(state.data.results, state.groupBy, props.allReferenceTypeInfo);
     chartHelper.refreshRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };

--- a/src/services/dashboards/widgets/aws-data-transfer-by-region/AWSDataTransferByRegion.vue
+++ b/src/services/dashboards/widgets/aws-data-transfer-by-region/AWSDataTransferByRegion.vue
@@ -250,16 +250,17 @@ const refreshWidget = async (thisPage = 1): Promise<FullData> => {
     state.legends = getPieChartLegends(state.data.results, state.groupBy);
     chartHelper.clearChildrenOfRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };
 
 /* Event */
-const handleSelectSelectorType = (selected: string) => {
+const handleSelectSelectorType = async (selected: string) => {
     state.selectedSelectorType = selected;
-    if (chartHelper.root.value) chartHelper.refreshRoot();
-    drawChart(state.chartData);
+    chartHelper.refreshRoot();
+    await nextTick();
+    if (chartHelper.root.value) drawChart(state.chartData);
 };
 const handleUpdateThisPage = (thisPage: number) => {
     state.thisPage = thisPage;

--- a/src/services/dashboards/widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrend.vue
+++ b/src/services/dashboards/widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrend.vue
@@ -249,16 +249,17 @@ const refreshWidget = async (): Promise<Data> => {
     state.legends = getXYChartLegends(state.data, state.groupBy, props.allReferenceTypeInfo);
     chartHelper.refreshRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };
 
 /* Event */
-const handleSelectSelectorType = (selected: string) => {
+const handleSelectSelectorType = async (selected: string) => {
     state.selectedSelectorType = selected;
-    if (chartHelper.root.value) chartHelper.refreshRoot();
-    drawChart(state.chartData);
+    chartHelper.refreshRoot();
+    await nextTick();
+    if (chartHelper.root.value) drawChart(state.chartData);
 };
 
 const handleRefresh = () => {

--- a/src/services/dashboards/widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
+++ b/src/services/dashboards/widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
@@ -257,7 +257,7 @@ const refreshWidget = async (): Promise<Data[]> => {
     state.data = await fetchData();
     refreshRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };

--- a/src/services/dashboards/widgets/cost-by-region/CostByRegion.vue
+++ b/src/services/dashboards/widgets/cost-by-region/CostByRegion.vue
@@ -279,7 +279,7 @@ const refreshWidget = async (thisPage = 1): Promise<FullData> => {
     state.legends = getXYChartLegends(state.data.results, GROUP_BY.PROVIDER, props.allReferenceTypeInfo);
     chartHelper.clearChildrenOfRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };

--- a/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
+++ b/src/services/dashboards/widgets/cost-map/CostMapWidget.vue
@@ -205,7 +205,7 @@ const refreshWidget = async (): Promise<TreemapChartData['children']> => {
     state.data = await fetchData();
     chartHelper.refreshRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };

--- a/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
+++ b/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
@@ -231,7 +231,7 @@ const refreshWidget = async (): Promise<Data> => {
     state.data = await fetchData();
     chartHelper.refreshRoot();
     await nextTick();
-    drawChart(state.chartData);
+    if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
     return state.data;
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
refresh widget only its' inherit option changed
**Please see first commit only!!!**

https://user-images.githubusercontent.com/18563857/212304826-a9e78524-2ddf-49e8-9154-bc93ca17bed7.mov

