### PR TITLE
fix(dashboard): dashboard name bug while creating

### DIFF
--- a/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -98,18 +98,21 @@ export default {
                     ...dashboardTemplate.value,
                     dashboard_id: undefined,
                     project_id: dashboardProject.value?.id ?? '',
+                    name: '',
                     viewers: state.dashboardViewerType,
                 };
             } else {
                 _dashboardTemplate = {
                     ...dashboardTemplate.value,
                     dashboard_id: undefined,
+                    name: '',
                     viewers: state.dashboardViewerType,
                 };
             }
 
             dashboardDetailStore.setDashboardInfo(_dashboardTemplate);
             dashboardDetailState.dashboardId = undefined;
+            dashboardDetailState.placeholder = dashboardTemplate.value.name;
             const routeName = state.dashboardScope === DASHBOARD_SCOPE.PROJECT ? DASHBOARDS_ROUTE.PROJECT.CUSTOMIZE._NAME : DASHBOARDS_ROUTE.WORKSPACE.CUSTOMIZE._NAME;
             SpaceRouter.router.push({ name: routeName });
         };

--- a/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
@@ -54,7 +54,7 @@
 import { vOnClickOutside } from '@vueuse/components';
 import { useFocus } from '@vueuse/core';
 import {
-    computed, nextTick, reactive, ref,
+    computed, nextTick, reactive, ref, watch,
 } from 'vue';
 
 import {
@@ -81,7 +81,7 @@ const dashboardDetailState = dashboardDetailStore.state;
 
 const state = reactive({
     name: useProxyValue('name', props, emit),
-    placeHolder: dashboardDetailState.name,
+    placeHolder: dashboardDetailState.placeholder,
     editMode: false,
     dashboardNameList: computed<string[]>(() => store.getters['dashboard/getDashboardNameList'](dashboardDetailState.projectId, dashboardDetailState.name)),
 });
@@ -138,6 +138,11 @@ const handleEnter = () => {
         state.name = props.name;
     }
 };
+
+watch(() => props.name, (d) => {
+    // for creating dashboard
+    if (!d) setForm('nameInput', '');
+}, { immediate: true });
 
 (async () => {
     await store.dispatch('dashboard/loadProjectDashboard');

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -45,6 +45,7 @@ export interface DashboardDetailInfoStoreState {
     dashboardId: string | undefined;
     projectId: string;
     name: string;
+    placeholder: string;
     settings: DashboardSettings;
     variables: DashboardVariables;
     variablesSchema: DashboardVariablesSchema;
@@ -91,6 +92,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         dashboardId: '',
         projectId: '',
         name: '',
+        placeholder: '',
         settings: DASHBOARD_DEFAULT.settings,
         variables: {},
         variablesSchema: {
@@ -112,6 +114,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
     const resetDashboardData = () => {
         originState.dashboardInfo = null;
         state.name = '';
+        state.placeholder = '';
         state.projectId = '';
         state.settings = DASHBOARD_DEFAULT.settings;
         state.variables = {};

--- a/src/store/modules/dashboard/getters.ts
+++ b/src/store/modules/dashboard/getters.ts
@@ -33,7 +33,7 @@ const getItems = (items: DashboardModel[], filters: ConsoleFilter[], viewers: st
     return result;
 };
 
-export const getDashboardNameList: Getter<DashboardState, any> = (state, getters): any => (projectId:string, dashboardName: string) => {
+export const getDashboardNameList: Getter<DashboardState, any> = (state, getters): any => (projectId: string, dashboardName: string) => {
     if (projectId) {
         return getters.getProjectItems
             .filter((item) => (


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

There was a bug that 

as-is: When creating dashboard, the dashboard template's name has been set. 
to-be: While creating dashboard, dashboard name should be empty. 

### Things to Talk About
