### PR TITLE
fix(dashboard-customize): apply dashboard name valid state

### DIFF
--- a/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
@@ -78,6 +78,7 @@ const emit = defineEmits<{(e: string, value: string): void}>();
 
 const dashboardDetailStore = useDashboardDetailInfoStore();
 const dashboardDetailState = dashboardDetailStore.state;
+const dashboardDetailValidationState = dashboardDetailStore.validationState;
 
 const state = reactive({
     name: useProxyValue('name', props, emit),
@@ -142,6 +143,10 @@ const handleEnter = () => {
 watch(() => props.name, (d) => {
     // for creating dashboard
     if (!d) setForm('nameInput', '');
+}, { immediate: true });
+
+watch(() => invalidState.nameInput, (invalid) => {
+    dashboardDetailValidationState.isNameValid = !invalid;
 }, { immediate: true });
 
 (async () => {

--- a/src/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue
+++ b/src/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue
@@ -65,7 +65,7 @@
                     {{ $t('DASHBOARDS.CUSTOMIZE.CANCEL') }}
                 </p-button>
                 <p-button style-type="primary"
-                          :disabled="!dashboardDetailValidationState.isWidgetLayoutValid"
+                          :disabled="!dashboardDetailValidationState.isWidgetLayoutValid || !dashboardDetailValidationState.isNameValid"
                           :loading="loading"
                           @click="handleClickSaveButton"
                 >


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

[QA-396](https://pyengine.atlassian.net/browse/QA-396)

- Now dashboard validation state watch name invalid state in `DashboardCostomizePageName`
- Apply name validation state to dashboard customize save button 

https://user-images.githubusercontent.com/83635051/217193732-0f73bd50-223f-4bb3-a06a-d66f23b45b88.mov


