### PR TITLE
fix(WidgetForm): use inheritOptions in pinia store && set custom-error-map to json schema form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@amcharts/amcharts5": "^5.2.31",
         "@amcharts/amcharts5-geodata": "^5.0.6",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "^2.0.0-beta.15",
+        "@spaceone/design-system": "^2.0.0-beta.16",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -3650,9 +3650,9 @@
       }
     },
     "node_modules/@spaceone/design-system": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-2.0.0-beta.15.tgz",
-      "integrity": "sha512-TRF8BNgD3ZJ8uCU4qV66YLAArfBW1vW4GQ+xe7tjc4SYNsu/6EWphYFJ+sZNS2vG9b77QasUsRJyTKx/qIot/Q==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-2.0.0-beta.16.tgz",
+      "integrity": "sha512-l39fMC4DTZn5CV5JJvGyrAR9rxgy/YIismRytWAQQu24MbyQtPVzMFzkekqF5CHY4Tib96SfDauwVTdi+Fnrxw==",
       "dependencies": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -22668,9 +22668,9 @@
       }
     },
     "@spaceone/design-system": {
-      "version": "2.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-2.0.0-beta.15.tgz",
-      "integrity": "sha512-TRF8BNgD3ZJ8uCU4qV66YLAArfBW1vW4GQ+xe7tjc4SYNsu/6EWphYFJ+sZNS2vG9b77QasUsRJyTKx/qIot/Q==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-2.0.0-beta.16.tgz",
+      "integrity": "sha512-l39fMC4DTZn5CV5JJvGyrAR9rxgy/YIismRytWAQQu24MbyQtPVzMFzkekqF5CHY4Tib96SfDauwVTdi+Fnrxw==",
       "requires": {
         "@amcharts/amcharts4": "^4.10.10",
         "@babel/runtime": "^7.12.5",
@@ -25081,7 +25081,7 @@
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@gtm-support/vue2-gtm": "^1.3.0",
-        "@spaceone/design-system": "2.0.0-beta.15",
+        "@spaceone/design-system": "2.0.0-beta.16",
         "@tiptap/core": "^2.0.0-beta.1",
         "@tiptap/extension-color": "^2.0.0-beta.12",
         "@tiptap/extension-link": "^2.0.0-beta.43",
@@ -27751,9 +27751,9 @@
           }
         },
         "@spaceone/design-system": {
-          "version": "2.0.0-beta.15",
-          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-2.0.0-beta.15.tgz",
-          "integrity": "sha512-TRF8BNgD3ZJ8uCU4qV66YLAArfBW1vW4GQ+xe7tjc4SYNsu/6EWphYFJ+sZNS2vG9b77QasUsRJyTKx/qIot/Q==",
+          "version": "2.0.0-beta.16",
+          "resolved": "https://registry.npmjs.org/@spaceone/design-system/-/design-system-2.0.0-beta.16.tgz",
+          "integrity": "sha512-l39fMC4DTZn5CV5JJvGyrAR9rxgy/YIismRytWAQQu24MbyQtPVzMFzkekqF5CHY4Tib96SfDauwVTdi+Fnrxw==",
           "requires": {
             "@amcharts/amcharts4": "^4.10.10",
             "@babel/runtime": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@amcharts/amcharts5": "^5.2.31",
     "@amcharts/amcharts5-geodata": "^5.0.6",
     "@gtm-support/vue2-gtm": "^1.3.0",
-    "@spaceone/design-system": "^2.0.0-beta.15",
+    "@spaceone/design-system": "^2.0.0-beta.16",
     "@tiptap/core": "^2.0.0-beta.1",
     "@tiptap/extension-color": "^2.0.0-beta.12",
     "@tiptap/extension-link": "^2.0.0-beta.43",

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -23,6 +23,8 @@
             <p-json-schema-form v-if="widgetOptionsJsonSchema.properties"
                                 :schema="widgetOptionsJsonSchema"
                                 :form-data.sync="schemaFormData"
+                                :custom-error-map="inheritOptionsErrorMap"
+                                :validation-mode="widgetKey ? 'all' : 'input'"
                                 class="widget-options-form"
                                 @validate="handleFormValidate"
             >

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-widget-title-input.ts
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-widget-title-input.ts
@@ -8,6 +8,7 @@ import { useWidgetFormStore } from '@/services/dashboards/dashboard-customize/st
 
 export const useWidgetTitleInput = () => {
     const widgetFormStore = useWidgetFormStore();
+    const widgetFormState = widgetFormStore.state;
     const {
         forms: { title }, setForm, invalidState, invalidTexts, isAllValid: isTitleValid, resetAll: resetTitle,
     } = useFormValidator({
@@ -17,7 +18,7 @@ export const useWidgetTitleInput = () => {
     });
     const updateTitle = (val) => {
         setForm('title', val);
-        widgetFormStore.setWidgetTitle(val);
+        widgetFormState.widgetTitle = val;
     };
     const isTitleInvalid = toRef(invalidState, 'title');
     const titleInvalidText = toRef(invalidTexts, 'title');

--- a/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -18,8 +18,8 @@
                 <div class="error-title">
                     <span class="error-icon-wrapper">
                         <p-i name="ic_alert"
-                             height="1rem"
-                             width="1rem"
+                             height="1.5rem"
+                             width="1.5rem"
                              color="inherit"
                         />
                     </span>

--- a/src/services/dashboards/widgets/_helpers/widget-validation-helper.ts
+++ b/src/services/dashboards/widgets/_helpers/widget-validation-helper.ts
@@ -25,7 +25,8 @@ export const getWidgetInheritOptionsErrorMap = (
         if (!inheritOption?.enabled) return;
 
         const variableKey = inheritOption?.variable_info?.key;
-        if (!variableKey || !dashboardVariablesSchema?.properties?.[variableKey]?.use) {
+        if (!variableKey) return;
+        if (!dashboardVariablesSchema?.properties?.[variableKey]?.use) {
             errorMap[propertyName] = i18n.t('DASHBOARDS.WIDGET.VALIDATION_PROPERTY_NOT_EXIST');
             return;
         }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- There're `inheritItemMap` and `widgetFormState.inheritOptions` in Widget Form. For **single source of truth**, I only use `widgetFormState.inheritOptions` and change `inheritItemMap` as computed state.
- set `custom-error-map` to Json Schema Form