### PR TITLE
fix(notice): allow popup/pin for domain_admin

### DIFF
--- a/src/lib/access-control/page-permission-helper.ts
+++ b/src/lib/access-control/page-permission-helper.ts
@@ -20,6 +20,7 @@ import type { RoleType } from '@/services/administration/iam/role/config';
 export const getDefaultPagePermissionList = (isDomainOwner: boolean, roleType?: RoleType): PagePermissionTuple[] => {
     if (isDomainOwner) return DOMAIN_OWNER_DEFAULT_PERMISSIONS;
     if (roleType === 'SYSTEM') return SYSTEM_USER_DEFAULT_PERMISSIONS;
+    // FIXME:: DOMAIN_VIEWER should not get ADMIN_PERMISSION.
     if (roleType === 'DOMAIN') return ADMIN_USER_DEFAULT_PERMISSIONS;
     if (roleType === 'PROJECT') return PROJECT_USER_DEFAULT_PERMISSIONS;
     return NO_ROLE_USER_DEFAULT_PERMISSIONS;

--- a/src/lib/menu/menu-info.ts
+++ b/src/lib/menu/menu-info.ts
@@ -135,6 +135,5 @@ export const MENU_INFO_MAP: Record<MenuId, MenuInfo> = Object.freeze({
     [MENU_ID.INFO_NOTICE]: {
         translationId: 'MENU.INFO_NOTICE',
         isNew: true,
-        needPermissionByRole: true,
     },
 });

--- a/src/lib/menu/menu-info.ts
+++ b/src/lib/menu/menu-info.ts
@@ -135,5 +135,6 @@ export const MENU_INFO_MAP: Record<MenuId, MenuInfo> = Object.freeze({
     [MENU_ID.INFO_NOTICE]: {
         translationId: 'MENU.INFO_NOTICE',
         isNew: true,
+        needPermissionByRole: true,
     },
 });

--- a/src/services/info/notice/modules/NoticeForm.vue
+++ b/src/services/info/notice/modules/NoticeForm.vue
@@ -69,7 +69,7 @@
                     />
                 </template>
             </p-field-group>
-            <div v-if="hasSystemRole"
+            <div v-if="hasSystemRole || hasDomainRole"
                  class="notice-create-options-wrapper"
             >
                 <p-check-box v-model="isPinned">
@@ -163,6 +163,7 @@ export default {
     setup(props) {
         const state = reactive({
             hasSystemRole: computed<boolean>(() => store.getters['user/hasSystemRole']),
+            hasDomainRole: computed<boolean>(() => store.getters['user/hasDomainRole']),
             userName: computed<string>(() => store.state.user.name),
             isPinned: false,
             isPopup: false,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

![스크린샷 2023-01-25 오후 6 47 38](https://user-images.githubusercontent.com/29014433/214531245-671b0380-0053-45f2-ae64-45ab79b372ca.png)


Resolves #332 

Every feature is working fine. 

### Things to Talk About

There is a problem that,
`DOMAIN_VIEWER` would have `ADMIN_PERMISSION`.
So, `DOMAIN_VIEWER` can access to notice create page. 😱
But create api is not working for them 👍 