### PR TITLE
fix(dashboard): label input height

### DIFF
--- a/src/services/dashboards/modules/dashboard-label/DashboardLabels.vue
+++ b/src/services/dashboards/modules/dashboard-label/DashboardLabels.vue
@@ -141,6 +141,7 @@ const handleDelete = (index: number) => {
 :deep(.p-text-input) {
     .input-container {
         min-height: 1.5rem;
+        height: 1.5rem;
     }
 }
 </style>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
![스크린샷 2023-01-13 오후 8 31 32](https://user-images.githubusercontent.com/29014433/212310719-a4f841c9-4ff7-4bb2-892a-0a130710b2e5.png)

In design, height is `1.5rem`. But I've added only `min-height: 1.5rem` 

### Things to Talk About
