### PR TITLE
fix: apply text beautifier to alert note, change history note, alert description

### DIFF
--- a/src/services/alert-manager/alert/alert-detail/modules/AlertNote.vue
+++ b/src/services/alert-manager/alert/alert-detail/modules/AlertNote.vue
@@ -36,7 +36,9 @@
                     </div>
                 </template>
                 <template #default="{data}">
-                    <span class="note-content">{{ data.note }}</span>
+                    <p-text-beautifier class="note-content"
+                                       :value="data.note"
+                    />
                 </template>
             </p-collapsible-list>
         </article>
@@ -52,7 +54,7 @@
 import { computed, reactive, toRefs } from 'vue';
 
 import {
-    PButton, PCollapsibleList, PPaneLayout, PHeading, PTextarea, PSelectDropdown,
+    PButton, PCollapsibleList, PPaneLayout, PHeading, PTextarea, PSelectDropdown, PTextBeautifier,
 } from '@spaceone/design-system';
 
 import { iso8601Formatter } from '@cloudforet/core-lib';
@@ -84,6 +86,7 @@ export default {
         PButton,
         PCollapsibleList,
         PSelectDropdown,
+        PTextBeautifier,
         DeleteModal,
     },
     props: {
@@ -211,7 +214,7 @@ export default {
     margin-top: 0.5rem;
     .p-collapsible-list {
         max-height: 27.5rem;
-        overflow-y: scroll;
+        overflow-y: auto;
     }
 
     .title-wrapper {

--- a/src/services/alert-manager/alert/alert-detail/modules/alert-key-info/modules/AlertInfoDescription.vue
+++ b/src/services/alert-manager/alert/alert-detail/modules/alert-key-info/modules/AlertInfoDescription.vue
@@ -2,7 +2,9 @@
     <p v-if="!isEditMode"
        class="content-wrapper"
     >
-        <span class="description">{{ alertData.description }}&zwnj;</span>
+        <p-text-beautifier class="description"
+                           :value="alertData.description"
+        />&zwnj;
         <button class="edit-btn"
                 :class="{'disabled': manageDisabled}"
                 @click="startEdit(alertData.description)"
@@ -39,7 +41,7 @@
 <script lang="ts">
 import { toRefs } from 'vue';
 
-import { PTextarea, PButton } from '@spaceone/design-system';
+import { PTextarea, PButton, PTextBeautifier } from '@spaceone/design-system';
 
 import { useAlertInfoItem } from '@/services/alert-manager/alert/alert-detail/modules/alert-key-info/composables';
 import { EDIT_MODE } from '@/services/alert-manager/lib/config';
@@ -49,6 +51,7 @@ export default {
     components: {
         PTextarea,
         PButton,
+        PTextBeautifier,
     },
     props: {
         id: {

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-history-detail/CloudServiceHistoryDetailNoteTab.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-history-detail/CloudServiceHistoryDetailNoteTab.vue
@@ -26,7 +26,9 @@
                     </div>
                 </template>
                 <template #default="{data}">
-                    <span class="note-content">{{ data.note }}</span>
+                    <p-text-beautifier class="note-content"
+                                       :value="data.note"
+                    />
                 </template>
             </p-collapsible-list>
         </article>
@@ -57,7 +59,7 @@ import {
 } from 'vue';
 
 import {
-    PButton, PCollapsibleList, PPaneLayout, PHeading, PTextarea, PSelectDropdown,
+    PButton, PCollapsibleList, PPaneLayout, PHeading, PTextarea, PSelectDropdown, PTextBeautifier,
 } from '@spaceone/design-system';
 
 import { iso8601Formatter } from '@cloudforet/core-lib';
@@ -81,6 +83,7 @@ export default {
         PButton,
         PCollapsibleList,
         PSelectDropdown,
+        PTextBeautifier,
         DeleteModal,
     },
     props: {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/26986739/218960143-f9f4719d-668b-4480-b87a-228ee36e39fd.png">


<img width="1363" alt="image" src="https://user-images.githubusercontent.com/26986739/218960022-78f3e103-8050-4af2-ab0a-c0583b006b79.png">


### Things to Talk About
