### PR TITLE
fix(project-select-dropdown): bind readonly state with props

### DIFF
--- a/src/common/modules/project/ProjectSelectDropdown.vue
+++ b/src/common/modules/project/ProjectSelectDropdown.vue
@@ -9,8 +9,7 @@
                                :disabled="disabled"
                                :placeholder="$t('COMMON.PROJECT_SELECT_DROPDOWN.PLACEHOLDER')"
                                :selected.sync="selectedItems"
-                               readonly
-                               disable-delete-all
+                               :readonly="readonly"
                                disable-handler
                                appearance-type="stack"
                                @update:visible-menu="handleUpdateVisibleMenu"
@@ -126,6 +125,10 @@ export default {
             default: false,
         },
         disabled: {
+            type: Boolean,
+            default: false,
+        },
+        readonly: {
             type: Boolean,
             default: false,
         },


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

There was a problem that delete all button was not appeared. 
That was because of the FilterableDropdown component's readonly prop was always true.
So This PR add readonly prop to ProjectSelectDropdown and bound it with FilterableDropdown.

### Things to Talk About
