### PR TITLE
fix(cloud-service-log): change default tab from auto to last1day

### DIFF
--- a/packages/cloudforet/language-pack/console-translation.babel
+++ b/packages/cloudforet/language-pack/console-translation.babel
@@ -33124,48 +33124,6 @@
                                                 <name>LOG_TAB</name>
                                                 <children>
                                                     <concept_node>
-                                                        <name>AUTO</name>
-                                                        <definition_loaded>false</definition_loaded>
-                                                        <description/>
-                                                        <comment/>
-                                                        <default_text/>
-                                                        <translations>
-                                                            <translation>
-                                                                <language>en-US</language>
-                                                                <approved>true</approved>
-                                                            </translation>
-                                                            <translation>
-                                                                <language>ja-JP</language>
-                                                                <approved>true</approved>
-                                                            </translation>
-                                                            <translation>
-                                                                <language>ko-KR</language>
-                                                                <approved>true</approved>
-                                                            </translation>
-                                                        </translations>
-                                                    </concept_node>
-                                                    <concept_node>
-                                                        <name>LAST_12_HRS</name>
-                                                        <definition_loaded>false</definition_loaded>
-                                                        <description/>
-                                                        <comment/>
-                                                        <default_text/>
-                                                        <translations>
-                                                            <translation>
-                                                                <language>en-US</language>
-                                                                <approved>true</approved>
-                                                            </translation>
-                                                            <translation>
-                                                                <language>ja-JP</language>
-                                                                <approved>true</approved>
-                                                            </translation>
-                                                            <translation>
-                                                                <language>ko-KR</language>
-                                                                <approved>true</approved>
-                                                            </translation>
-                                                        </translations>
-                                                    </concept_node>
-                                                    <concept_node>
                                                         <name>LAST_1_DAY</name>
                                                         <definition_loaded>false</definition_loaded>
                                                         <description/>
@@ -33187,7 +33145,7 @@
                                                         </translations>
                                                     </concept_node>
                                                     <concept_node>
-                                                        <name>LAST_2_DAYS</name>
+                                                        <name>LAST_3_DAYS</name>
                                                         <definition_loaded>false</definition_loaded>
                                                         <description/>
                                                         <comment/>
@@ -33208,7 +33166,7 @@
                                                         </translations>
                                                     </concept_node>
                                                     <concept_node>
-                                                        <name>LAST_6_HRS</name>
+                                                        <name>LAST_A_WEEK</name>
                                                         <definition_loaded>false</definition_loaded>
                                                         <description/>
                                                         <comment/>
@@ -33216,15 +33174,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>true</approved>
+                                                                <approved>false</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>true</approved>
+                                                                <approved>false</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>true</approved>
+                                                                <approved>false</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>

--- a/packages/cloudforet/language-pack/console-translation.babel
+++ b/packages/cloudforet/language-pack/console-translation.babel
@@ -34387,6 +34387,27 @@
                                         </translations>
                                     </concept_node>
                                     <concept_node>
+                                        <name>TAB_LOG</name>
+                                        <definition_loaded>false</definition_loaded>
+                                        <description/>
+                                        <comment/>
+                                        <default_text/>
+                                        <translations>
+                                            <translation>
+                                                <language>en-US</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                            <translation>
+                                                <language>ja-JP</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                            <translation>
+                                                <language>ko-KR</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                        </translations>
+                                    </concept_node>
+                                    <concept_node>
                                         <name>TAB_MEMBER</name>
                                         <definition_loaded>false</definition_loaded>
                                         <description/>

--- a/packages/cloudforet/language-pack/en.json
+++ b/packages/cloudforet/language-pack/en.json
@@ -1867,11 +1867,9 @@
 					"HISTORY_DETAIL": "History Detail",
 					"LOG": "Log",
 					"LOG_TAB": {
-						"AUTO": "Auto",
-						"LAST_12_HRS": "Last 12 hrs",
 						"LAST_1_DAY": "Last 1 day",
-						"LAST_2_DAYS": "Last 2 days",
-						"LAST_6_HRS": "Last 6 hrs",
+						"LAST_3_DAYS": "Last 3 days",
+						"LAST_A_WEEK": "Last a week",
 						"NO_LOG_HELP_TEXT": "No log available for this provider",
 						"TIME_WITHIN": "Time Within"
 					},

--- a/packages/cloudforet/language-pack/en.json
+++ b/packages/cloudforet/language-pack/en.json
@@ -1936,6 +1936,7 @@
 				"TAB_DATA": "Data ",
 				"TAB_DETAILS": "Details",
 				"TAB_HISTORY": "History",
+				"TAB_LOG": "Log",
 				"TAB_MEMBER": "Related Member",
 				"TAB_MONITORING": "Monitoring",
 				"TAB_SELECTED_DATA": "Selected Data",

--- a/packages/cloudforet/language-pack/ja.json
+++ b/packages/cloudforet/language-pack/ja.json
@@ -1936,6 +1936,7 @@
 				"TAB_DATA": "データ",
 				"TAB_DETAILS": "詳細情報",
 				"TAB_HISTORY": "変更履歴",
+				"TAB_LOG": "ログ",
 				"TAB_MEMBER": "関連するメンバー",
 				"TAB_MONITORING": "モニタリング",
 				"TAB_SELECTED_DATA": "選択したデータ",

--- a/packages/cloudforet/language-pack/ja.json
+++ b/packages/cloudforet/language-pack/ja.json
@@ -1867,11 +1867,9 @@
 					"HISTORY_DETAIL": "変更履歴詳細",
 					"LOG": "ログ",
 					"LOG_TAB": {
-						"AUTO": "自動",
-						"LAST_12_HRS": "過去12時間",
 						"LAST_1_DAY": "過去1日",
-						"LAST_2_DAYS": "過去2日",
-						"LAST_6_HRS": "過去6時間",
+						"LAST_3_DAYS": "過去3日",
+						"LAST_A_WEEK": "",
 						"NO_LOG_HELP_TEXT": "該当のクラウドプロバイダは、現在別途のログを提供していません。",
 						"TIME_WITHIN": "照会期間"
 					},

--- a/packages/cloudforet/language-pack/ko.json
+++ b/packages/cloudforet/language-pack/ko.json
@@ -1867,11 +1867,9 @@
 					"HISTORY_DETAIL": "변경 이력 상세",
 					"LOG": "로그",
 					"LOG_TAB": {
-						"AUTO": "자동",
-						"LAST_12_HRS": "지난 12시간",
 						"LAST_1_DAY": "지난 1일",
-						"LAST_2_DAYS": "지난 2일",
-						"LAST_6_HRS": "지난 6시간",
+						"LAST_3_DAYS": "지난 3일",
+						"LAST_A_WEEK": "지난 1주",
 						"NO_LOG_HELP_TEXT": "해당 클라우드 프로바이더는 현재 별도의 로그를 제공하고 있지 않습니다.",
 						"TIME_WITHIN": "조회 기간"
 					},

--- a/packages/cloudforet/language-pack/ko.json
+++ b/packages/cloudforet/language-pack/ko.json
@@ -1936,6 +1936,7 @@
 				"TAB_DATA": "데이터 ",
 				"TAB_DETAILS": "상세 정보",
 				"TAB_HISTORY": "변경 이력",
+				"TAB_LOG": "로그",
 				"TAB_MEMBER": "연관된 멤버",
 				"TAB_MONITORING": "모니터링",
 				"TAB_SELECTED_DATA": "선택한 데이터 ",

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/CloudServiceDetailPage.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/CloudServiceDetailPage.vue
@@ -101,6 +101,11 @@
                                        :provider="tableState.selectedItems[0].provider"
                 />
             </template>
+            <template #log>
+                <cloud-service-history-log-tab :cloud-service-id="tableState.selectedItems[0].cloud_service_id"
+                                               :provider="tableState.selectedItems[0].provider"
+                />
+            </template>
             <template #monitoring>
                 <monitoring :resources="monitoringState.resources" />
             </template>
@@ -155,7 +160,6 @@
 </template>
 
 <script lang="ts">
-
 import { debouncedWatch } from '@vueuse/core';
 import {
     reactive, computed, getCurrentInstance, watch,
@@ -202,6 +206,7 @@ import CloudServiceUsageOverview
 import CloudServiceAdmin from '@/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceAdmin.vue';
 import CloudServiceDetail from '@/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceDetail.vue';
 import CloudServiceHistory from '@/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceHistory.vue';
+import CloudServiceHistoryLogTab from '@/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceHistoryLogTab.vue';
 import CloudServiceTagsPanel
     from '@/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceTagsPanel.vue';
 import CloudServicePeriodFilter from '@/services/asset-inventory/cloud-service/modules/CloudServicePeriodFilter.vue';
@@ -218,6 +223,7 @@ const TABLE_MIN_HEIGHT = 400;
 export default {
     name: 'CloudServiceDetailPage',
     components: {
+        CloudServiceHistoryLogTab,
         CloudServiceTagsPanel,
         CloudServicePeriodFilter,
         CloudServiceUsageOverview,
@@ -496,6 +502,7 @@ export default {
                 { name: 'tag', label: i18n.t('INVENTORY.CLOUD_SERVICE.PAGE.TAB_TAG') },
                 { name: 'member', label: i18n.t('INVENTORY.CLOUD_SERVICE.PAGE.TAB_MEMBER') },
                 { name: 'history', label: i18n.t('INVENTORY.CLOUD_SERVICE.PAGE.TAB_HISTORY') },
+                { name: 'log', label: i18n.t('INVENTORY.CLOUD_SERVICE.PAGE.TAB_LOG') },
                 { name: 'monitoring', label: i18n.t('INVENTORY.CLOUD_SERVICE.PAGE.TAB_MONITORING') },
             ])),
             activeTab: 'detail',

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceHistoryLogTab.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceHistoryLogTab.vue
@@ -95,7 +95,6 @@ interface Props {
     provider: string;
     cloudServiceId: string;
     date: string;
-    prevDate: string | undefined;
 }
 interface PeriodItem {
     name: string;
@@ -124,11 +123,7 @@ export default defineComponent<Props>({
         },
         date: {
             type: String,
-            default: '',
-        },
-        prevDate: {
-            type: String,
-            default: undefined,
+            default: dayjs.utc().format(),
         },
     },
     setup(props) {
@@ -256,7 +251,7 @@ export default defineComponent<Props>({
         })();
 
         // watcher
-        watch([() => state.selectedTimeWithin, () => props.date], () => {
+        watch([() => state.selectedTimeWithin, () => props.date, () => props.cloudServiceId], () => {
             if (state.totalLayoutCount) getLogData();
         });
         return {

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-history-detail/CloudServiceHistoryDetailOverlay.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-history-detail/CloudServiceHistoryDetailOverlay.vue
@@ -116,7 +116,7 @@ import CloudServiceHistoryChangesTab
 import CloudServiceHistoryDetailNote
     from '@/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-history-detail/CloudServiceHistoryDetailNoteTab.vue';
 import CloudServiceHistoryLogTab
-    from '@/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-history-detail/CloudServiceHistoryLogTab.vue';
+    from '@/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceHistoryLogTab.vue';
 import type { CloudServiceHistoryItem } from '@/services/asset-inventory/cloud-service/cloud-service-detail/type';
 import { HISTORY_ACTION_MAP } from '@/services/asset-inventory/cloud-service/cloud-service-detail/type';
 

--- a/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-history-detail/CloudServiceHistoryLogTab.vue
+++ b/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-history-detail/CloudServiceHistoryLogTab.vue
@@ -140,42 +140,27 @@ export default defineComponent<Props>({
             pageLimit: 15,
             tabs: [] as TabItem[],
             activeTab: '',
-            timeWithinList: computed<PeriodItem[]>(() => {
-                const checkDate = props.prevDate ? dayjs.utc(props.date).diff(props.prevDate, 'day') < 2 : false;
-                return ([
-                    {
-                        name: 'auto',
-                        label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.DETAIL.LOG_TAB.AUTO'),
-                        start: checkDate ? dayjs.utc(props.prevDate) : dayjs.utc(props.date).subtract(2, 'day'),
-                        end: dayjs.utc(props.date),
-                    },
-                    {
-                        name: 'last6hrs',
-                        label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.DETAIL.LOG_TAB.LAST_6_HRS'),
-                        start: dayjs.utc(props.date).subtract(6, 'hour'),
-                        end: dayjs.utc(props.date),
-                    },
-                    {
-                        name: 'last12hrs',
-                        label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.DETAIL.LOG_TAB.LAST_12_HRS'),
-                        start: dayjs.utc(props.date).subtract(12, 'hour'),
-                        end: dayjs.utc(props.date),
-                    },
-                    {
-                        name: 'last1day',
-                        label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.DETAIL.LOG_TAB.LAST_1_DAY'),
-                        start: dayjs.utc(props.date).subtract(1, 'day'),
-                        end: dayjs.utc(props.date),
-                    },
-                    {
-                        name: 'last2day',
-                        label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.DETAIL.LOG_TAB.LAST_2_DAYS'),
-                        start: dayjs.utc(props.date).subtract(2, 'day'),
-                        end: dayjs.utc(props.date),
-                    },
-                ]);
-            }),
-            selectedTimeWithin: 'auto',
+            timeWithinList: computed<PeriodItem[]>(() => ([
+                {
+                    name: 'last1day',
+                    label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.DETAIL.LOG_TAB.LAST_1_DAY'),
+                    start: dayjs.utc(props.date).subtract(1, 'day'),
+                    end: dayjs.utc(props.date),
+                },
+                {
+                    name: 'last2day',
+                    label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.DETAIL.LOG_TAB.LAST_3_DAYS'),
+                    start: dayjs.utc(props.date).subtract(3, 'day'),
+                    end: dayjs.utc(props.date),
+                },
+                {
+                    name: 'last1week',
+                    label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.DETAIL.LOG_TAB.LAST_A_WEEK'),
+                    start: dayjs.utc(props.date).subtract(1, 'week'),
+                    end: dayjs.utc(props.date),
+                },
+            ])),
+            selectedTimeWithin: 'last1day',
             layouts: [] as DynamicLayout[],
             currentLayout: computed(() => state.layouts.find((layout) => layout.name === state.activeTab)),
             dataSourceIds: {} as { [key: string]: string },


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- change default tab from auto to last1day
- add log tab to CloudServiceDetail page
