### PR TITLE
fix(dashboard-pagination): fix wrong property name

### DIFF
--- a/src/services/dashboards/all-dashboards/modules/DashboardBoardList.vue
+++ b/src/services/dashboards/all-dashboards/modules/DashboardBoardList.vue
@@ -3,7 +3,7 @@
         <p-field-title class="p-field-title">
             <template #default>
                 <span>{{ fieldTitle }}</span>
-                <span class="board-count">({{ dashboardList.length }})</span>
+                <span class="board-count">({{ dashboardTotalCount }})</span>
             </template>
         </p-field-title>
         <p-board :board-sets="dashboardListByBoardSets"
@@ -49,12 +49,12 @@
                 </div>
             </template>
         </p-board>
-        <div v-if="dashboardList.length >= 10"
+        <div v-if="dashboardTotalCount >= 10"
              class="dashboard-list-pagination"
         >
-            <p-pagination :total-count="dashboardList.length"
+            <p-pagination :total-count="dashboardTotalCount"
                           :page-size="PAGE_SIZE"
-                          :current-page="thisPage"
+                          :this-page="thisPage"
                           @change="handlePage"
             />
         </div>
@@ -143,6 +143,7 @@ export default defineComponent<DashboardBoardListProps>({
     setup(props) {
         const state = reactive({
             thisPage: 1,
+            dashboardTotalCount: computed<number>(() => props.dashboardList.length ?? 0),
             dashboardScopeKey: computed(() => (props.scopeType === DASHBOARD_SCOPE.DOMAIN ? DOMAIN_SCOPE_KEY : PROJECT_SCOPE_KEY)),
             projectItems: computed(() => store.getters['reference/projectItems']),
             dashboardListByBoardSets: computed<BoardSet[]>(() => props.dashboardList


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
SSIA

Fix wrong prop name. `current-page` => `this-page`

<img width="906" alt="스크린샷 2023-01-22 오후 7 49 15" src="https://user-images.githubusercontent.com/83635051/213911988-e708fedc-d59b-40c7-aa02-db132f91ba74.png">


### Things to Talk About
