### PR TITLE
fix(dashboard-customize): change object delete property method

### DIFF
--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, UnwrapRef } from 'vue';
-import Vue, {
+import {
     computed, reactive,
 } from 'vue';
 
@@ -218,7 +218,9 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
 
     const deleteWidget = (widgetKey: string) => {
         state.dashboardWidgetInfoList = state.dashboardWidgetInfoList.filter((info) => info.widget_key !== widgetKey);
-        Vue.delete(validationState.widgetValidMap, widgetKey);
+        const _widgetValidMap = { ...validationState.widgetValidMap };
+        delete _widgetValidMap[widgetKey];
+        validationState.widgetValidMap = _widgetValidMap;
     };
     const resetVariables = () => {
         const originProperties = { ...managedDashboardVariablesSchema.properties, ...originState.dashboardInfo.variables_schema.properties };

--- a/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
+++ b/src/services/dashboards/dashboard-detail/store/dashboard-detail-info.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, UnwrapRef } from 'vue';
-import {
+import Vue, {
     computed, reactive,
 } from 'vue';
 
@@ -218,7 +218,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
 
     const deleteWidget = (widgetKey: string) => {
         state.dashboardWidgetInfoList = state.dashboardWidgetInfoList.filter((info) => info.widget_key !== widgetKey);
-        delete validationState.widgetValidMap[widgetKey];
+        Vue.delete(validationState.widgetValidMap, widgetKey);
     };
     const resetVariables = () => {
         const originProperties = { ...managedDashboardVariablesSchema.properties, ...originState.dashboardInfo.variables_schema.properties };


### PR DESCRIPTION
Signed-off-by: Yongtae Park <samuel.park@mz.co.kr>

### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
[QA-397](https://pyengine.atlassian.net/browse/QA-397)

- Object `delete` can't be updating the DOM
- So, use `Vue.delete` 

https://user-images.githubusercontent.com/83635051/217208159-02e30775-1cd9-4f62-b8cb-63b410270872.mov




### Things to Talk About
Is this a good way?
If not, try using below sample code in comment.