### PR TITLE
Removing code that disables amCharts branding

### DIFF
--- a/src/common/components/charts/metric-chart/MetricChart.vue
+++ b/src/common/components/charts/metric-chart/MetricChart.vue
@@ -176,7 +176,6 @@ export default defineComponent<MetricChartProps>({
 
         const drawChart = (ctx) => {
             const chart: any = am4core.create(ctx, am4charts.XYChart);
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.paddingLeft = -5;
             chart.paddingBottom = -10;
             chart.paddingTop = 10;

--- a/src/services/alert-manager/alert-dashboard/modules/CurrentProjectStatusWidget.vue
+++ b/src/services/alert-manager/alert-dashboard/modules/CurrentProjectStatusWidget.vue
@@ -121,7 +121,6 @@ export default {
 
             const chart = createChart();
             state.chart = chart;
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.responsive.enabled = true;
             chart.innerRadius = am4core.percent(62);
 

--- a/src/services/alert-manager/alert-dashboard/modules/alert-history-widget/AlertHistoryChart.vue
+++ b/src/services/alert-manager/alert-dashboard/modules/alert-history-widget/AlertHistoryChart.vue
@@ -125,7 +125,6 @@ export default {
             };
             const chart = createChart();
             state.chart = chart;
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.paddingLeft = -5;
             chart.paddingBottom = -10;
             chart.paddingTop = -10;

--- a/src/services/asset-inventory/collector/collector-history/modules/CollectorHistoryChart.vue
+++ b/src/services/asset-inventory/collector/collector-history/modules/CollectorHistoryChart.vue
@@ -158,7 +158,6 @@ export default {
             };
             const chart = createChart();
             state.chart = chart;
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.paddingLeft = -5;
             chart.paddingBottom = -10;
             chart.data = state.chartData;

--- a/src/services/cost-explorer/budget/budget-detail/modules/budget-summary/BudgetSummaryChart.vue
+++ b/src/services/cost-explorer/budget/budget-detail/modules/budget-summary/BudgetSummaryChart.vue
@@ -123,7 +123,6 @@ export default {
             };
             const chart = createChart();
             state.chart = chart;
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
 
             /* Create axes */
             const categoryAxis = chart.xAxes.push(new am4charts.CategoryAxis());

--- a/src/services/cost-explorer/cost-analysis/modules/CostAnalysisStackedColumnChart.vue
+++ b/src/services/cost-explorer/cost-analysis/modules/CostAnalysisStackedColumnChart.vue
@@ -200,7 +200,6 @@ export default {
             state.USDChartData = USDChartData;
 
             const chart = am4core.create(chartContainer, am4charts.XYChart);
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.events.on('ready', () => {
                 state.isChartDrawn = true;
             });

--- a/src/services/cost-explorer/widgets/AWSCloudFrontCost.vue
+++ b/src/services/cost-explorer/widgets/AWSCloudFrontCost.vue
@@ -249,7 +249,6 @@ export default {
         };
         const drawChart = (chartContext, chartData, legends) => {
             const chart: any = am4core.create(chartContext, am4charts.XYChart);
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.events.on('ready', () => {
                 emit('rendered');
             });

--- a/src/services/cost-explorer/widgets/AWSDataTransferByRegion.vue
+++ b/src/services/cost-explorer/widgets/AWSDataTransferByRegion.vue
@@ -251,7 +251,6 @@ export default {
                 emit('rendered');
             });
 
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.chartContainer.wheelable = true;
             chart.zoomControl = new am4maps.ZoomControl();
 

--- a/src/services/cost-explorer/widgets/AWSDataTransferCostTrend.vue
+++ b/src/services/cost-explorer/widgets/AWSDataTransferCostTrend.vue
@@ -273,7 +273,6 @@ export default {
         };
         const drawChart = (chartContext, chartData, legends) => {
             const chart: any = am4core.create(chartContext, am4charts.XYChart);
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.events.on('ready', () => {
                 emit('rendered');
             });

--- a/src/services/cost-explorer/widgets/CostByRegion.vue
+++ b/src/services/cost-explorer/widgets/CostByRegion.vue
@@ -226,7 +226,6 @@ export default defineComponent<WidgetProps>({
                 return state.chartRegistry[chartContext];
             };
             const chart = createChart();
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
 
             chart.events.on('ready', () => {
                 emit('rendered');

--- a/src/services/cost-explorer/widgets/CostDonut.vue
+++ b/src/services/cost-explorer/widgets/CostDonut.vue
@@ -172,7 +172,6 @@ export default defineComponent<WidgetProps>({
             }
 
             chart.innerRadius = am4core.percent(65);
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.events.on('ready', () => {
                 emit('rendered');
             });

--- a/src/services/cost-explorer/widgets/CostPie.vue
+++ b/src/services/cost-explorer/widgets/CostPie.vue
@@ -186,7 +186,6 @@ export default defineComponent<WidgetProps>({
             chart.paddingTop = 5;
             chart.paddingBottom = 5;
             chart.radius = am4core.percent(100);
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
 
             const series = chart.series.push(new am4charts.PieSeries());
             if (props.printMode) series.showOnInit = false;

--- a/src/services/cost-explorer/widgets/CostTreeMap.vue
+++ b/src/services/cost-explorer/widgets/CostTreeMap.vue
@@ -188,7 +188,6 @@ export default defineComponent<WidgetProps>({
                 return state.chartRegistry[chartContext];
             };
             const chart = createChart();
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.events.on('ready', () => {
                 emit('rendered');
             });

--- a/src/services/cost-explorer/widgets/CostTrendLine.vue
+++ b/src/services/cost-explorer/widgets/CostTrendLine.vue
@@ -196,7 +196,6 @@ export default {
                 return state.chartRegistry[chartContext];
             };
             const chart = createChart();
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.events.on('ready', () => {
                 emit('rendered');
             });

--- a/src/services/cost-explorer/widgets/LastMonthTotalSpend.vue
+++ b/src/services/cost-explorer/widgets/LastMonthTotalSpend.vue
@@ -138,7 +138,6 @@ export default defineComponent<WidgetProps>({
             };
             const chart = createChart();
             state.chart = chart;
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.events.on('ready', () => {
                 emit('rendered');
             });

--- a/src/services/home-dashboard/modules/ResourceMap.vue
+++ b/src/services/home-dashboard/modules/ResourceMap.vue
@@ -278,7 +278,6 @@ export default {
             chart.geodata = am4geodataWorldLow;
             chart.projection = new am4maps.projections.Miller();
             chart.responsive.enabled = true;
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.chartContainer.wheelable = true;
 
             const polygonSeries = chart.series.push(new am4maps.MapPolygonSeries());

--- a/src/services/home-dashboard/modules/ServiceAccounts.vue
+++ b/src/services/home-dashboard/modules/ServiceAccounts.vue
@@ -157,7 +157,6 @@ export default {
             };
             const chart = createChart();
             state.chart = chart;
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.responsive.enabled = true;
             chart.innerRadius = am4core.percent(63);
 

--- a/src/services/home-dashboard/modules/TopProjects.vue
+++ b/src/services/home-dashboard/modules/TopProjects.vue
@@ -188,7 +188,6 @@ export default {
         /* Util */
         const drawChart = (chartContext) => {
             const chart = am4core.create(chartContext, am4charts.XYChart);
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.paddingRight = 10;
             chart.paddingLeft = -5;
             chart.paddingTop = 5;

--- a/src/services/project/project-detail/project-summary/modules/ProjectAllSummary.vue
+++ b/src/services/project/project-detail/project-summary/modules/ProjectAllSummary.vue
@@ -252,7 +252,6 @@ export default {
             const chart = createChart();
             state.chart = chart;
 
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.paddingLeft = -5;
             chart.paddingBottom = 0;
             chart.paddingTop = 10;

--- a/src/services/project/project-detail/project-summary/modules/ProjectBilling.vue
+++ b/src/services/project/project-detail/project-summary/modules/ProjectBilling.vue
@@ -286,7 +286,6 @@ export default {
                 return chartState.registry[state.chartRef];
             };
             const chart = createChart();
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.paddingLeft = -5;
             chart.paddingBottom = -10;
             chart.paddingTop = 10;

--- a/src/services/project/project-detail/project-summary/modules/ProjectRegionService.vue
+++ b/src/services/project/project-detail/project-summary/modules/ProjectRegionService.vue
@@ -143,7 +143,6 @@ export default {
             };
             const chart = createChart();
             state.chart = chart;
-            if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
             chart.responsive.enabled = true;
             chart.innerRadius = am4core.percent(63);
 


### PR DESCRIPTION
### Description

The only proper way to remove amCharts branding is via application of a commercial license acquired from amCharts.

It is alrady applied correctly via `initAmcharts()` function.

However, some widgets have a hardcoded code that disables amCharts branding even without proper license.

This PR removes those lines to get in-line with [amCharts free license](https://github.com/amcharts/amcharts4/blob/master/dist/script/LICENSE).