### PR TITLE
fix(dashboard-dropdown): fix no default variable issue in customize page

### DIFF
--- a/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
@@ -144,11 +144,11 @@ watch(visibleMenu, (_visibleMenu) => {
     if (_visibleMenu) {
         initiateMenu();
     } else {
+        // Reflect selectedForUpdate changes after the dropdown is closed.
         updateVariablesUse();
         state.searchText = '';
     }
-    // Reflect selectedForUpdate changes after the dropdown is closed.
-}, { immediate: true });
+});
 
 const {
     targetRef,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
SSIA

- Because more dropdown's watcher was working with `immediate`, variable uses were clear when entering customize page.