### PR TITLE
refactor(variable-table): fix show more toggle issue

### DIFF
--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
@@ -35,7 +35,6 @@
                                              :content-type.sync="contentType"
                                              :variables="variableSchema.properties"
                                              :order="variableSchema.order"
-                                             @use-change="handleChangeVariableUse"
                                              @delete="handleOpenDeleteModal"
                                              @edit="handleChangeEditContent"
             />
@@ -156,11 +155,6 @@ const handleConfirmModalAction = () => {
         SpaceRouter.router.go(-1);
     }
     resetDeleteModalState();
-};
-const handleChangeVariableUse = (name: string, value: boolean) => {
-    const properties = cloneDeep(state.variableSchema.properties) as DashboardVariablesSchema['properties'];
-    properties[name].use = value;
-    dashboardDetailState.variablesSchema = { ...dashboardDetailState.variablesSchema, properties };
 };
 const handleChangeEditContent = (propertyName: string) => {
     state.selectedVariable = propertyName;

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
@@ -32,9 +32,6 @@
                 </template>
             </p-panel-top>
             <dashboard-manage-variable-table v-if="contentType === 'LIST'"
-                                             :content-type.sync="contentType"
-                                             :variables="variableSchema.properties"
-                                             :order="variableSchema.order"
                                              @delete="handleOpenDeleteModal"
                                              @edit="handleChangeEditContent"
             />

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
@@ -67,14 +67,13 @@
 
 <script setup lang="ts">
 import {
-    computed, onMounted, reactive, toRefs,
+    computed, reactive, toRefs, watch,
 } from 'vue';
 
 import {
     PBadge, PDataTable, PSelectStatus, PToggleButton, PButton, PCollapsiblePanel,
 } from '@spaceone/design-system';
 
-import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
@@ -148,13 +147,8 @@ const handleToggleUse = (propertyName: string, value: boolean) => {
     dashboardDetailState.variablesSchema.properties[propertyName].use = !value;
 };
 
-onMounted(() => {
-    if (dashboardDetailState.variablesSchema.order.length === 0) {
-        SpaceRouter.router.go(-1);
-        return;
-    }
+watch(() => dashboardDetailState.variablesSchema.order, (order) => {
     const properties = dashboardDetailState.variablesSchema.properties;
-    const order = dashboardDetailState.variablesSchema.order;
     const convertedVariables = order.map((d) => {
         if (properties[d].variable_type === 'MANAGED') {
             return {
@@ -172,7 +166,7 @@ onMounted(() => {
     if (state.selectedVariableType === 'ALL') {
         state.orderedVariables = convertedVariables;
     } else state.orderedVariables = convertedVariables.filter((d) => d.variable_type === state.selectedVariableType);
-});
+}, { immediate: true });
 
 const {
     orderedVariables,

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
@@ -67,7 +67,7 @@
 
 <script setup lang="ts">
 import {
-    computed, reactive, toRefs,
+    computed, onMounted, reactive, toRefs,
 } from 'vue';
 
 import {
@@ -77,40 +77,26 @@ import {
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
-import type { VariableType, DashboardVariablesSchema } from '@/services/dashboards/config';
 
-interface Props {
-    variables: DashboardVariablesSchema['properties'];
-    order: string[];
+import type { VariableType, DashboardVariableSchemaProperty } from '@/services/dashboards/config';
+import { useDashboardDetailInfoStore } from '@/services/dashboards/dashboard-detail/store/dashboard-detail-info';
+
+interface VariablesPropertiesForManage extends DashboardVariableSchemaProperty {
+    propertyName: string;
+    managable?: string;
 }
 interface EmitFn {
     (e: 'delete', value: string): void;
-    (e: 'use-change', name: string, value: boolean): void;
     (e: 'edit', name: string): void;
 }
 
-const props = defineProps<Props>();
 const emit = defineEmits<EmitFn>();
 
+const dashboardDetailStore = useDashboardDetailInfoStore();
+const dashboardDetailState = dashboardDetailStore.state;
+
 const state = reactive({
-    orderedVariables: computed(() => {
-        const convertedVariables = props.order.map((d) => {
-            if (props.variables[d].variable_type === 'MANAGED') {
-                return {
-                    ...props.variables[d],
-                    propertyName: d,
-                    options: Object.keys(state.allReferenceTypeInfo[d].referenceMap),
-                };
-            }
-            return {
-                ...props.variables[d],
-                propertyName: d,
-                managable: d,
-            };
-        });
-        if (state.selectedVariableType === 'ALL') return convertedVariables;
-        return convertedVariables.filter((d) => d.variable_type === state.selectedVariableType);
-    }),
+    orderedVariables: [] as VariablesPropertiesForManage[],
     variableFilterList: computed(() => [
         { label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_ALL'), name: 'ALL' },
         { label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.FILTER_MANAGED'), name: 'MANAGED' },
@@ -152,8 +138,37 @@ const handleDeleteVariable = (propertyName: string) => {
     emit('delete', propertyName);
 };
 const handleToggleUse = (propertyName: string, value: boolean) => {
-    emit('use-change', propertyName, !value);
+    // change use in state.orderedVariables
+    const selectedIndex = state.orderedVariables.findIndex((variable) => variable.propertyName === propertyName);
+    if (selectedIndex === -1) return;
+    state.orderedVariables[selectedIndex].use = !value;
+
+    // change use in store
+    dashboardDetailState.variablesSchema.properties[propertyName].use = !value;
 };
+
+onMounted(() => {
+    const properties = dashboardDetailState.variablesSchema.properties;
+    const order = dashboardDetailState.variablesSchema.order;
+    const convertedVariables = order.map((d) => {
+        if (properties[d].variable_type === 'MANAGED') {
+            return {
+                ...properties[d],
+                propertyName: d,
+                options: Object.keys(state.allReferenceTypeInfo[d].referenceMap),
+            };
+        }
+        return {
+            ...properties[d],
+            propertyName: d,
+            managable: d,
+        };
+    });
+    if (state.selectedVariableType === 'ALL') {
+        state.orderedVariables = convertedVariables;
+    } else state.orderedVariables = convertedVariables.filter((d) => d.variable_type === state.selectedVariableType);
+});
+
 const {
     orderedVariables,
     variableFilterList,

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
@@ -74,6 +74,7 @@ import {
     PBadge, PDataTable, PSelectStatus, PToggleButton, PButton, PCollapsiblePanel,
 } from '@spaceone/design-system';
 
+import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
@@ -148,6 +149,10 @@ const handleToggleUse = (propertyName: string, value: boolean) => {
 };
 
 onMounted(() => {
+    if (dashboardDetailState.variablesSchema.order.length === 0) {
+        SpaceRouter.router.go(-1);
+        return;
+    }
     const properties = dashboardDetailState.variablesSchema.properties;
     const order = dashboardDetailState.variablesSchema.order;
     const convertedVariables = order.map((d) => {

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
@@ -122,11 +122,6 @@ const state = reactive({
     allReferenceTypeInfo: computed(() => store.getters['reference/allReferenceTypeInfo']),
 });
 
-/* Helper */
-const variableTypeBadgeStyleFormatter = (type: VariableType) => {
-    if (type === 'MANAGED') return 'gray';
-    return 'primary';
-};
 /* EVENT */
 const handleSelectType = (selected) => {
     state.selectedVariableType = selected;
@@ -147,7 +142,12 @@ const handleToggleUse = (propertyName: string, value: boolean) => {
     dashboardDetailState.variablesSchema.properties[propertyName].use = !value;
 };
 
-watch(() => dashboardDetailState.variablesSchema.order, (order) => {
+/* Helper */
+const variableTypeBadgeStyleFormatter = (type: VariableType) => {
+    if (type === 'MANAGED') return 'gray';
+    return 'primary';
+};
+const convertAndUpdateVariablesForTable = (order: string[]) => {
     const properties = dashboardDetailState.variablesSchema.properties;
     const convertedVariables = order.map((d) => {
         if (properties[d].variable_type === 'MANAGED') {
@@ -166,6 +166,10 @@ watch(() => dashboardDetailState.variablesSchema.order, (order) => {
     if (state.selectedVariableType === 'ALL') {
         state.orderedVariables = convertedVariables;
     } else state.orderedVariables = convertedVariables.filter((d) => d.variable_type === state.selectedVariableType);
+};
+
+watch(() => dashboardDetailState.variablesSchema.order, (_order) => {
+    convertAndUpdateVariablesForTable(_order);
 }, { immediate: true });
 
 const {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
SSIA

Solve [QA - 314 - 1](https://pyengine.atlassian.net/browse/QA-314)

- Replace entire connection to conditional connection between table data and store data, because variable table data is linked to store and always converting to appropriate type that fits table. That kept causing new rendering and weird move.

- Watcher is watching variable-order, and cause conditional rendering in only deletion case or forced refresh.


https://user-images.githubusercontent.com/83635051/212932525-80f9084e-fe48-4244-8f69-9114993c9ed1.mov


