### PR TITLE
feat(widget-container): support more specific widget width range

### DIFF
--- a/src/services/dashboards/dashboard-detail/lib/__tests__/index.test.ts
+++ b/src/services/dashboards/dashboard-detail/lib/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest';
 
 import {
     WIDGET_CONTAINER_MAX_WIDTH,
-    WIDGET_CONTAINER_MIN_WIDTH, WIDGET_GAP,
+    WIDGET_CONTAINER_MIN_WIDTH, WIDGET_WIDTH_CRITERIA,
 } from '@/services/dashboards/dashboard-detail/lib/config';
 import { widgetWidthAssigner } from '@/services/dashboards/dashboard-detail/lib/width-helper';
 import type { WidgetSize } from '@/services/dashboards/widgets/_configs/config';
@@ -64,7 +64,7 @@ describe('Assign width for permutation selected widgets', () => {
 
     it('Count of widgets should not be changed after assigning its width', () => {
         for (let caseCount = 0; caseCount < widgetCasesLength; caseCount += 1) {
-            for (let containerWidth = WIDGET_CONTAINER_MIN_WIDTH; containerWidth <= WIDGET_CONTAINER_MAX_WIDTH; containerWidth += WIDGET_GAP) {
+            for (let containerWidth = WIDGET_CONTAINER_MIN_WIDTH; containerWidth <= WIDGET_CONTAINER_MAX_WIDTH; containerWidth += WIDGET_WIDTH_CRITERIA) {
                 assignedWidgetCasesCount = 0;
                 const selectedCase = [...widgetCases[caseCount]];
 

--- a/src/services/dashboards/dashboard-detail/lib/config.ts
+++ b/src/services/dashboards/dashboard-detail/lib/config.ts
@@ -1,8 +1,12 @@
+export const WIDGET_WIDTH_CRITERIA = 16;
+
+const getWidthRangeList = (n: number) => [...Array(36)].map((_, index) => n + index * WIDGET_WIDTH_CRITERIA);
+
 export const WIDGET_WIDTH_RANGE_LIST = {
-    sm: [320, 400, 480],
-    md: [480, 560, 640],
-    lg: [640, 720, 800],
-    xl: [800, 880, 960],
+    sm: getWidthRangeList(320), // 320 ~ 880
+    md: getWidthRangeList(480), // 480 ~ 960
+    lg: getWidthRangeList(640), // 640 ~ 1200
+    xl: getWidthRangeList(800), // 800 ~ 1360
 };
 
 export const WIDGET_CONTAINER_MIN_WIDTH = 320;

--- a/src/services/dashboards/dashboard-detail/lib/width-helper.ts
+++ b/src/services/dashboards/dashboard-detail/lib/width-helper.ts
@@ -1,6 +1,10 @@
 import { sum, max } from 'lodash';
 
-import { WIDGET_WIDTH_RANGE_LIST, WIDGET_GAP } from '@/services/dashboards/dashboard-detail/lib/config';
+import {
+    WIDGET_WIDTH_RANGE_LIST,
+    WIDGET_GAP,
+    WIDGET_WIDTH_CRITERIA,
+} from '@/services/dashboards/dashboard-detail/lib/config';
 import type { WidgetSize } from '@/services/dashboards/widgets/_configs/config';
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/_configs/config';
 
@@ -14,14 +18,14 @@ const isEveryWidthMax = (sizeRow: string[], widthRow: number[]): boolean => size
 const getWidthRow = (sizeRow: string[], containerWidth: number): number[] => {
     const widthRow = sizeRow.map((d) => WIDGET_WIDTH_RANGE_LIST[d][0]);
     let extraWidth = containerWidth - ((widthRow.length - 1) * WIDGET_GAP) - sum(widthRow);
-    if (extraWidth < 80) return widthRow;
+    if (extraWidth < WIDGET_WIDTH_CRITERIA) return widthRow;
 
-    while (extraWidth >= 80 && !isEveryWidthMax(sizeRow, widthRow)) {
+    while (extraWidth >= WIDGET_WIDTH_CRITERIA && !isEveryWidthMax(sizeRow, widthRow)) {
         // eslint-disable-next-line no-loop-func
         sizeRow.forEach((size, idx) => {
             const maxWidth = max(WIDGET_WIDTH_RANGE_LIST[size]) as number;
-            if (maxWidth > widthRow[idx] && extraWidth >= 80) widthRow[idx] += 80;
-            extraWidth -= 80;
+            if (maxWidth > widthRow[idx] && extraWidth >= WIDGET_WIDTH_CRITERIA) widthRow[idx] += WIDGET_WIDTH_CRITERIA;
+            extraWidth -= WIDGET_WIDTH_CRITERIA;
         });
     }
     return widthRow;

--- a/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
+++ b/src/services/dashboards/dashboard-detail/modules/DashboardWidgetContainer.vue
@@ -47,7 +47,7 @@ import type { AllReferenceTypeInfo } from '@/store/modules/reference/type';
 
 import type { DashboardSettings } from '@/services/dashboards/config';
 import {
-    WIDGET_CONTAINER_MAX_WIDTH, WIDGET_CONTAINER_MIN_WIDTH,
+    WIDGET_CONTAINER_MAX_WIDTH, WIDGET_CONTAINER_MIN_WIDTH, WIDGET_WIDTH_CRITERIA,
 } from '@/services/dashboards/dashboard-detail/lib/config';
 import { widgetThemeAssigner } from '@/services/dashboards/dashboard-detail/lib/theme-helper';
 import { widgetWidthAssigner } from '@/services/dashboards/dashboard-detail/lib/width-helper';
@@ -125,7 +125,7 @@ export default defineComponent<Props>({
         const refineContainerWidth = (containerWidth: number|undefined): number => {
             if (!containerWidth || containerWidth < WIDGET_CONTAINER_MIN_WIDTH) return WIDGET_CONTAINER_MIN_WIDTH;
             if (containerWidth > WIDGET_CONTAINER_MAX_WIDTH) return WIDGET_CONTAINER_MAX_WIDTH;
-            return containerWidth - (containerWidth % 16);
+            return containerWidth - (containerWidth % WIDGET_WIDTH_CRITERIA);
         };
 
         const handleIntersectionObserver = async ([{ isIntersecting, target }]) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

For less losing teeth,


1. Widget width range was supported by `+80px` -> `+16px`
as-is: sm: 320, 400, 480
to-be: sm: 320, 336, 352, 368 ... 464, 480 

2. Widget max width was `default + 160px`-> `default + 560px`
as-is: 
- sm: 320 ~ 480
- md: 480 ~ 640
  ...
to-be: 
- sm: 320 ~ 880 
- md: 480 ~ 960
 ...

Please look below beautiful screenshot.
![스크린샷 2023-01-25 오후 5 00 30](https://user-images.githubusercontent.com/29014433/214509848-1858fca0-b6b8-4132-a3c9-c01e818c4532.png)



### Things to Talk About
