### PR TITLE
fix(dashboard): wrong route causing wrong dashboardId

### DIFF
--- a/src/services/dashboards/routes.ts
+++ b/src/services/dashboards/routes.ts
@@ -50,7 +50,7 @@ const dashboardsRoute: RouteConfig = {
                     component: { template: '<router-view/>' },
                     children: [
                         {
-                            path: ':dashboardId',
+                            path: 'detail/:dashboardId',
                             name: DASHBOARDS_ROUTE.PROJECT.DETAIL._NAME,
                             meta: { lnbVisible: true, label: ({ params }) => params.dashboardId, copiable: true },
                             props: true,
@@ -98,7 +98,7 @@ const dashboardsRoute: RouteConfig = {
                     component: { template: '<router-view/>' },
                     children: [
                         {
-                            path: ':dashboardId',
+                            path: 'detail/:dashboardId',
                             name: DASHBOARDS_ROUTE.WORKSPACE.DETAIL._NAME,
                             meta: { lnbVisible: true, label: ({ params }) => params.dashboardId, copiable: true },
                             props: true,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

There was a problem at dashboard-route and it causes wrong dashboardId.
When user wants to create a dashboard, url is '/project/customize'.
But it was recognized as `customize` is dashboardId.

So I've fixed it.

### Things to Talk About
