### PR TITLE
fix: make gnb dashboard recent, favorite css the same

### DIFF
--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardFavorite.vue
@@ -230,7 +230,6 @@ export default defineComponent<Props>({
             @apply text-gray-400;
             font-size: 0.875rem;
             line-height: 1.5;
-            padding-top: 1.5rem;
         }
         .button-wrapper {
             display: flex;

--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardRecent.vue
@@ -2,7 +2,7 @@
     <div class="gnb-dashboard-recent">
         <p-data-loader :data="recentDashboardItems"
                        :loading="loading"
-                       :class="{ loading: loading && !recentDashboardItems.length }"
+                       class="gnb-dashboard-recent-context"
         >
             <div class="gnb-dashboard-recent-list">
                 <div @click="hideMenu">
@@ -147,16 +147,11 @@ export default defineComponent<Props>({
 </script>
 <style lang="postcss" scoped>
 .gnb-dashboard-recent {
-    /* custom design-system component - p-data-loader */
-    :deep(.p-data-loader) {
-        &.loading {
-            height: 13rem;
-        }
-        .data-loader-container {
-            max-height: calc(100vh - $gnb-height - 3.75rem);
-            overflow-y: auto;
-            padding: 0.5rem;
-        }
+    .gnb-dashboard-recent-context {
+        max-height: calc(85vh - 9rem);
+        overflow-y: auto;
+        padding: 0.5rem;
+        min-height: 15rem;
     }
 
     .gnb-dashboard-recent-list {

--- a/src/lib/site-initializer/api-client.ts
+++ b/src/lib/site-initializer/api-client.ts
@@ -43,7 +43,8 @@ const getMockInfo = (config): MockInfo => ({
 });
 
 export const initApiClient = async (store, config) => {
-    const endpoints = getApiEndpoints(config);
+    const mockInfo = getMockInfo(config);
+    const endpoints = mockInfo.all ? mockInfo.endpoints as string[] : getApiEndpoints(config);
     const tokenApi = new TokenAPI(endpoints[0], getSessionTimeoutCallback(store));
     await SpaceConnector.init(
         endpoints,

--- a/src/services/dashboards/dashboard-customize/modules/DashboardDefaultWidgetTab.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardDefaultWidgetTab.vue
@@ -51,7 +51,7 @@ import type { TabItem } from '@spaceone/design-system/types/navigation/tabs/tab/
 
 import { i18n } from '@/translations';
 
-import DashboardWidgetInputForm from '@/services/dashboards/dashboard-customize/modules/DashboardWidgetInputForm.vue';
+import DashboardWidgetInputForm from '@/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue';
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
 import { CONSOLE_WIDGET_CONFIGS } from '@/services/dashboards/widgets/_configs/widget-list-config';
 

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-reference-store.ts
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-reference-store.ts
@@ -1,0 +1,37 @@
+import { computed, reactive } from 'vue';
+
+import { store } from '@/store';
+
+import type { CloudServiceTypeReferenceMap } from '@/store/modules/reference/cloud-service-type/type';
+import type { ProviderReferenceMap } from '@/store/modules/reference/provider/type';
+import type { RegionReferenceMap } from '@/store/modules/reference/region/type';
+import type { ServiceAccountReferenceMap } from '@/store/modules/reference/service-account/type';
+import type { UserReferenceMap } from '@/store/modules/reference/user/type';
+
+export const useReferenceStore = () => {
+    const referenceStoreState = reactive({
+        loading: true,
+        provider: computed<ProviderReferenceMap>(() => store.getters['reference/providerItems']),
+        project_id: computed(() => store.getters['reference/projectItems']),
+        service_account_id: computed<ServiceAccountReferenceMap>(() => store.getters['reference/serviceAccountItems']),
+        user_id: computed<UserReferenceMap>(() => store.getters['reference/userItems']),
+        cloud_service_type_id: computed<CloudServiceTypeReferenceMap>(() => store.getters['reference/cloudServiceTypeItems']),
+        region_code: computed<RegionReferenceMap>(() => store.getters['reference/regionItems']),
+    });
+    (async () => {
+        referenceStoreState.loading = true;
+        await Promise.allSettled([
+            store.dispatch('reference/provider/load'),
+            store.dispatch('reference/project/load'),
+            store.dispatch('reference/serviceAccount/load'),
+            store.dispatch('reference/cloudServiceType/load'),
+            store.dispatch('reference/region/load'),
+            store.dispatch('reference/user/load'),
+        ]);
+        referenceStoreState.loading = false;
+    })();
+
+    return {
+        referenceStoreState,
+    };
+};

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-widget-name-input.ts
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-widget-name-input.ts
@@ -1,0 +1,33 @@
+import { toRef } from 'vue';
+
+import { i18n } from '@/translations';
+
+import { useFormValidator } from '@/common/composables/form-validator';
+
+import { useWidgetFormStore } from '@/services/dashboards/dashboard-customize/stores/widget-form';
+
+export const useWidgetNameInput = () => {
+    const widgetFormStore = useWidgetFormStore();
+    const {
+        forms: { name }, setForm, invalidState, invalidTexts, isAllValid: isNameValid, resetAll: resetName,
+    } = useFormValidator({
+        name: '',
+    }, {
+        name(value: string) { return value.trim().length ? '' : i18n.t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.VALIDATION_NAME'); },
+    });
+    const updateName = (val) => {
+        setForm('name', val);
+        widgetFormStore.setWidgetTitle(val);
+    };
+    const isNameInvalid = toRef(invalidState, 'name');
+    const nameInvalidText = toRef(invalidTexts, 'name');
+
+    return {
+        name,
+        resetName,
+        updateName,
+        isNameValid,
+        isNameInvalid,
+        nameInvalidText,
+    };
+};

--- a/src/services/dashboards/widgets/_components/DashboardWidgetEditModal.vue
+++ b/src/services/dashboards/widgets/_components/DashboardWidgetEditModal.vue
@@ -22,7 +22,7 @@ import {
 
 import { useProxyValue } from '@/common/composables/proxy-state';
 
-import DashboardWidgetInputForm from '@/services/dashboards/dashboard-customize/modules/DashboardWidgetInputForm.vue';
+import DashboardWidgetInputForm from '@/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue';
 import { useWidgetFormStore } from '@/services/dashboards/dashboard-customize/stores/widget-form';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/dashboard-detail/store/dashboard-detail-info';
 import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/_configs/config';


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- (fix) make gnb dashboard recent, favorite css the same
- (fix) make use mock info endpoints in api client in mock mode
- (refactor) separate widget title(name) input logic as composable from DashboardWidgetInputForm.vue
- (refactor) separate reference store logics as composable from DashboardWidgetInputForm.vue

This PR includes some refactoring tasks. They are pre tasks of developing the inherit validation feature.

### Things to Talk About
