### PR TITLE
fix(dashboard-widget-options): set default value to inherited options

### DIFF
--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -137,9 +137,15 @@ export default defineComponent<Props>({
             widgetOptionsJsonSchema: {} as JsonSchema,
             schemaFormData: {},
             // inherit
-            inheritableProperties: computed<string[]>(() => Object.entries<InheritOptions[string]>(widgetFormState.inheritOptions ?? {})
-                .filter(([, inheritOption]) => !!inheritOption.enabled)
-                .map(([propertyName]) => propertyName)),
+            requiredProperties: computed<string[]>(() => state.widgetConfig.options_schema?.schema.required ?? []),
+            inheritableProperties: computed<string[]>(() => {
+                if (props.widgetKey) {
+                    return Object.entries<InheritOptions[string]>(widgetFormState.inheritOptions ?? {})
+                        .filter(([, inheritOption]) => !!inheritOption.enabled)
+                        .map(([propertyName]) => propertyName);
+                }
+                return widgetFormState.defaultSchemaProperties?.filter((d) => !state.requiredProperties.includes(d)) ?? [];
+            }),
             inheritOptionsErrorMap: computed<InheritOptionsErrorMap>(() => getWidgetInheritOptionsErrorMap(
                 widgetFormState.inheritOptions,
                 state.widgetConfig?.options_schema?.schema,
@@ -230,6 +236,9 @@ export default defineComponent<Props>({
         /* inherit */
         const handleChangeInheritToggle = (propertyName: string, { value }) => {
             widgetFormState.inheritOptions = { ...widgetFormState.inheritOptions, [propertyName]: { enabled: value } };
+            if (value) {
+                state.schemaFormData[propertyName] = propertyName.replace('filters.', '');
+            }
 
             // update widget option schema
             const originPropertySchema = state.widgetConfig?.options_schema?.schema?.properties?.[propertyName] ?? {};
@@ -292,8 +301,17 @@ export default defineComponent<Props>({
             const widgetOptionsSchema: WidgetOptionsSchema = state.widgetConfig?.options_schema ?? {};
             // init widget form store states
             widgetFormState.widgetConfigId = widgetConfigId;
-            widgetFormState.inheritOptions = {};
             widgetFormState.defaultSchemaProperties = getRefinedDefaultSchemaProperties(widgetOptionsSchema);
+            widgetFormState.inheritOptions = {};
+            if (!props.widgetKey) {
+                widgetFormState.defaultSchemaProperties.filter((d) => !state.requiredProperties.includes(d)).forEach((propertyName) => {
+                    widgetFormState.inheritOptions = {
+                        ...widgetFormState.inheritOptions,
+                        [propertyName]: { enabled: true },
+                    };
+                    state.schemaFormData[propertyName] = propertyName.replace('filters.', '');
+                });
+            }
             // init states
             state.widgetOptionsJsonSchema = getRefinedWidgetOptionsSchema(
                 referenceStoreState,

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -355,7 +355,6 @@ export default defineComponent<Props>({
             }
 
             // initiate states by widget config
-            resetStates();
             initStatesByWidgetConfig(widgetConfigId);
 
             // set states if widget key exists. this is for updating widget case.

--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -355,6 +355,7 @@ export default defineComponent<Props>({
             }
 
             // initiate states by widget config
+            resetStates();
             initStatesByWidgetConfig(widgetConfigId);
 
             // set states if widget key exists. this is for updating widget case.

--- a/src/services/dashboards/default-dashboard/helper.ts
+++ b/src/services/dashboards/default-dashboard/helper.ts
@@ -1,12 +1,21 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { ERROR_CASE_WIDGET_INFO } from '@/services/dashboards/default-dashboard/config';
-import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/_configs/config';
+import type { DashboardLayoutWidgetInfo, InheritOptions } from '@/services/dashboards/widgets/_configs/config';
 import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
 
 export const getDashboardLayoutWidgetInfoList = (widgetList: string[]): DashboardLayoutWidgetInfo[] => widgetList.map((widgetId) => {
     try {
         const widgetConfig = getWidgetConfig(widgetId);
+        const _defaultProperties = widgetConfig.options_schema?.default_properties ?? [];
+        const _requiredProperties = widgetConfig.options_schema?.schema.required ?? [];
+        const _inheritOptions: InheritOptions = {};
+        _defaultProperties.filter((d) => !_requiredProperties.includes(d)).forEach((propertyName) => {
+            _inheritOptions[propertyName] = {
+                enabled: true,
+                variable_info: { key: propertyName.replace('filters.', '') },
+            };
+        });
         const widgetInfo: DashboardLayoutWidgetInfo = {
             widget_key: uuidv4(),
             widget_name: widgetConfig.widget_config_id,
@@ -14,8 +23,8 @@ export const getDashboardLayoutWidgetInfoList = (widgetList: string[]): Dashboar
             widget_options: widgetConfig.options ?? {},
             size: widgetConfig.sizes[0],
             version: '1',
-            inherit_options: {},
-            default_schema_properties: widgetConfig.options_schema?.default_properties ?? [],
+            inherit_options: _inheritOptions,
+            default_schema_properties: _defaultProperties,
         };
         return widgetInfo;
     } catch (e) {

--- a/src/services/dashboards/widgets/_configs/widget-schema-config.ts
+++ b/src/services/dashboards/widgets/_configs/widget-schema-config.ts
@@ -7,22 +7,27 @@ export const RESOURCE_REFERENCE_SCHEMA = {
     [REFERENCE_TYPE_INFO.provider.type]: {
         title: REFERENCE_TYPE_INFO.provider.name,
         type: 'array',
+        default: REFERENCE_TYPE_INFO.provider.name,
     },
     [REFERENCE_TYPE_INFO.project.type]: {
         title: REFERENCE_TYPE_INFO.project.name,
         type: 'array',
+        default: REFERENCE_TYPE_INFO.project.name,
     },
     [REFERENCE_TYPE_INFO.service_account.type]: {
         title: REFERENCE_TYPE_INFO.service_account.name,
         type: 'array',
+        default: REFERENCE_TYPE_INFO.service_account.name,
     },
     [REFERENCE_TYPE_INFO.project_group.type]: {
         title: REFERENCE_TYPE_INFO.project_group.name,
         type: 'array',
+        default: REFERENCE_TYPE_INFO.project_group.name,
     },
     [REFERENCE_TYPE_INFO.region.type]: {
         title: REFERENCE_TYPE_INFO.region.name,
         type: 'array',
+        default: REFERENCE_TYPE_INFO.region.name,
     },
 } as const;
 

--- a/src/services/dashboards/widgets/aws-cloud-front-cost/widget-config.ts
+++ b/src/services/dashboards/widgets/aws-cloud-front-cost/widget-config.ts
@@ -42,7 +42,7 @@ const awsCloudFrontCostWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('project', 'service_account')],
+        default_properties: ['group_by', ...getWidgetFilterSchemaPropertyNames('project', 'service_account', 'region')],
         schema: {
             type: 'object',
             properties: {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- add `regions` as default option
- set default inherited options to widgets of dashboard templates
- set default dashboard values to inherited options of widgets

https://user-images.githubusercontent.com/18563857/217740822-09b79497-7d22-4447-b62c-29b00563ee35.mov


