### PR TITLE
fix(widget-input-form): set inherit `false` when add widget option

### DIFF
--- a/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -138,14 +138,9 @@ export default defineComponent<Props>({
             schemaFormData: {},
             // inherit
             requiredProperties: computed<string[]>(() => state.widgetConfig.options_schema?.schema.required ?? []),
-            inheritableProperties: computed<string[]>(() => {
-                if (props.widgetKey) {
-                    return Object.entries<InheritOptions[string]>(widgetFormState.inheritOptions ?? {})
-                        .filter(([, inheritOption]) => !!inheritOption.enabled)
-                        .map(([propertyName]) => propertyName);
-                }
-                return widgetFormState.defaultSchemaProperties?.filter((d) => !state.requiredProperties.includes(d)) ?? [];
-            }),
+            inheritableProperties: computed(() => Object.entries<InheritOptions[string]>(widgetFormState.inheritOptions ?? {})
+                .filter(([, inheritOption]) => !!inheritOption.enabled)
+                .map(([propertyName]) => propertyName)),
             inheritOptionsErrorMap: computed<InheritOptionsErrorMap>(() => getWidgetInheritOptionsErrorMap(
                 widgetFormState.inheritOptions,
                 state.widgetConfig?.options_schema?.schema,


### PR DESCRIPTION
Signed-off-by: Dahyun Yu <yuda@megazone.com>

### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- set `inherit`: `false` when add widget options
