### PR TITLE
refactor: do not use reference key as widget schema property key

### DIFF
--- a/src/lib/reference/reference-config.ts
+++ b/src/lib/reference/reference-config.ts
@@ -1,0 +1,62 @@
+export const REFERENCE_TYPE_INFO = {
+    project_group: {
+        type: 'project_group',
+        key: 'project_group_id',
+        name: 'Project Group',
+    },
+    project: {
+        type: 'project',
+        key: 'project_id',
+        name: 'Project',
+    },
+    protocol: {
+        type: 'protocol',
+        key: 'protocol_id',
+        name: 'Protocol',
+    },
+    cloud_service_type: {
+        type: 'cloud_service_type',
+        key: 'cloud_service_type',
+        name: 'Cloud Service Type',
+    },
+    collector: {
+        type: 'collector',
+        key: 'collector_id',
+        name: 'Collector',
+    },
+    plugin: {
+        type: 'plugin',
+        key: 'plugin_id',
+        name: 'Plugin',
+    },
+    provider: {
+        type: 'provider',
+        key: 'provider',
+        name: 'Provider',
+    },
+    region: {
+        type: 'region',
+        key: 'region_code',
+        name: 'Region',
+    },
+    secret: {
+        type: 'secret',
+        key: 'secret_id',
+        name: 'Secret',
+    },
+    service_account: {
+        type: 'service_account',
+        key: 'service_account_id',
+        name: 'Service Account',
+    },
+    user: {
+        type: 'user',
+        key: 'user_id',
+        name: 'User',
+    },
+    webhook: {
+        type: 'webhook',
+        key: 'webhook_id',
+        name: 'Webhook',
+    },
+} as const;

--- a/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
+++ b/src/services/dashboards/dashboard-customize/modules/VariableMoreButtonDropdown.vue
@@ -69,14 +69,14 @@ const state = reactive({
     variableList: computed<MenuItem[]>(() => state.variableSchema.order.map((property) => {
         const currentProperty = state.variableSchema.properties[property];
         return ({
-            name: property, label: currentProperty.name,
+            name: property, label: currentProperty?.name ?? property,
         });
     })),
     selected: computed<MenuItem[]>(() => {
         const result = [] as MenuItem[];
         state.variableSchema.order.forEach((property) => {
             const currentProperty = state.variableSchema.properties[property];
-            if (!currentProperty.use) return;
+            if (!currentProperty?.use) return;
             result.push({ name: property, label: currentProperty.name });
         });
         return result;

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
@@ -106,7 +106,7 @@ const state = reactive({
     selectedVariable: '' as string,
     variableNames: computed<string[]>(() => {
         const properties = state.variableSchema.properties;
-        return state.variableSchema.order.map((d) => properties[d].name).filter((name) => name !== properties[state.selectedVariable]?.name);
+        return state.variableSchema.order.map((d) => properties[d]?.name).filter((name) => name !== properties[state.selectedVariable]?.name);
     }),
 });
 

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -26,6 +26,7 @@
                                 :form-data.sync="schemaFormData"
                                 :custom-error-map="inheritOptionsErrorMap"
                                 :validation-mode="widgetKey ? 'all' : 'input'"
+                                use-fixed-menu-style
                                 class="widget-options-form"
                                 @validate="handleFormValidate"
             >
@@ -78,7 +79,7 @@ import DashboardWidgetMoreOptions
     from '@/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetMoreOptions.vue';
 import {
     getRefinedWidgetOptionsSchema, getWidgetOptionSchema,
-} from '@/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/helpers';
+} from '@/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/schema-helpers';
 import { useWidgetFormStore } from '@/services/dashboards/dashboard-customize/stores/widget-form';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/dashboard-detail/store/dashboard-detail-info';
 import type {

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -195,8 +195,6 @@ export default defineComponent<Props>({
                     Object.entries((optionValue ?? {}) as WidgetFiltersMap).forEach(([key, value]) => {
                         if (Array.isArray(value)) {
                             formData[`filters.${key}`] = value.map((filter) => filter.v).flat();
-                        } else {
-                            formData[`filters.${key}`] = value.v;
                         }
                     });
                 } else {

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-reference-store.ts
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-reference-store.ts
@@ -12,10 +12,10 @@ export const useReferenceStore = () => {
     const referenceStoreState = reactive({
         loading: true,
         provider: computed<ProviderReferenceMap>(() => store.getters['reference/providerItems']),
-        project_id: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
-        project_group_id: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
-        service_account_id: computed<ServiceAccountReferenceMap>(() => store.getters['reference/serviceAccountItems']),
-        region_code: computed<RegionReferenceMap>(() => store.getters['reference/regionItems']),
+        project: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
+        project_group: computed<ProjectGroupReferenceMap>(() => store.getters['reference/projectGroupItems']),
+        service_account: computed<ServiceAccountReferenceMap>(() => store.getters['reference/serviceAccountItems']),
+        region: computed<RegionReferenceMap>(() => store.getters['reference/regionItems']),
     });
     (async () => {
         referenceStoreState.loading = true;

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/schema-helpers.ts
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/schema-helpers.ts
@@ -95,7 +95,7 @@ export const getRefinedWidgetOptionsSchema = (
         type: 'object',
         properties: {},
         required: schema?.required ?? [],
-        order: defaultSchemaProperties as WidgetOptionsSchemaProperty[],
+        order: schema?.order ?? defaultSchemaProperties as WidgetOptionsSchemaProperty[],
     };
     if (!schema?.properties) return refinedJsonSchema;
 

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/schema-helpers.ts
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/schema-helpers.ts
@@ -7,7 +7,11 @@ import type { DashboardVariablesSchema } from '@/services/dashboards/config';
 import type {
     useReferenceStore,
 } from '@/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/composables/use-reference-store';
-import type { InheritOptions, WidgetOptionsSchema } from '@/services/dashboards/widgets/_configs/config';
+import type {
+    InheritOptions,
+    WidgetOptionsSchema,
+    WidgetOptionsSchemaProperty,
+} from '@/services/dashboards/widgets/_configs/config';
 
 type ReferenceStoreState = ReturnType<typeof useReferenceStore>['referenceStoreState'];
 
@@ -84,15 +88,15 @@ export const getRefinedWidgetOptionsSchema = (
     variablesSchema: DashboardVariablesSchema,
     inheritOptions: InheritOptions,
     defaultSchemaProperties: string[],
-): JsonSchema => {
+): WidgetOptionsSchema['schema'] => {
     const schema = widgetOptionsSchema?.schema;
 
-    const refinedJsonSchema = {
+    const refinedJsonSchema: WidgetOptionsSchema['schema'] = {
         type: 'object',
         properties: {},
         required: schema?.required ?? [],
-        order: defaultSchemaProperties,
-    } as JsonSchema;
+        order: defaultSchemaProperties as WidgetOptionsSchemaProperty[],
+    };
     if (!schema?.properties) return refinedJsonSchema;
 
     // refine each property schema

--- a/src/services/dashboards/managed-variables-schema.ts
+++ b/src/services/dashboards/managed-variables-schema.ts
@@ -1,43 +1,52 @@
+import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
+
 import type { DashboardVariablesSchema } from '@/services/dashboards/config';
 
 export const managedDashboardVariablesSchema: DashboardVariablesSchema = {
     properties: {
-        project: {
-            name: 'Project',
+        [REFERENCE_TYPE_INFO.project.type]: {
+            name: REFERENCE_TYPE_INFO.project.name,
             variable_type: 'MANAGED',
             use: true,
             selection_type: 'MULTI',
         },
-        provider: {
-            name: 'Provider',
+        [REFERENCE_TYPE_INFO.provider.type]: {
+            name: REFERENCE_TYPE_INFO.provider.name,
             variable_type: 'MANAGED',
             use: true,
             selection_type: 'MULTI',
         },
-        serviceAccount: {
-            name: 'Service Account',
+        [REFERENCE_TYPE_INFO.service_account.type]: {
+            name: REFERENCE_TYPE_INFO.service_account.name,
             variable_type: 'MANAGED',
             use: true,
             selection_type: 'MULTI',
         },
-        user: {
-            name: 'User',
+        [REFERENCE_TYPE_INFO.user.type]: {
+            name: REFERENCE_TYPE_INFO.user.name,
             variable_type: 'MANAGED',
             use: false,
             selection_type: 'MULTI',
         },
-        cloudServiceType: {
-            name: 'Cloud Service Type',
+        [REFERENCE_TYPE_INFO.cloud_service_type.type]: {
+            name: REFERENCE_TYPE_INFO.cloud_service_type.name,
             variable_type: 'MANAGED',
             use: false,
             selection_type: 'MULTI',
         },
-        region: {
-            name: 'Region',
+        [REFERENCE_TYPE_INFO.region.type]: {
+            name: REFERENCE_TYPE_INFO.region.name,
             variable_type: 'MANAGED',
             use: false,
             selection_type: 'MULTI',
         },
     },
-    order: ['project', 'provider', 'serviceAccount', 'user', 'cloudServiceType', 'region'],
+    order: [
+        REFERENCE_TYPE_INFO.project.type,
+        REFERENCE_TYPE_INFO.provider.type,
+        REFERENCE_TYPE_INFO.service_account.type,
+        REFERENCE_TYPE_INFO.user.type,
+        REFERENCE_TYPE_INFO.cloud_service_type.type,
+        REFERENCE_TYPE_INFO.region.type,
+    ],
 };

--- a/src/services/dashboards/widgets/__tests__/widget-helper.test.ts
+++ b/src/services/dashboards/widgets/__tests__/widget-helper.test.ts
@@ -33,21 +33,21 @@ describe('[Widget Helper] getWidgetConfig', () => {
         expect(mergedCostPieConfig.options_schema?.schema?.properties['filters.provider']).toBeTruthy();
     });
     it('Merge default_properties of base trend config', () => {
-        const mergedBaseTrendConfig = getWidgetConfig(costTrendConfigId);
+        const mergedBaseTrendConfig = getWidgetConfig(costTrendConfigId as string);
         expect(mergedBaseTrendConfig?.options_schema?.default_properties).toEqual(expect.arrayContaining([
-            'filters.provider', 'filters.project_id', 'filters.service_account_id',
+            'filters.provider', 'filters.project', 'filters.service_account',
         ]));
     });
     it('test MonthlyCostWidget', () => {
         const mergedMonthlyCostWidgetConfig = getWidgetConfig(monthlyCostWidgetConfigId);
         expect(mergedMonthlyCostWidgetConfig?.options_schema?.default_properties).toEqual(expect.arrayContaining([
-            'filters.provider', 'filters.project_id', 'filters.service_account_id',
+            'filters.provider', 'filters.project', 'filters.service_account',
         ]));
     });
     it('test CostMapWidget', () => {
         const mergedCostMapWidgetConfig = getWidgetConfig(costMapWidgetConfigId);
         expect(mergedCostMapWidgetConfig?.options_schema?.default_properties).toEqual(expect.arrayContaining([
-            'group_by', 'filters.provider', 'filters.project_id', 'filters.service_account_id',
+            'group_by', 'filters.provider', 'filters.project', 'filters.service_account',
         ]));
     });
 });

--- a/src/services/dashboards/widgets/_configs/config.ts
+++ b/src/services/dashboards/widgets/_configs/config.ts
@@ -98,7 +98,7 @@ interface LegendOptions {
 /* widget filters */
 export interface WidgetFilter {
     k?: string;
-    v: null|string|boolean|number;
+    v: null|string|boolean|number|Array<null|string|boolean|number>;
     o?: ConsoleFilterOperator;
 }
 export const WIDGET_FILTER_KEYS = [

--- a/src/services/dashboards/widgets/_configs/widget-schema-config.ts
+++ b/src/services/dashboards/widgets/_configs/widget-schema-config.ts
@@ -1,0 +1,62 @@
+import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
+
+import { GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
+import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/_configs/view-config';
+
+export const RESOURCE_REFERENCE_SCHEMA = {
+    [REFERENCE_TYPE_INFO.provider.type]: {
+        title: REFERENCE_TYPE_INFO.provider.name,
+        type: 'array',
+    },
+    [REFERENCE_TYPE_INFO.project.type]: {
+        title: REFERENCE_TYPE_INFO.project.name,
+        type: 'array',
+    },
+    [REFERENCE_TYPE_INFO.service_account.type]: {
+        title: REFERENCE_TYPE_INFO.service_account.name,
+        type: 'array',
+    },
+    [REFERENCE_TYPE_INFO.project_group.type]: {
+        title: REFERENCE_TYPE_INFO.project_group.name,
+        type: 'array',
+    },
+    [REFERENCE_TYPE_INFO.region.type]: {
+        title: REFERENCE_TYPE_INFO.region.name,
+        type: 'array',
+    },
+} as const;
+
+export const COST_REFERENCE_SCHEMA = {
+    [GROUP_BY.CATEGORY]: {
+        title: 'Category',
+        type: 'array',
+        reference: 'cost_analysis.Cost',
+    },
+    [GROUP_BY.RESOURCE_GROUP]: {
+        title: 'Resource Group',
+        type: 'array',
+        reference: 'cost_analysis.Cost',
+    },
+    [GROUP_BY.PRODUCT]: {
+        title: 'Product',
+        type: 'array',
+        reference: 'cost_analysis.Cost',
+    },
+    [GROUP_BY.TYPE]: {
+        title: 'Type',
+        type: 'array',
+        reference: 'cost_analysis.Cost',
+    },
+    [GROUP_BY.ACCOUNT]: {
+        title: 'Account ID',
+        type: 'array',
+        reference: 'cost_analysis.Cost',
+    },
+} as const;
+
+export const GROUP_BY_SCHEMA = {
+    title: 'Group by',
+    type: 'string',
+    enum: Object.values(GROUP_BY),
+    menuItems: Object.values(GROUP_BY_ITEM_MAP),
+};

--- a/src/services/dashboards/widgets/_helpers/widget-filters-helper.ts
+++ b/src/services/dashboards/widgets/_helpers/widget-filters-helper.ts
@@ -1,0 +1,9 @@
+import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
+
+export const getWidgetFilterDataKey = (filterKey: string) => {
+    const resourceReference = REFERENCE_TYPE_INFO[filterKey];
+    if (resourceReference) {
+        return resourceReference.key;
+    }
+    return filterKey;
+};

--- a/src/services/dashboards/widgets/_helpers/widget-schema-helper.ts
+++ b/src/services/dashboards/widgets/_helpers/widget-schema-helper.ts
@@ -1,0 +1,44 @@
+import type { JsonSchema } from '@spaceone/design-system/types/inputs/forms/json-schema-form/type';
+
+import type {
+    WidgetFilterKey,
+    WidgetFiltersSchemaProperty,
+    WidgetOptionsSchemaProperty,
+} from '@/services/dashboards/widgets/_configs/config';
+import {
+    COST_REFERENCE_SCHEMA, GROUP_BY_SCHEMA,
+    RESOURCE_REFERENCE_SCHEMA,
+} from '@/services/dashboards/widgets/_configs/widget-schema-config';
+
+
+export const getWidgetOptionsSchema = (...optionNames: WidgetOptionsSchemaProperty[]): object => {
+    const result: JsonSchema['properties'] = {};
+
+    optionNames.forEach((optionName) => {
+        if (optionName === 'group_by') result.group_by = GROUP_BY_SCHEMA;
+        else if (optionName.startsWith('filters.')) {
+            const filterKey = optionName.replace('filters.', '');
+            const filterSchema = getWidgetFilterOptionsSchema(filterKey as WidgetFilterKey);
+            if (filterSchema[optionName]) result[optionName] = filterSchema[optionName];
+        } else {
+            console.error(`No matched option schema for ${optionName}`);
+        }
+    });
+
+    return result;
+};
+
+export const getWidgetFilterOptionsSchema = (...filterKeys: WidgetFilterKey[]): object => {
+    const result: JsonSchema['properties'] = {};
+
+    filterKeys.forEach((optionName) => {
+        if (RESOURCE_REFERENCE_SCHEMA[optionName]) result[`filters.${optionName}`] = RESOURCE_REFERENCE_SCHEMA[optionName];
+        else if (COST_REFERENCE_SCHEMA[optionName]) result[`filters.${optionName}`] = COST_REFERENCE_SCHEMA[optionName];
+        else console.error(`No matched filter option schema for ${optionName}`);
+    });
+
+    return result;
+};
+
+
+export const getWidgetFilterSchemaPropertyNames = (...keys: WidgetFilterKey[]): WidgetFiltersSchemaProperty[] => keys.map((key) => `filters.${key}` as WidgetFiltersSchemaProperty);

--- a/src/services/dashboards/widgets/_helpers/widget-validation-helper.ts
+++ b/src/services/dashboards/widgets/_helpers/widget-validation-helper.ts
@@ -32,7 +32,7 @@ export const getWidgetInheritOptionsErrorMap = (
         }
 
         const variableType = dashboardVariablesSchema.properties[variableKey].selection_type === 'MULTI' ? 'array' : 'string';
-        const widgetPropertyType = widgetOptionsSchema.properties[propertyName].type;
+        const widgetPropertyType = widgetOptionsSchema?.properties?.[propertyName]?.type;
         if (variableType !== widgetPropertyType) {
             errorMap[propertyName] = i18n.t('DASHBOARDS.WIDGET.VALIDATION_PROPERTY_NOT_EXIST');
         }

--- a/src/services/dashboards/widgets/_hooks/use-widget-state.ts
+++ b/src/services/dashboards/widgets/_hooks/use-widget-state.ts
@@ -12,6 +12,8 @@ import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import type { Currency } from '@/store/modules/display/config';
 import { CURRENCY } from '@/store/modules/display/config';
 
+import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
+
 import type { ChartType } from '@/services/cost-explorer/cost-dashboard/type';
 import type { DashboardSettings, DashboardVariables } from '@/services/dashboards/config';
 import type {
@@ -22,7 +24,6 @@ import type {
     WidgetFiltersMap,
     WidgetFilter,
 } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
 import { getWidgetFilterDataKey } from '@/services/dashboards/widgets/_helpers/widget-filters-helper';
 import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
 import type { InheritOptionsErrorMap } from '@/services/dashboards/widgets/_helpers/widget-validation-helper';
@@ -77,15 +78,16 @@ const getConvertedBudgetConsoleFilters = (widgetFiltersMap: WidgetFiltersMap): C
     const results: ConsoleFilter[] = [];
     Object.entries(widgetFiltersMap).forEach(([filterKey, filterItems]) => {
         if (!filterItems?.length) return;
-        if ((filterKey === GROUP_BY.PROJECT || filterKey === GROUP_BY.PROJECT_GROUP)) {
+        if ((filterKey === REFERENCE_TYPE_INFO.project.type || filterKey === REFERENCE_TYPE_INFO.project_group.type)) {
             filterItems.forEach((d) => {
                 results.push(d);
             });
         } else {
             filterItems.forEach((d) => {
+                const value = Array.isArray(d.v) ? d.v : [d.v];
                 results.push({
-                    k: `cost_types.${filterKey}`,
-                    v: [null, ...d.v],
+                    k: `cost_types.${d.k}`,
+                    v: [null, ...value],
                     o: d.o,
                 });
             });

--- a/src/services/dashboards/widgets/_hooks/use-widget-state.ts
+++ b/src/services/dashboards/widgets/_hooks/use-widget-state.ts
@@ -20,8 +20,10 @@ import type {
     Granularity, GroupBy,
     SelectorType,
     WidgetFiltersMap,
+    WidgetFilter,
 } from '@/services/dashboards/widgets/_configs/config';
 import { GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
+import { getWidgetFilterDataKey } from '@/services/dashboards/widgets/_helpers/widget-filters-helper';
 import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
 import type { InheritOptionsErrorMap } from '@/services/dashboards/widgets/_helpers/widget-validation-helper';
 import { getWidgetInheritOptionsErrorMap } from '@/services/dashboards/widgets/_helpers/widget-validation-helper';
@@ -59,12 +61,11 @@ const convertInheritOptionsToWidgetFiltersMap = (
 
         if (filterKey.startsWith('filters.')) {
             const _filterKey = filterKey.replace('filters.', '');
-            if (variableValue) {
-                result.filters = {
-                    ...result.filters,
-                    [_filterKey]: [{ k: _filterKey, v: variableValue, o: '=' }],
-                };
-            }
+            const filterDataKey = getWidgetFilterDataKey(_filterKey);
+            result.filters = {
+                ...result.filters,
+                [_filterKey]: [{ k: filterDataKey, v: variableValue, o: '=' }],
+            };
         } else {
             result[filterKey] = variableValue;
         }
@@ -167,9 +168,9 @@ export function useWidgetState<Data = any>(
             if (state.options?.pagination_options?.enabled) return state.options.pagination_options.page_size;
             return undefined;
         }),
-        consoleFilters: computed(() => {
+        consoleFilters: computed<WidgetFilter[]>(() => {
             if (!state.options?.filters || isEmpty(state.options.filters)) return [];
-            return flattenDeep(Object.values(state.options.filters));
+            return flattenDeep<WidgetFilter[]>(Object.values(state.options.filters));
         }),
         budgetConsoleFilters: computed(() => {
             if (!state.options?.filters || isEmpty(state.options.filters)) return [];

--- a/src/services/dashboards/widgets/aws-cloud-front-cost/widget-config.ts
+++ b/src/services/dashboards/widgets/aws-cloud-front-cost/widget-config.ts
@@ -1,7 +1,10 @@
 import { GRANULARITY } from '@/services/dashboards/config';
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
 import { CHART_TYPE, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/_configs/view-config';
+import {
+    getWidgetFilterOptionsSchema, getWidgetFilterSchemaPropertyNames,
+    getWidgetOptionsSchema,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 
 const awsCloudFrontCostWidgetConfig: WidgetConfig = {
@@ -39,38 +42,15 @@ const awsCloudFrontCostWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: ['group_by', `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('project', 'service_account')],
         schema: {
             type: 'object',
             properties: {
-                group_by: {
-                    title: 'Group by',
-                    type: 'string',
-                    enum: Object.values(GROUP_BY),
-                    menuItems: Object.values(GROUP_BY_ITEM_MAP),
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
+                ...getWidgetOptionsSchema('group_by'),
+                ...getWidgetFilterOptionsSchema('project', 'service_account', 'project_group', 'region', 'account'),
             },
             required: ['group_by'],
+            order: ['group_by', ...getWidgetFilterSchemaPropertyNames('project', 'service_account', 'project_group', 'region', 'account')],
         },
     },
 };

--- a/src/services/dashboards/widgets/aws-data-transfer-by-region/widget-config.ts
+++ b/src/services/dashboards/widgets/aws-data-transfer-by-region/widget-config.ts
@@ -1,5 +1,9 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
 import { CHART_TYPE, GRANULARITY, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 
 const awsDataTransferByRegionWidgetConfig: WidgetConfig = {
@@ -36,31 +40,11 @@ const awsDataTransferByRegionWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: [`filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: getWidgetFilterSchemaPropertyNames('project', 'service_account'),
         schema: {
             type: 'object',
-            properties: {
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
-            },
+            properties: getWidgetFilterOptionsSchema('project', 'service_account', 'project_group', 'region', 'account'),
+            order: getWidgetFilterSchemaPropertyNames('project', 'service_account', 'project_group', 'region', 'account'),
         },
     },
 };

--- a/src/services/dashboards/widgets/aws-data-transfer-cost-trend/widget-config.ts
+++ b/src/services/dashboards/widgets/aws-data-transfer-cost-trend/widget-config.ts
@@ -1,6 +1,10 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
 import { CHART_TYPE, GRANULARITY, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/_configs/view-config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+    getWidgetOptionsSchema,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 
 const awsDataTransferCostTrendWidgetConfig: WidgetConfig = {
@@ -34,38 +38,15 @@ const awsDataTransferCostTrendWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: ['group_by', `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('project', 'service_account')],
         schema: {
             type: 'object',
             properties: {
-                group_by: {
-                    title: 'Group by',
-                    type: 'string',
-                    enum: Object.values(GROUP_BY),
-                    menuItems: Object.values(GROUP_BY_ITEM_MAP),
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
+                ...getWidgetOptionsSchema('group_by'),
+                ...getWidgetFilterOptionsSchema('project', 'service_account', 'project_group', 'region', 'account'),
             },
             required: ['group_by'],
+            order: ['group_by', ...getWidgetFilterSchemaPropertyNames('project', 'service_account', 'project_group', 'region', 'account')],
         },
     },
 };

--- a/src/services/dashboards/widgets/budget-status/widget-config.ts
+++ b/src/services/dashboards/widgets/budget-status/widget-config.ts
@@ -1,6 +1,10 @@
 import { GRANULARITY } from '@/services/dashboards/config';
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
-import { CHART_TYPE, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
+import { CHART_TYPE } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const budgetStatusWidgetConfig: WidgetConfig = {
     widget_config_id: 'budgetStatus',
@@ -24,31 +28,11 @@ const budgetStatusWidgetConfig: WidgetConfig = {
         group_by: 'budget_id',
     },
     options_schema: {
-        default_properties: [`filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`],
+        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project'),
         schema: {
             type: 'object',
-            properties: {
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-            },
+            properties: getWidgetFilterOptionsSchema('provider', 'project', 'service_account', 'product', 'region'),
+            order: getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account', 'product', 'region'),
         },
     },
 };

--- a/src/services/dashboards/widgets/budget-usage-by-target/widget-config.ts
+++ b/src/services/dashboards/widgets/budget-usage-by-target/widget-config.ts
@@ -1,6 +1,9 @@
 import { GRANULARITY } from '@/services/dashboards/config';
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const budgetUsageByTargetWidgetConfig: WidgetConfig = {
     widget_config_id: 'budgetUsageByTarget',
@@ -23,31 +26,11 @@ const budgetUsageByTargetWidgetConfig: WidgetConfig = {
         group_by: 'budget_id',
     },
     options_schema: {
-        default_properties: [`filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`],
+        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project'),
         schema: {
             type: 'object',
-            properties: {
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-            },
+            properties: getWidgetFilterOptionsSchema('provider', 'project', 'service_account', 'product', 'region'),
+            order: getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account', 'product', 'region'),
         },
     },
 } as WidgetConfig;

--- a/src/services/dashboards/widgets/budget-usage-summary/widget-config.ts
+++ b/src/services/dashboards/widgets/budget-usage-summary/widget-config.ts
@@ -1,5 +1,9 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
-import { GRANULARITY, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
+import { GRANULARITY } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const budgetUsageSummaryConfig: WidgetConfig = {
     widget_config_id: 'budgetUsageSummary',
@@ -22,31 +26,11 @@ const budgetUsageSummaryConfig: WidgetConfig = {
         granularity: GRANULARITY.ACCUMULATED,
     },
     options_schema: {
-        default_properties: [`filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`],
+        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project'),
         schema: {
             type: 'object',
-            properties: {
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-            },
+            properties: getWidgetFilterOptionsSchema('provider', 'project', 'service_account', 'product', 'region'),
+            order: getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account', 'product', 'region'),
         },
     },
 };

--- a/src/services/dashboards/widgets/cost-analysis-query/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-analysis-query/widget-config.ts
@@ -1,6 +1,5 @@
-import { CHART_TYPE } from '@/services/cost-explorer/cost-analysis/type';
-import { GRANULARITY, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
+import { getWidgetOptionsSchema } from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const costAnalysisQueryWidgetConfig: WidgetConfig = {
     widget_config_id: 'costAnalysisQuery',
@@ -20,23 +19,20 @@ const costAnalysisQueryWidgetConfig: WidgetConfig = {
         schema: {
             type: 'object',
             properties: {
-                group_by: {
-                    type: 'string',
-                    enum: Object.values(GROUP_BY),
-                },
-                granularity: {
-                    type: 'string',
-                    enum: Object.values(GRANULARITY),
-                },
-                chart_type: {
-                    type: 'string',
-                    enum: Object.values(CHART_TYPE),
-                },
-                stacked: {
-                    type: 'boolean',
-                },
+                ...getWidgetOptionsSchema('group_by'),
+                // granularity: {
+                //     type: 'string',
+                //     enum: Object.values(GRANULARITY),
+                // },
+                // chart_type: {
+                //     type: 'string',
+                //     enum: Object.values(CHART_TYPE),
+                // },
+                // stacked: {
+                //     type: 'boolean',
+                // },
             },
-            required: ['group_by', 'granularity', 'chart_type'],
+            // required: ['group_by', 'granularity', 'chart_type'],
         },
     },
 };

--- a/src/services/dashboards/widgets/cost-by-region/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-by-region/widget-config.ts
@@ -1,5 +1,9 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
 import { CHART_TYPE, GRANULARITY, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const costByRegionWidgetConfig: WidgetConfig = {
     widget_config_id: 'costByRegion',
@@ -31,47 +35,31 @@ const costByRegionWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: [`filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account'),
         schema: {
             type: 'object',
-            properties: {
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.CATEGORY}`]: {
-                    title: 'Category',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.RESOURCE_GROUP}`]: {
-                    title: 'Resource Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
-            },
+            properties: getWidgetFilterOptionsSchema(
+                'provider',
+                'project',
+                'service_account',
+                'project_group',
+                'category',
+                'resource_group',
+                'product',
+                'region',
+                'account',
+            ),
+            order: getWidgetFilterSchemaPropertyNames(
+                'provider',
+                'project',
+                'service_account',
+                'project_group',
+                'category',
+                'resource_group',
+                'product',
+                'region',
+                'account',
+            ),
         },
     },
 };

--- a/src/services/dashboards/widgets/cost-donut/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-donut/widget-config.ts
@@ -1,6 +1,9 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
-import { CHART_TYPE, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/_configs/view-config';
+import { CHART_TYPE } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema, getWidgetFilterSchemaPropertyNames,
+    getWidgetOptionsSchema,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const costDonutWidgetConfig: Partial<WidgetConfig> = {
     widget_config_id: 'costDonut',
@@ -15,58 +18,37 @@ const costDonutWidgetConfig: Partial<WidgetConfig> = {
         chart_type: CHART_TYPE.DONUT,
     },
     options_schema: {
-        default_properties: ['group_by', `filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account')],
         schema: {
             type: 'object',
             properties: {
-                group_by: {
-                    title: 'Group by',
-                    type: 'string',
-                    enum: Object.values(GROUP_BY),
-                    menuItems: Object.values(GROUP_BY_ITEM_MAP),
-                },
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.CATEGORY}`]: {
-                    title: 'Category',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.RESOURCE_GROUP}`]: {
-                    title: 'Resource Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.TYPE}`]: {
-                    title: 'Type',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
+                ...getWidgetOptionsSchema('group_by'),
+                ...getWidgetFilterOptionsSchema(
+                    'provider',
+                    'project',
+                    'service_account',
+                    'project_group',
+                    'category',
+                    'resource_group',
+                    'product',
+                    'region',
+                    'usage_type',
+                    'account',
+                ),
             },
             required: ['group_by'],
+            order: ['group_by', ...getWidgetFilterSchemaPropertyNames(
+                'provider',
+                'project',
+                'service_account',
+                'project_group',
+                'category',
+                'resource_group',
+                'product',
+                'region',
+                'usage_type',
+                'account',
+            )],
         },
     },
 };

--- a/src/services/dashboards/widgets/cost-map/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-map/widget-config.ts
@@ -1,6 +1,9 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
 import { GRANULARITY, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/_configs/view-config';
+import {
+    getWidgetFilterOptionsSchema, getWidgetFilterSchemaPropertyNames,
+    getWidgetOptionsSchema,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const costMapWidgetConfig: WidgetConfig = {
     widget_config_id: 'costMap',
@@ -24,58 +27,37 @@ const costMapWidgetConfig: WidgetConfig = {
         granularity: GRANULARITY.ACCUMULATED,
     },
     options_schema: {
-        default_properties: ['group_by', `filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account')],
         schema: {
             type: 'object',
             properties: {
-                group_by: {
-                    title: 'Group by',
-                    type: 'string',
-                    enum: Object.values(GROUP_BY),
-                    menuItems: Object.values(GROUP_BY_ITEM_MAP),
-                },
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.CATEGORY}`]: {
-                    title: 'Category',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.RESOURCE_GROUP}`]: {
-                    title: 'Resource Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.TYPE}`]: {
-                    title: 'Type',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
+                ...getWidgetOptionsSchema('group_by'),
+                ...getWidgetFilterOptionsSchema(
+                    'provider',
+                    'project',
+                    'service_account',
+                    'project_group',
+                    'category',
+                    'resource_group',
+                    'product',
+                    'region',
+                    'usage_type',
+                    'account',
+                ),
             },
             required: ['group_by'],
+            order: ['group_by', ...getWidgetFilterSchemaPropertyNames(
+                'provider',
+                'project',
+                'service_account',
+                'project_group',
+                'category',
+                'resource_group',
+                'product',
+                'region',
+                'usage_type',
+                'account',
+            )],
         },
     },
 };

--- a/src/services/dashboards/widgets/cost-pie/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-pie/widget-config.ts
@@ -1,6 +1,10 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
-import { CHART_TYPE, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/_configs/view-config';
+import { CHART_TYPE } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+    getWidgetOptionsSchema,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const costPieWidgetConfig: Partial<WidgetConfig> = {
     widget_config_id: 'costPie',
@@ -15,58 +19,37 @@ const costPieWidgetConfig: Partial<WidgetConfig> = {
         chart_type: CHART_TYPE.PIE,
     },
     options_schema: {
-        default_properties: ['group_by', `filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account')],
         schema: {
             type: 'object',
             properties: {
-                group_by: {
-                    title: 'Group by',
-                    type: 'string',
-                    enum: Object.values(GROUP_BY),
-                    menuItems: Object.values(GROUP_BY_ITEM_MAP),
-                },
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.CATEGORY}`]: {
-                    title: 'Category',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.RESOURCE_GROUP}`]: {
-                    title: 'Resource Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.TYPE}`]: {
-                    title: 'Type',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
+                ...getWidgetOptionsSchema('group_by'),
+                ...getWidgetFilterOptionsSchema(
+                    'provider',
+                    'project',
+                    'service_account',
+                    'project_group',
+                    'category',
+                    'resource_group',
+                    'product',
+                    'region',
+                    'usage_type',
+                    'account',
+                ),
             },
             required: ['group_by'],
+            order: ['group_by', ...getWidgetFilterSchemaPropertyNames(
+                'provider',
+                'project',
+                'service_account',
+                'project_group',
+                'category',
+                'resource_group',
+                'product',
+                'region',
+                'usage_type',
+                'account',
+            )],
         },
     },
 };

--- a/src/services/dashboards/widgets/cost-trend-stacked/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-trend-stacked/widget-config.ts
@@ -1,6 +1,10 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
-import { CHART_TYPE, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/_configs/view-config';
+import { CHART_TYPE } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+    getWidgetOptionsSchema,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const costTrendStackedWidgetConfig: Partial<WidgetConfig> = {
     widget_config_id: 'costTrendStacked',
@@ -21,58 +25,37 @@ const costTrendStackedWidgetConfig: Partial<WidgetConfig> = {
         },
     },
     options_schema: {
-        default_properties: ['group_by', `filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account')],
         schema: {
             type: 'object',
             properties: {
-                group_by: {
-                    title: 'Group by',
-                    type: 'string',
-                    enum: Object.values(GROUP_BY),
-                    menuItems: Object.values(GROUP_BY_ITEM_MAP),
-                },
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.CATEGORY}`]: {
-                    title: 'Category',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.RESOURCE_GROUP}`]: {
-                    title: 'Resource Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.TYPE}`]: {
-                    title: 'Type',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
+                ...getWidgetOptionsSchema('group_by'),
+                ...getWidgetFilterOptionsSchema(
+                    'provider',
+                    'project',
+                    'service_account',
+                    'project_group',
+                    'category',
+                    'resource_group',
+                    'product',
+                    'region',
+                    'usage_type',
+                    'account',
+                ),
             },
             required: ['group_by'],
+            order: ['group_by', ...getWidgetFilterSchemaPropertyNames(
+                'provider',
+                'project',
+                'service_account',
+                'project_group',
+                'category',
+                'resource_group',
+                'product',
+                'region',
+                'usage_type',
+                'account',
+            )],
         },
     },
 };

--- a/src/services/dashboards/widgets/cost-trend/widget-config.ts
+++ b/src/services/dashboards/widgets/cost-trend/widget-config.ts
@@ -1,6 +1,10 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
-import { CHART_TYPE, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
-import { GROUP_BY_ITEM_MAP } from '@/services/dashboards/widgets/_configs/view-config';
+import { CHART_TYPE } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+    getWidgetOptionsSchema,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const costTrendWidgetConfig: Partial<WidgetConfig> = {
     widget_config_id: 'costTrend',
@@ -21,58 +25,37 @@ const costTrendWidgetConfig: Partial<WidgetConfig> = {
         },
     },
     options_schema: {
-        default_properties: ['group_by', `filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account')],
         schema: {
             type: 'object',
             properties: {
-                group_by: {
-                    title: 'Group by',
-                    type: 'string',
-                    enum: Object.values(GROUP_BY),
-                    menuItems: Object.values(GROUP_BY_ITEM_MAP),
-                },
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.CATEGORY}`]: {
-                    title: 'Category',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.RESOURCE_GROUP}`]: {
-                    title: 'Resource Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.TYPE}`]: {
-                    title: 'Type',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
+                ...getWidgetOptionsSchema('group_by'),
+                ...getWidgetFilterOptionsSchema(
+                    'provider',
+                    'project',
+                    'service_account',
+                    'project_group',
+                    'category',
+                    'resource_group',
+                    'product',
+                    'region',
+                    'usage_type',
+                    'account',
+                ),
             },
             required: ['group_by'],
+            order: ['group_by', ...getWidgetFilterSchemaPropertyNames(
+                'provider',
+                'project',
+                'service_account',
+                'project_group',
+                'category',
+                'resource_group',
+                'product',
+                'region',
+                'usage_type',
+                'account',
+            )],
         },
     },
 };

--- a/src/services/dashboards/widgets/monthly-cost/widget-config.ts
+++ b/src/services/dashboards/widgets/monthly-cost/widget-config.ts
@@ -1,5 +1,9 @@
 import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
-import { GRANULARITY, GROUP_BY } from '@/services/dashboards/widgets/_configs/config';
+import { GRANULARITY } from '@/services/dashboards/widgets/_configs/config';
+import {
+    getWidgetFilterOptionsSchema,
+    getWidgetFilterSchemaPropertyNames,
+} from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 const monthlyCostWidgetConfig: WidgetConfig = {
     widget_config_id: 'monthlyCost',
@@ -22,50 +26,22 @@ const monthlyCostWidgetConfig: WidgetConfig = {
         granularity: GRANULARITY.MONTHLY,
     },
     options_schema: {
-        default_properties: [`filters.${GROUP_BY.PROVIDER}`, `filters.${GROUP_BY.PROJECT}`, `filters.${GROUP_BY.SERVICE_ACCOUNT}`],
+        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account'),
         schema: {
             type: 'object',
             properties: {
-                [`filters.${GROUP_BY.PROVIDER}`]: {
-                    title: 'Provider',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT}`]: {
-                    title: 'Project',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.SERVICE_ACCOUNT}`]: {
-                    title: 'Service Account',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PROJECT_GROUP}`]: {
-                    title: 'Project Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.CATEGORY}`]: {
-                    title: 'Category',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.RESOURCE_GROUP}`]: {
-                    title: 'Resource Group',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.PRODUCT}`]: {
-                    title: 'Product',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.REGION}`]: {
-                    title: 'Region',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.TYPE}`]: {
-                    title: 'Type',
-                    type: 'array',
-                },
-                [`filters.${GROUP_BY.ACCOUNT}`]: {
-                    title: 'Account ID',
-                    type: 'array',
-                },
+                ...getWidgetFilterOptionsSchema(
+                    'provider',
+                    'project',
+                    'service_account',
+                    'project_group',
+                    'category',
+                    'resource_group',
+                    'product',
+                    'region',
+                    'usage_type',
+                    'account',
+                ),
             },
         },
     },

--- a/src/store/modules/reference/getters.ts
+++ b/src/store/modules/reference/getters.ts
@@ -14,6 +14,8 @@ import type { AllReferenceTypeInfo } from '@/store/modules/reference/type';
 import type { UserReferenceMap } from '@/store/modules/reference/user/type';
 import type { WebhookReferenceMap } from '@/store/modules/reference/webhook/type';
 
+import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
+
 export const projectItems: Getter<any, any> = (state): ProjectReferenceMap => state.project?.items ?? {};
 
 export const projectGroupItems: Getter<any, any> = (state): ProjectGroupReferenceMap => state.projectGroup?.items ?? {};
@@ -40,75 +42,74 @@ export const webhookItems: Getter<any, any> = (state): WebhookReferenceMap => st
 
 export const allReferenceTypeInfo: Getter<any, any> = (state, getters): AllReferenceTypeInfo => ({
     projectGroup: {
-        type: 'projectGroup',
-        key: 'project_group_id',
-        name: 'Project Group',
+        ...REFERENCE_TYPE_INFO.project_group,
         referenceMap: getters.projectGroupItems,
     },
+    project_group: {
+        ...REFERENCE_TYPE_INFO.project_group,
+        referenceMap: getters.projectGroupItems,
+    },
+    //
     project: {
-        type: 'project',
-        key: 'project_id',
-        name: 'Project',
+        ...REFERENCE_TYPE_INFO.project,
         referenceMap: getters.projectItems,
     },
+    //
     protocol: {
-        type: 'protocol',
-        key: 'protocol_id',
-        name: 'Protocol',
+        ...REFERENCE_TYPE_INFO.protocol,
         referenceMap: getters.protocolItems,
     },
+    //
     cloudServiceType: {
-        type: 'cloudServiceType',
-        key: 'cloud_service_type',
-        name: 'Cloud Service Type',
+        ...REFERENCE_TYPE_INFO.cloud_service_type,
         referenceMap: getters.cloudServiceTypeItems,
     },
+    cloud_service_type: {
+        ...REFERENCE_TYPE_INFO.cloud_service_type,
+        referenceMap: getters.cloudServiceTypeItems,
+    },
+    //
     collector: {
-        type: 'collector',
-        key: 'collector_id',
-        name: 'Collector',
+        ...REFERENCE_TYPE_INFO.collector,
         referenceMap: getters.collectorItems,
     },
+    //
     plugin: {
-        type: 'plugin',
-        key: 'plugin_id',
-        name: 'Plugin',
+        ...REFERENCE_TYPE_INFO.plugin,
         referenceMap: getters.pluginItems,
     },
+    //
     provider: {
-        type: 'provider',
-        key: 'provider',
-        name: 'Provider',
+        ...REFERENCE_TYPE_INFO.provider,
         referenceMap: getters.providerItems,
     },
+    //
     region: {
-        type: 'region',
-        key: 'region_code',
-        name: 'Region',
+        ...REFERENCE_TYPE_INFO.region,
         referenceMap: getters.regionItems,
     },
+    //
     secret: {
-        type: 'secret',
-        key: 'secret_id',
-        name: 'Secret',
+        ...REFERENCE_TYPE_INFO.secret,
         referenceMap: getters.secretItems,
     },
+    //
     serviceAccount: {
-        type: 'serviceAccount',
-        key: 'service_account_id',
-        name: 'Service Account',
+        ...REFERENCE_TYPE_INFO.service_account,
         referenceMap: getters.serviceAccountItems,
     },
+    service_account: {
+        ...REFERENCE_TYPE_INFO.service_account,
+        referenceMap: getters.serviceAccountItems,
+    },
+    //
     user: {
-        type: 'user',
-        key: 'user_id',
-        name: 'User',
+        ...REFERENCE_TYPE_INFO.user,
         referenceMap: getters.userItems,
     },
+    //
     webhook: {
-        type: 'webhook',
-        key: 'webhook_id',
-        name: 'Webhook',
+        ...REFERENCE_TYPE_INFO.webhook,
         referenceMap: getters.webhookItems,
     },
 });

--- a/src/store/modules/reference/type.ts
+++ b/src/store/modules/reference/type.ts
@@ -18,7 +18,20 @@ export interface ReferenceItem<Data = Record<string, any>> {
 
 export type ReferenceMap<Item extends ReferenceItem = ReferenceItem> = Record<string, Item>;
 
-export type ReferenceType = 'projectGroup'|'project'|'cloudServiceType'|'provider'|'region'|'serviceAccount'|'collector'|'protocol'|'plugin'|'secret'|'user'|'webhook';
+export type ReferenceType =
+    'projectGroup'|'project_group' // supports both camel case and snake case
+    |'project'
+    |'cloudServiceType'|'cloud_service_type'
+    |'provider'
+    |'region'
+    | 'serviceAccount'|'service_account'
+    |'collector'
+    |'protocol'
+    |'plugin'
+    |'secret'
+    |'user'
+    |'webhook';
+
 interface ReferenceTypeInfo {
     type: ReferenceType;
     key: string; // project_id


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- Add WidgetOptionsSchema type for typescript checking
- Refactor not to use reference key (such as 'project_id') as widget options schema property name. Change them to use reference type (such as 'project') 

All dashboard data MUST be changed after this PR merged.

### Things to Talk About
