### PR TITLE
fix(role): fix page permission malfunction issue

### DIFF
--- a/src/services/administration/iam/role/update-role/modules/RoleUpdatePageAccessForm.vue
+++ b/src/services/administration/iam/role/update-role/modules/RoleUpdatePageAccessForm.vue
@@ -100,13 +100,12 @@ const getIndividualPagePermissions = (menuItem: PageAccessMenuItem): RawPagePerm
 const getPagePermissions = (menuItems: PageAccessMenuItem[], roleType: RoleType): RawPagePermission[] => {
     // all case
     const allItem = find(menuItems, { id: 'all' });
-    if (allItem && (allItem.isManaged || allItem.isViewed)) {
-        const permission = allItem.isManaged ? PAGE_PERMISSION_TYPE.MANAGE : PAGE_PERMISSION_TYPE.VIEW;
+    if (allItem && allItem.isManaged) {
         if (roleType === ROLE_TYPE.PROJECT) {
             // wildcard is not available for PROJECT role type
             return menuItems.map((menuItem) => getIndividualPagePermissions(menuItem)).flat();
         }
-        return [{ page: '*', permission }];
+        return [{ page: '*', permission: PAGE_PERMISSION_TYPE.MANAGE }];
     }
 
     let results: RawPagePermission[] = [];
@@ -141,6 +140,7 @@ const getPagePermissions = (menuItems: PageAccessMenuItem[], roleType: RoleType)
         });
     });
 
+    if (allItem && allItem.isViewed) return [{ page: '*', permission: PAGE_PERMISSION_TYPE.VIEW }, ...results];
     return results;
 };
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

[Back log](https://github.com/cloudforet-io/console/issues/862)

- In `VIEW` all, `MANAGE` permission can be present. But func `getPagePermissions` didn't handle that case.
- All case only handle `MANAGE` all. Func `getPagePermissions` handle `VIEW` all case at bottom of func.

