### PR TITLE
feat: add default_schema_properties to widget info

### DIFF
--- a/packages/cloudforet/core-lib/src/space-connector/index.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/index.ts
@@ -79,6 +79,8 @@ export class SpaceConnector {
                 SpaceConnector.instance.loadAPI(1),
                 SpaceConnector.instance.loadAPI(2),
             ]);
+        } else {
+            throw new Error('Instance already exists');
         }
     }
 

--- a/packages/cloudforet/core-lib/src/space-connector/token-api.ts
+++ b/packages/cloudforet/core-lib/src/space-connector/token-api.ts
@@ -33,6 +33,8 @@ export default class TokenAPI {
     private readonly sessionTimeoutCallback: SessionTimeoutCallback;
 
     constructor(baseURL: string, sessionTimeoutCallback: SessionTimeoutCallback) {
+        // init refreshing state to avoid passing refreshing process
+        TokenAPI.unsetRefreshingState();
         this.sessionTimeoutCallback = sessionTimeoutCallback;
 
         const axiosConfig = {

--- a/src/services/dashboards/dashboard-customize/modules/DashboardAddWidgetModal.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardAddWidgetModal.vue
@@ -78,6 +78,7 @@ export default defineComponent<Props>({
                 version: '1', // TODO: auto?
                 inherit_options: widgetFormState.inheritOptions ?? {},
                 widget_options: widgetFormState.widgetOptions ?? {},
+                default_schema_properties: widgetFormState.defaultSchemaProperties ?? [],
             };
             emit('add-widget', dashboardLayoutWidgetInfo);
             state.proxyVisible = false;

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -132,7 +132,6 @@ export default defineComponent<Props>({
             widgetOptionsJsonSchema: {} as JsonSchema,
             schemaFormData: {},
             // inherit
-            inheritOptions: {} as InheritOptions,
             inheritableProperties: computed<string[]>(() => Object.entries<InheritOptions[string]>(widgetFormState.inheritOptions ?? {})
                 .filter(([, inheritOption]) => !!inheritOption.enabled)
                 .map(([propertyName]) => propertyName)),

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/helpers.ts
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/helpers.ts
@@ -1,0 +1,103 @@
+import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
+import type { JsonSchema } from '@spaceone/design-system/types/inputs/forms/json-schema-form/type';
+
+import type { ReferenceMap } from '@/store/modules/reference/type';
+
+import type { DashboardVariablesSchema } from '@/services/dashboards/config';
+import type {
+    useReferenceStore,
+} from '@/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-reference-store';
+import type { InheritOptions, WidgetOptionsSchema } from '@/services/dashboards/widgets/_configs/config';
+
+type ReferenceStoreState = ReturnType<typeof useReferenceStore>['referenceStoreState'];
+
+const refineFilterOptionSchema = (propertyName: string, propertySchema: JsonSchema['properties'], referenceStoreState: ReferenceStoreState): JsonSchema['properties'] => {
+    const referenceType = propertyName.replace('filters.', '');
+
+    // use reference store data if exists
+    const referenceData: ReferenceMap = referenceStoreState[referenceType];
+    const menuItems: MenuItem[] = Object.values(referenceData).map((d) => ({
+        name: d.key, label: d.label,
+    }));
+
+    const _enum = Object.keys(referenceData);
+    if (propertySchema.type === 'array') {
+        return {
+            ...propertySchema,
+            items: { enum: _enum.length ? _enum : [null] },
+            menuItems,
+        };
+    }
+    return {
+        ...propertySchema,
+        enum: _enum.length ? _enum : [null],
+        menuItems,
+    };
+};
+const refineOptionSchema = (propertyName: string, propertySchema: JsonSchema['properties'], referenceStoreState: ReferenceStoreState): JsonSchema['properties'] => {
+    if (propertyName.startsWith('filters.')) return refineFilterOptionSchema(propertyName, propertySchema, referenceStoreState);
+    return propertySchema;
+};
+const refineOptionSchemaByVariablesSchema = (propertySchema: JsonSchema['properties'], variablesSchema: DashboardVariablesSchema) => {
+    const availableVariables = Object.entries(variablesSchema.properties)
+        .filter(([, d]) => {
+            if (!d.use) return false;
+            const variableType = d.selection_type === 'MULTI' ? 'array' : 'string';
+            return propertySchema.type === variableType;
+        });
+    const _enum = availableVariables.map(([key]) => key);
+    return {
+        title: propertySchema.title,
+        type: 'string',
+        enum: _enum.length ? _enum : [null],
+        menuItems: availableVariables.map(([key, val]) => ({
+            name: key, label: val.name,
+        })),
+        default: undefined,
+    };
+};
+
+export const getWidgetOptionSchema = (
+    propertyName: string,
+    propertySchema: JsonSchema['properties'],
+    variablesSchema: DashboardVariablesSchema,
+    referenceStoreState: ReferenceStoreState,
+    isInherit: boolean,
+) => {
+    let refinedPropertySchema;
+    if (isInherit) {
+        // inherit case
+        refinedPropertySchema = refineOptionSchemaByVariablesSchema(propertySchema, variablesSchema);
+    } else {
+        // non inherit case
+        refinedPropertySchema = refineOptionSchema(propertyName, propertySchema, referenceStoreState);
+    }
+    return refinedPropertySchema;
+};
+export const getRefinedWidgetOptionsSchema = (
+    referenceStoreState: ReferenceStoreState,
+    widgetOptionsSchema: WidgetOptionsSchema,
+    variablesSchema: DashboardVariablesSchema,
+    inheritOptions: InheritOptions,
+    defaultSchemaProperties: string[],
+): JsonSchema => {
+    const schema = widgetOptionsSchema?.schema;
+
+    const refinedJsonSchema = {
+        type: 'object',
+        properties: {},
+        required: schema?.required ?? [],
+        order: defaultSchemaProperties,
+    } as JsonSchema;
+    if (!schema?.properties) return refinedJsonSchema;
+
+    // refine each property schema
+    Object.entries(schema.properties).forEach(([propertyName, propertySchema]) => {
+        // set properties declared in defaultSchemaProperties only
+        if (!defaultSchemaProperties.includes(propertyName)) return;
+        const isInherit = !!inheritOptions[propertyName]?.enabled;
+        refinedJsonSchema.properties[propertyName] = getWidgetOptionSchema(propertyName, propertySchema, variablesSchema, referenceStoreState, isInherit);
+    });
+
+    return refinedJsonSchema;
+};

--- a/src/services/dashboards/dashboard-customize/stores/widget-form.ts
+++ b/src/services/dashboards/dashboard-customize/stores/widget-form.ts
@@ -15,6 +15,7 @@ interface State {
     inheritOptions?: InheritOptions;
     widgetOptions?: WidgetOptions;
     widgetInfo?: DashboardLayoutWidgetInfo;
+    defaultSchemaProperties?: string[];
 }
 
 export const useWidgetFormStore = defineStore('widget-form', () => {
@@ -27,6 +28,7 @@ export const useWidgetFormStore = defineStore('widget-form', () => {
         inheritOptions: undefined,
         widgetOptions: undefined,
         widgetInfo: undefined,
+        defaultSchemaProperties: undefined,
     });
     const setFormData = (formData: any) => {
         if (!state.widgetConfigId) return;
@@ -53,18 +55,19 @@ export const useWidgetFormStore = defineStore('widget-form', () => {
         });
         widgetOptions.filters = widgetFiltersMap;
 
-        //
         state.widgetOptions = widgetOptions;
     };
 
-    const initWidgetForm = (widgetKey: string) => {
+    const initWidgetForm = (widgetKey: string): DashboardLayoutWidgetInfo|undefined => {
         state.widgetInfo = dashboardDetailInfoStore.dashboardWidgetInfoList.find((w) => w.widget_key === widgetKey);
         if (state.widgetInfo) {
             state.widgetConfigId = state.widgetInfo.widget_name;
             state.widgetTitle = state.widgetInfo.title;
             state.widgetOptions = state.widgetInfo.widget_options;
             state.inheritOptions = state.widgetInfo.inherit_options;
+            state.defaultSchemaProperties = state.widgetInfo.default_schema_properties;
         }
+        return state.widgetInfo;
     };
 
     return {

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -154,10 +154,10 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         };
         state.variables = _dashboardInfo.variables ?? {};
         state.labels = _dashboardInfo.labels;
-        state.dashboardWidgetInfoList = flattenDeep(_dashboardInfo?.layouts ?? []).map((info) => ({
+        state.dashboardWidgetInfoList = _dashboardInfo?.layouts?.flat()?.map((info) => ({
             ...info,
-            widget_key: uuidv4(),
-        }));
+            widget_key: info.widget_key ?? uuidv4(),
+        })) ?? [];
         state.widgetDataMap = {};
     };
 

--- a/src/services/dashboards/default-dashboard/helper.ts
+++ b/src/services/dashboards/default-dashboard/helper.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { ERROR_CASE_WIDGET_INFO } from '@/services/dashboards/default-dashboard/config';
 import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/_configs/config';
 import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
@@ -6,12 +8,14 @@ export const getDashboardLayoutWidgetInfoList = (widgetList: string[]): Dashboar
     try {
         const widgetConfig = getWidgetConfig(widgetId);
         const widgetInfo: DashboardLayoutWidgetInfo = {
+            widget_key: uuidv4(),
             widget_name: widgetConfig.widget_config_id,
             title: widgetConfig.title ?? widgetConfig.widget_config_id,
             widget_options: widgetConfig.options ?? {},
             size: widgetConfig.sizes[0],
             version: '1',
             inherit_options: {},
+            default_schema_properties: widgetConfig.options_schema?.default_properties ?? [],
         };
         return widgetInfo;
     } catch (e) {

--- a/src/services/dashboards/default-dashboard/templates/cdn-and-traffic-cost.ts
+++ b/src/services/dashboards/default-dashboard/templates/cdn-and-traffic-cost.ts
@@ -27,6 +27,7 @@ export const cdnAndTrafficCostDashboard: DashboardConfig = {
         currency: {
             enabled: true,
         },
+        refresh_interval_option: '15s',
     },
     variables_schema: {
         properties: {},

--- a/src/services/dashboards/default-dashboard/templates/monthly-cost-summary.ts
+++ b/src/services/dashboards/default-dashboard/templates/monthly-cost-summary.ts
@@ -32,6 +32,7 @@ export const monthlyCostSummaryDashboard: DashboardConfig = {
         currency: {
             enabled: true,
         },
+        refresh_interval_option: '15s',
     },
     variables_schema: {
         properties: {},

--- a/src/services/dashboards/widgets/_components/DashboardWidgetEditModal.vue
+++ b/src/services/dashboards/widgets/_components/DashboardWidgetEditModal.vue
@@ -52,6 +52,7 @@ const handleEditModalConfirm = () => {
         title: widgetFormState.widgetTitle ?? '',
         inherit_options: widgetFormState.inheritOptions ?? {},
         widget_options: widgetFormState.widgetOptions ?? {},
+        default_schema_properties: widgetFormState.defaultSchemaProperties ?? [],
     };
     dashboardDetailStore.updateWidgetInfo(props.widgetKey, widgetInfo);
     dashboardDetailStore.updateWidgetValidation(true, props.widgetKey);

--- a/src/services/dashboards/widgets/_configs/config.ts
+++ b/src/services/dashboards/widgets/_configs/config.ts
@@ -133,12 +133,13 @@ export interface WidgetOptions {
 
 export interface DashboardLayoutWidgetInfo {
     widget_name: string; // widget config name
-    widget_key: string; // widget unique key
+    widget_key: string; // widget unique key. used for layout key binding.
     title: string; // widget title
     widget_options: WidgetOptions;
     size: WidgetSize;
     version: string; // widget config version
     inherit_options: InheritOptions; // inherit information for the widget option
+    default_schema_properties: string[]; // schema properties that are shown on widget form. updated when use add more options.
 }
 export type InheritOptions = Record<string, {
     enabled?: boolean;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- (fix) core-lib > token api: init refreshing state on token api creation
- (fix) do not generate widget_key if exists
- (fix) resolve some type errors in dashboard template creation helpers
- (feat) add default_schema_properties to widget info


### Things to Talk About
