### PR TITLE
fix(dashboard-route): handle a case of route with reference routes

### DIFF
--- a/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
+++ b/src/common/modules/navigations/gnb/modules/gnb-menu/modules/dashboard-recent-favorite/modules/GNBDashboardMenu.vue
@@ -99,7 +99,7 @@ export default defineComponent({
                 {
                     label: i18n.t('COMMON.GNB.DASHBOARDS.CREATE_DASHBOARDS'),
                     to: { name: DASHBOARDS_ROUTE.CREATE._NAME },
-                    show: computed(() => !state.hasOnlyViewPermission),
+                    show: !state.hasOnlyViewPermission,
                 },
             ] as DisplayMenu[]),
             isOverflown: false,

--- a/src/lib/access-control/config.ts
+++ b/src/lib/access-control/config.ts
@@ -16,6 +16,10 @@ export const PAGE_PERMISSION_TYPE = {
 
 export type PagePermissionType = typeof PAGE_PERMISSION_TYPE[keyof typeof PAGE_PERMISSION_TYPE];
 
+export interface AccessInfo {
+    referenceRouteNames: string[];
+}
+
 // backend data format of page permissions. page includes wildcard('*').
 export interface RawPagePermission {
     page: string;

--- a/src/lib/access-control/index.ts
+++ b/src/lib/access-control/index.ts
@@ -33,13 +33,13 @@ export const getRouteAccessLevel = (route: Route): AccessLevel => {
     return closestRoute.meta.accessLevel ?? ACCESS_LEVEL.AUTHENTICATED;
 };
 
-export const getUserAccessLevel = (routeName?: string|null, pagePermissions: PagePermissionTuple[] = [], isTokenAlive = true): AccessLevel => {
+export const getUserAccessLevel = (routeName?: string|null, pagePermissions: PagePermissionTuple[] = [], isTokenAlive = true, referenceRouteNames?: string[]|undefined): AccessLevel => {
     if (!isTokenAlive) return ACCESS_LEVEL.EXCLUDE_AUTH;
 
     const menuId = getMenuIdByRouteName(routeName);
     if (!menuId) return ACCESS_LEVEL.AUTHENTICATED;
 
-    const permission = getPermissionOfPage(menuId, pagePermissions);
+    const permission = getPermissionOfPage(menuId, pagePermissions, referenceRouteNames);
     return getAccessTypeFromPermission(permission);
 };
 const getMenuAccessLevel = (id: MenuId): AccessLevel => (MENU_INFO_MAP[id]?.needPermissionByRole ? ACCESS_LEVEL.VIEW_PERMISSION : ACCESS_LEVEL.AUTHENTICATED);

--- a/src/lib/access-control/page-permission-helper.ts
+++ b/src/lib/access-control/page-permission-helper.ts
@@ -77,10 +77,15 @@ export const filterLNBMenuByPermission = (menuSet: LNBMenu[], pagePermissionList
     return results;
 }, [] as LNBMenu[]);
 
-export const getPermissionOfPage = (menuId: MenuId, pagePermissions: PagePermissionTuple[]): PagePermissionType|undefined => {
+export const getPermissionOfPage = (menuId: MenuId, pagePermissions: PagePermissionTuple[], referenceRouteNames: string[] = []): PagePermissionType|undefined => {
     let result: PagePermissionType|undefined;
     pagePermissions.some(([id, permission]) => {
         if (id === menuId) {
+            result = permission;
+            return true;
+        }
+        // return MANAGE permission if user have any of reference route names in route case with reference route
+        if (referenceRouteNames.includes(id)) {
             result = permission;
             return true;
         }

--- a/src/lib/access-control/page-permission-helper.ts
+++ b/src/lib/access-control/page-permission-helper.ts
@@ -84,7 +84,7 @@ export const getPermissionOfPage = (menuId: MenuId, pagePermissions: PagePermiss
             result = permission;
             return true;
         }
-        // return MANAGE permission if user have any of reference route names in route case with reference route
+        // Check reference routes and return permission if user have any of reference route names in RouteConfig
         if (referenceRouteNames.includes(id)) {
             result = permission;
             return true;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -57,7 +57,7 @@ export class SpaceRouter {
             const isTokenAlive = SpaceConnector.isTokenAlive;
             const userPagePermissions = SpaceRouter.router.app?.$store.getters['user/pagePermissionList'];
             const routeAccessLevel = getRouteAccessLevel(to);
-            const userAccessLevel = getUserAccessLevel(to.name, userPagePermissions, isTokenAlive);
+            const userAccessLevel = getUserAccessLevel(to.name, userPagePermissions, isTokenAlive, to.meta?.accessInfo?.referenceRouteNames);
             const userNeedPwdReset = SpaceRouter.router.app?.$store.getters['user/isUserNeedPasswordReset'];
             let nextLocation;
 

--- a/src/services/dashboards/routes.ts
+++ b/src/services/dashboards/routes.ts
@@ -38,7 +38,13 @@ const dashboardsRoute: RouteConfig = {
                 {
                     path: 'create',
                     name: DASHBOARDS_ROUTE.CREATE._NAME,
-                    meta: { translationId: 'DASHBOARDS.CREATE.TITLE', accessLevel: ACCESS_LEVEL.MANAGE_PERMISSION },
+                    meta: {
+                        translationId: 'DASHBOARDS.CREATE.TITLE',
+                        accessLevel: ACCESS_LEVEL.MANAGE_PERMISSION,
+                        accessInfo: {
+                            referenceRouteNames: [DASHBOARDS_ROUTE.PROJECT._NAME, DASHBOARDS_ROUTE.WORKSPACE._NAME],
+                        },
+                    },
                     component: DashboardCreatePage,
                 },
                 {

--- a/src/shims-vue-router.d.ts
+++ b/src/shims-vue-router.d.ts
@@ -1,3 +1,5 @@
+import type { AccessInfo } from '@/lib/access-control/config';
+
 declare module 'vue-router' {
     import type { TranslateResult } from 'vue-i18n';
   import type {
@@ -32,6 +34,7 @@ import {
     copiable?: boolean; // for breadcrumbs
     isSignInPage?: boolean;
     accessLevel?: AccessLevel;
+    accessInfo?: AccessInfo;
   }
   export interface RouteConfigSingleView extends OriginRouteConfigSingleView {
       meta?: RouteMeta;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

#### New route config rule
*Add `accessInfo` to supplement `accessLevel`'s exception case*

```
meta: {
    accessLevel: ACCESS_LEVEL.MANAGE_PERMISSION,
    accessInfo: {
       referenceRouteNames: [DASHBOARDS_ROUTE.PROJECT._NAME, DASHBOARDS_ROUTE.WORKSPACE._NAME ]
    }
}
```
*accessInfo* (optional)
- Dashboard route has *different hierarchy route case* than before.
- So we decide to solve this issue through `accessInfo`.
- `accessInfo` is created to supplement problems that could not be covered by `accessLevel`
- And current problem is solved through `referenceRouteNames`.
- If you are curious about how it works, check it out through this PR.


++ Another issue is fixed
- Create New Dashboard button's permission in GNB was not working.
- FIx misuse of `computed`.


