### PR TITLE
fix: fix chart width and height for blinking map charts

### DIFF
--- a/src/services/dashboards/widgets/aws-data-transfer-by-region/AWSDataTransferByRegionWidget.vue
+++ b/src/services/dashboards/widgets/aws-data-transfer-by-region/AWSDataTransferByRegionWidget.vue
@@ -302,17 +302,18 @@ defineExpose<WidgetExpose<FullData>>({
 .aws-data-transfer-by-region {
     .chart-wrapper {
         height: 10.125rem;
+        margin-bottom: 1rem;
         .chart-loader {
             height: 100%;
             .chart {
                 @apply border border-gray-200;
-                height: 100%;
+                height: calc(100% - 2px);
+                width: calc(100% - 2px);
             }
         }
     }
     .widget-data-table {
-        padding-top: 1rem;
-        height: calc(50% - 1rem);
+        height: 50%;
     }
     &.full {
         .widget-data-table {

--- a/src/services/dashboards/widgets/aws-data-transfer-by-region/AWSDataTransferByRegionWidget.vue
+++ b/src/services/dashboards/widgets/aws-data-transfer-by-region/AWSDataTransferByRegionWidget.vue
@@ -9,35 +9,36 @@
                                           @select="handleSelectSelectorType"
             />
         </template>
-
-        <div class="chart-wrapper">
-            <p-data-loader class="chart-loader"
-                           :loading="state.loading"
-                           :data="state.data"
-                           loader-type="skeleton"
-                           disable-empty-case
-                           :loader-backdrop-opacity="1"
-                           show-data-from-scratch
-            >
-                <div ref="chartContext"
-                     class="chart"
-                />
-            </p-data-loader>
+        <div class="data-container">
+            <div class="chart-wrapper">
+                <p-data-loader class="chart-loader"
+                               :loading="state.loading"
+                               :data="state.data"
+                               loader-type="skeleton"
+                               disable-empty-case
+                               :loader-backdrop-opacity="1"
+                               show-data-from-scratch
+                >
+                    <div ref="chartContext"
+                         class="chart"
+                    />
+                </p-data-loader>
+            </div>
+            <widget-data-table :loading="state.loading"
+                               :fields="state.tableFields"
+                               :items="state.data?.results"
+                               :currency="state.currency"
+                               :currency-rates="props.currencyRates"
+                               :all-reference-type-info="props.allReferenceTypeInfo"
+                               :this-page="state.thisPage"
+                               :show-next-page="state.data?.more"
+                               :legends="state.legends"
+                               :color-set="colorSet"
+                               show-legend
+                               disable-toggle
+                               @update:thisPage="handleUpdateThisPage"
+            />
         </div>
-        <widget-data-table :loading="state.loading"
-                           :fields="state.tableFields"
-                           :items="state.data?.results"
-                           :currency="state.currency"
-                           :currency-rates="props.currencyRates"
-                           :all-reference-type-info="props.allReferenceTypeInfo"
-                           :this-page="state.thisPage"
-                           :show-next-page="state.data?.more"
-                           :legends="state.legends"
-                           :color-set="colorSet"
-                           show-legend
-                           disable-toggle
-                           @update:thisPage="handleUpdateThisPage"
-        />
     </widget-frame>
 </template>
 
@@ -300,9 +301,14 @@ defineExpose<WidgetExpose<FullData>>({
 </script>
 <style lang="postcss" scoped>
 .aws-data-transfer-by-region {
+    .data-container {
+        display: flex;
+        flex-direction: column;
+        row-gap: 1rem;
+        height: 100%;
+    }
     .chart-wrapper {
         height: 10.125rem;
-        margin-bottom: 1rem;
         .chart-loader {
             height: 100%;
             .chart {
@@ -313,7 +319,7 @@ defineExpose<WidgetExpose<FullData>>({
         }
     }
     .widget-data-table {
-        height: 50%;
+        @apply flex-grow;
     }
     &.full {
         .widget-data-table {

--- a/src/services/dashboards/widgets/cost-by-region/CostByRegion.vue
+++ b/src/services/dashboards/widgets/cost-by-region/CostByRegion.vue
@@ -333,7 +333,8 @@ defineExpose<WidgetExpose<FullData>>({
             padding-bottom: 1rem;
             .chart {
                 @apply border border-gray-200;
-                height: 90%;
+                height: calc(90% - 2px);
+                width: calc(100% - 2px);
             }
             .legend-wrapper {
                 .circle-wrapper {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [X] Not that difficult

### Type of Change
- [ ] New feature
- [X] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [X] `Error / Warning / Lint / Type`

### Description
* fix blinking map charts because of adding 1px border to `.chart`

### Things to Talk About
