### PR TITLE
fix: use filter data key for api query not property name

### DIFF
--- a/src/services/dashboards/dashboard-customize/stores/widget-form.ts
+++ b/src/services/dashboards/dashboard-customize/stores/widget-form.ts
@@ -32,7 +32,6 @@ export const useWidgetFormStore = defineStore('widget-form', () => {
         defaultSchemaProperties: undefined,
     });
     const setFormData = (formData: any) => {
-        console.debug('setFormData');
         if (!state.widgetConfigId) return;
         const widgetConfig = getWidgetConfig(state.widgetConfigId);
         const _widgetOptions: WidgetOptions = {

--- a/src/services/dashboards/dashboard-customize/stores/widget-form.ts
+++ b/src/services/dashboards/dashboard-customize/stores/widget-form.ts
@@ -5,6 +5,7 @@ import { defineStore } from 'pinia';
 
 import { useDashboardDetailInfoStore } from '@/services/dashboards/dashboard-detail/store/dashboard-detail-info';
 import type { DashboardLayoutWidgetInfo, InheritOptions, WidgetOptions } from '@/services/dashboards/widgets/_configs/config';
+import { getWidgetFilterDataKey } from '@/services/dashboards/widgets/_helpers/widget-filters-helper';
 import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
 
 
@@ -31,6 +32,7 @@ export const useWidgetFormStore = defineStore('widget-form', () => {
         defaultSchemaProperties: undefined,
     });
     const setFormData = (formData: any) => {
+        console.debug('setFormData');
         if (!state.widgetConfigId) return;
         const widgetConfig = getWidgetConfig(state.widgetConfigId);
         const _widgetOptions: WidgetOptions = {
@@ -48,7 +50,10 @@ export const useWidgetFormStore = defineStore('widget-form', () => {
                     },
                 };
             } else if (key.startsWith('filters.')) {
-                if (val) widgetFiltersMap[_propertyName] = [{ k: _propertyName, v: val, o: '=' }];
+                if (val) {
+                    const filterDataKey = getWidgetFilterDataKey(_propertyName);
+                    widgetFiltersMap[_propertyName] = [{ k: filterDataKey, v: val, o: '=' }];
+                }
             } else {
                 _widgetOptions[key] = val;
             }

--- a/src/services/dashboards/widgets/_hooks/use-widget-state.ts
+++ b/src/services/dashboards/widgets/_hooks/use-widget-state.ts
@@ -40,7 +40,17 @@ const getRefinedOptions = (
     if (!inheritOptions || !dashboardVariables) return mergedOptions;
 
     const parentOptions: Partial<WidgetOptions> = convertInheritOptionsToWidgetFiltersMap(inheritOptions, dashboardVariables, optionsErrorMap);
-    return merge({}, mergedOptions, parentOptions);
+    const refined = merge({}, mergedOptions, parentOptions);
+
+    // This is compatible code for already stored data before 1.11.0.2
+    const filtersEntries = refined.filters ? Object.entries(refined.filters) : [];
+    filtersEntries.forEach(([filterKey, filters]) => {
+        const filterDataKey = getWidgetFilterDataKey(filterKey);
+        filters?.forEach((filter) => {
+            if (filter.k === filterKey) filter.k = filterDataKey;
+        });
+    });
+    return refined;
 };
 
 const convertInheritOptionsToWidgetFiltersMap = (


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

widgetConfig's schema property names are different from api query filter keys.
This PR Convert filter keys to api query spec(e.g. project -> project_id).
It occurs in cases below:
1. When widget options.filters are updated by user interaction. 
2. When each widget's options(which is from api) are applied to each widget's state. 

The second case codes are the compatible codes that make work even the data from api is wrong. (e.g. 'region_code' is correct key, but the previous version(<1.11.0.2) data has 'region' as the key.)

### Things to Talk About
