### PR TITLE
fix: fix monthly cost widget loading, empty case and dashboard title loading case

### DIFF
--- a/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
@@ -3,12 +3,10 @@
         child
         @goBack="$router.go(-1)"
     >
-        <template v-if="props.dashboardId"
-                  #title
-        >
-            <p-field-group
-                :invalid="invalidState.nameInput"
-                :invalid-text="invalidTexts.nameInput"
+        <template v-if="props.dashboardId">
+            <p-field-group v-if="props.name"
+                           :invalid="invalidState.nameInput"
+                           :invalid-text="invalidTexts.nameInput"
             >
                 <template #default>
                     <input v-if="state.editMode"
@@ -27,10 +25,12 @@
                     </span>
                 </template>
             </p-field-group>
+            <p-skeleton v-else
+                        width="20rem"
+                        height="1.5rem"
+            />
         </template>
-        <template v-else-if="props.dashboardId === undefined"
-                  #title
-        >
+        <template v-else-if="props.dashboardId === undefined">
             <p-field-group
                 :invalid="invalidState.nameInput"
                 :invalid-text="invalidTexts.nameInput"
@@ -52,7 +52,9 @@
 import { vOnClickOutside } from '@vueuse/components';
 import { computed, reactive } from 'vue';
 
-import { PFieldGroup, PPageTitle, PTextInput } from '@spaceone/design-system';
+import {
+    PFieldGroup, PPageTitle, PSkeleton, PTextInput,
+} from '@spaceone/design-system';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';

--- a/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -1,7 +1,11 @@
 <template>
     <div class="dashboard-detail-page">
         <p-page-title :title="dashboardDetailState.name">
-            <template v-if="dashboardDetailOriginState.dashboardViewer === DASHBOARD_VIEWER.PUBLIC"
+            <p-skeleton v-if="!dashboardDetailState.name"
+                        width="20rem"
+                        height="1.5rem"
+            />
+            <template v-if="dashboardDetailState.name && dashboardDetailOriginState.dashboardViewer === DASHBOARD_VIEWER.PUBLIC"
                       #title-left-extra
             >
                 <p-i name="ic_public"
@@ -10,7 +14,9 @@
                      :color="PUBLIC_ICON_COLOR"
                 />
             </template>
-            <template #title-right-extra>
+            <template v-if="dashboardDetailState.name"
+                      #title-right-extra
+            >
                 <span class="dashboard-title-icon-buttons-wrapper">
                     <favorite-button :item-id="props.dashboardId"
                                      :favorite-type="FAVORITE_TYPE.DASHBOARD"
@@ -74,7 +80,7 @@ import {
 } from 'vue';
 
 import {
-    PDivider, PI, PIconButton, PPageTitle,
+    PDivider, PI, PIconButton, PPageTitle, PSkeleton,
 } from '@spaceone/design-system';
 
 import { SpaceRouter } from '@/router';

--- a/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
+++ b/src/services/dashboards/widgets/monthly-cost/MonthlyCostWidget.vue
@@ -2,71 +2,97 @@
     <widget-frame v-bind="widgetFrameProps"
                   @refresh="handleRefresh"
     >
-        <p-data-loader class="monthly-cost"
-                       :loading="state.loading"
-                       :data="state.data"
-                       :loader-backdrop-opacity="1"
-                       loader-type="skeleton"
-        >
+        <div class="monthly-cost">
             <div class="cost">
                 <p class="cost-label">
                     {{ $t('DASHBOARDS.WIDGET.MONTHLY_COST.CURRENT_MONTH') }}
                 </p>
-                <div class="cost-value">
-                    {{ currencyMoneyFormatter(state.currentMonthlyCost, state.currency) }}
-                </div>
-                <div class="cost-info">
-                    <p-i
-                        :name="state.isDecreased ? 'ic_decrease' : 'ic_increase'"
-                        fill
-                        width="1rem"
-                        height="1rem"
-                        :color="state.isDecreased ? green[700] : red[500]"
-                        original
-                    />
-                    {{ currencyMoneyFormatter(state.differenceCost, state.currency) }}
-                    <p-badge :style-type="state.isDecreased ? 'green200' : 'alert'"
-                             shape="square"
-                    >
-                        {{ state.differenceCostRate }} %
-                    </p-badge>
-                </div>
+                <p-data-loader class="data-loader"
+                               :loading="state.loading"
+                               :data="state.data"
+                               :loader-backdrop-opacity="1"
+                               disable-empty-case
+                               loader-type="skeleton"
+                >
+                    <div class="cost-value">
+                        {{ currencyMoneyFormatter(state.currentMonthlyCost, state.currency) }}
+                    </div>
+                    <div class="cost-info">
+                        <p-i v-if="typeof state.isDecreased === 'boolean'"
+                             :name="state.isDecreased ? 'ic_decrease' : 'ic_increase'"
+                             fill
+                             width="1rem"
+                             height="1rem"
+                             :color="state.isDecreased ? green[700] : red[500]"
+                             original
+                        />
+                        {{ currencyMoneyFormatter(state.differenceCost, state.currency) }}
+                        <p-badge :style-type="state.isDecreased === undefined ? 'gray200' : state.isDecreased ? 'green200' : 'alert'"
+                                 shape="square"
+                        >
+                            {{ state.differenceCostRate }} %
+                        </p-badge>
+                    </div>
+                    <template #loader>
+                        <div class="skeleton-wrapper">
+                            <p-skeleton class="skeleton"
+                                        width="10rem"
+                                        height="1.875rem"
+                            />
+                            <p-skeleton class="skeleton"
+                                        width="7.5rem"
+                                        height="1.5rem"
+                            />
+                        </div>
+                    </template>
+                </p-data-loader>
             </div>
             <p-divider />
             <div class="cost">
                 <p class="cost-label">
                     {{ $t('DASHBOARDS.WIDGET.MONTHLY_COST.PREVIOUS_MONTH') }}
                 </p>
-                <div class="cost-value">
-                    {{ currencyMoneyFormatter(state.previousMonthlyCost, state.currency) }}
-                </div>
-                <div class="cost-info">
-                    {{ state.previousMonth.format('MMM YYYY') }}
-                </div>
+                <p-data-loader class="data-loader"
+                               :loading="state.loading"
+                               :data="state.data"
+                               :loader-backdrop-opacity="1"
+                               disable-empty-case
+                               loader-type="skeleton"
+                >
+                    <div class="cost-value">
+                        {{ currencyMoneyFormatter(state.previousMonthlyCost, state.currency) }}
+                    </div>
+                    <div class="cost-info">
+                        {{ state.previousMonth.format('MMM YYYY') }}
+                    </div>
+                    <template #loader>
+                        <div class="skeleton-wrapper">
+                            <p-skeleton class="skeleton"
+                                        width="10rem"
+                                        height="1.875rem"
+                            />
+                            <p-skeleton class="skeleton"
+                                        width="7.5rem"
+                                        height="1.5rem"
+                            />
+                        </div>
+                    </template>
+                </p-data-loader>
             </div>
             <div class="chart-wrapper">
-                <div ref="chartContext"
-                     class="chart"
-                />
-            </div>
-            <template #loader>
-                <div v-for="(_, idx) in state.skeletons"
-                     :key="`skeleton-${idx}`"
-                     class="skeleton-wrapper mt-4"
+                <p-data-loader class="data-loader"
+                               :loading="state.loading"
+                               :data="state.data"
+                               :loader-backdrop-opacity="1"
+                               disable-empty-case
+                               loader-type="skeleton"
                 >
-                    <p-skeleton width="10rem"
-                                height="1.875rem"
-                                class="mb-1"
+                    <div ref="chartContext"
+                         class="chart"
                     />
-                    <p-skeleton width="7.5rem"
-                                height="1.5rem"
-                    />
-                </div>
-                <p-skeleton width="100%"
-                            height="100%"
-                />
-            </template>
-        </p-data-loader>
+                </p-data-loader>
+            </div>
+        </div>
     </widget-frame>
 </template>
 
@@ -131,11 +157,17 @@ const state = reactive({
     }),
     differenceCostRate: computed(() => {
         let previousMonthlyCost = state.previousMonthlyCost;
-        if (Number.isNaN(state.differenceCost)) return '--';
+        if (typeof state.differenceCost !== 'number') return '--';
         if (state.currentMonthlyCost === 0) previousMonthlyCost = 1;
         return (state.differenceCost / previousMonthlyCost * 100).toFixed(2);
     }),
-    isDecreased: computed<boolean>(() => (state.differenceCost < 0)),
+    isDecreased: computed<boolean|undefined>(() => {
+        if (typeof state.differenceCost === 'number') {
+            if (state.differenceCost === 0) return undefined;
+            return state.differenceCost < 0;
+        }
+        return undefined;
+    }),
 });
 const widgetFrameProps:ComputedRef = useWidgetFrameProps(props, state);
 
@@ -256,9 +288,12 @@ defineExpose<WidgetExpose<Data>>({
     display: flex;
     flex-direction: column;
     padding: 0 1.5rem;
+    height: 100%;
+    width: 100%;
     .cost {
         @apply text-gray-900;
         line-height: 1.25;
+        height: 5.75rem;
         .cost-label {
             font-size: 1rem;
         }
@@ -281,23 +316,28 @@ defineExpose<WidgetExpose<Data>>({
 
     .chart-wrapper {
         flex-grow: 1;
-        height: 6.25rem;
         margin-top: 1.5rem;
+        margin-bottom: 1.5rem;
         width: 100%;
         .chart {
             height: 100%;
         }
     }
-}
-:deep(.data-loader-container) {
-    > .loader-wrapper > .loader {
-        @apply flex-col items-start justify-start;
-    }
-    .skeleton-wrapper {
-        @apply flex flex-col;
-        &:last-of-type {
-            margin-top: 3.8125rem;
-            margin-bottom: 1.875rem;
+    .data-loader {
+        display: flex;
+        width: 100%;
+        height: 100%;
+        .skeleton-wrapper {
+            width: 100%;
+            height: 100%;
+            .skeleton {
+                display: block;
+                margin-top: 0.25rem;
+            }
+            &.chart {
+                height: 6.25rem;
+                margin-bottom: 1.5rem;
+            }
         }
     }
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description

- update MonthlyCostWidget empty case
![image](https://user-images.githubusercontent.com/26986739/213373483-440cb089-2b31-4991-a122-7f636b54422f.png)

- update MonthlyCostWidget loading UI
![image](https://user-images.githubusercontent.com/26986739/213374474-99571558-d377-4bdd-9afc-c55448d9d981.png)

- add skeleton loader to page title when title is empty
![image](https://user-images.githubusercontent.com/26986739/213374604-c7d19b3a-0f57-49d2-ae8a-1d5f8275c9a1.png)



### Things to Talk About
