### PR TITLE
feat(dashboard-create): show dashboard templates depending on selected scope and fix UI

### DIFF
--- a/packages/cloudforet/language-pack/console-translation.babel
+++ b/packages/cloudforet/language-pack/console-translation.babel
@@ -20357,6 +20357,27 @@
                                 </translations>
                             </concept_node>
                             <concept_node>
+                                <name>CONTINUE</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
                                 <name>CREATE</name>
                                 <definition_loaded>false</definition_loaded>
                                 <description/>
@@ -20378,7 +20399,49 @@
                                 </translations>
                             </concept_node>
                             <concept_node>
+                                <name>CREATE_NEW_DASHBOARD</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
                                 <name>ENTIRE_WORKSPACES</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
+                                <name>GO_BACK</name>
                                 <definition_loaded>false</definition_loaded>
                                 <description/>
                                 <comment/>
@@ -20631,6 +20694,69 @@
                             </concept_node>
                             <concept_node>
                                 <name>SINGLE_PROJECT</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
+                                <name>STEP</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
+                                <name>STEP1_DESC</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
+                                <name>STEP2_DESC</name>
                                 <definition_loaded>false</definition_loaded>
                                 <description/>
                                 <comment/>

--- a/packages/cloudforet/language-pack/en.json
+++ b/packages/cloudforet/language-pack/en.json
@@ -1149,8 +1149,11 @@
 		"CREATE": {
 			"BLANK_DESC": "Build your own dashboard from scratch.",
 			"CANCEL": "Cancel",
+			"CONTINUE": "Continue",
 			"CREATE": "Create",
+			"CREATE_NEW_DASHBOARD": "Create New Dashboard",
 			"ENTIRE_WORKSPACES": "Entire Workspace",
+			"GO_BACK": "Go to Back",
 			"LABEL_DEFAULT_TEMPLATE": "Default Template",
 			"LABEL_EXISTING_DASHBOARD": "Existing Dashboard",
 			"LABEL_SCOPE": "Dashboard Scope",
@@ -1163,6 +1166,9 @@
 			"PUBLIC": "Public",
 			"PUBLIC_DESC": "Anyone who has 'View' access to selected dashboard scope",
 			"SINGLE_PROJECT": "Single Project",
+			"STEP": "Step",
+			"STEP1_DESC": "Choose dashboard scope and viewer.",
+			"STEP2_DESC": "Choose a template or an existing dashboard to get started quickly.",
 			"TITLE": "Create New Dashboard",
 			"VALIDATION_PROJECT": "Please Select Project",
 			"VALIDATION_TEMPLATE": "Please Select Template."

--- a/packages/cloudforet/language-pack/ja.json
+++ b/packages/cloudforet/language-pack/ja.json
@@ -1149,8 +1149,11 @@
 		"CREATE": {
 			"BLANK_DESC": "空のダッシュボードを利用して、最初から作成",
 			"CANCEL": "キャンセル",
+			"CONTINUE": "",
 			"CREATE": "作成",
+			"CREATE_NEW_DASHBOARD": "新規ダッシュボード作成",
 			"ENTIRE_WORKSPACES": "ワークスペース全体",
+			"GO_BACK": "",
 			"LABEL_DEFAULT_TEMPLATE": "デフォルトテンプレートから選択",
 			"LABEL_EXISTING_DASHBOARD": "既存のダッシュボードから選択",
 			"LABEL_SCOPE": "ダッシュボードの範囲",
@@ -1163,6 +1166,9 @@
 			"PUBLIC": "公開",
 			"PUBLIC_DESC": "該当するダッシュボード範囲に「view」アクセス権限を持つすべてのユーザー",
 			"SINGLE_PROJECT": "個別プロジェクト",
+			"STEP": "",
+			"STEP1_DESC": "",
+			"STEP2_DESC": "",
 			"TITLE": "新規ダッシュボード作成",
 			"VALIDATION_PROJECT": "プロジェクトを選択してください。",
 			"VALIDATION_TEMPLATE": "テンプレートを選択してください"

--- a/packages/cloudforet/language-pack/ko.json
+++ b/packages/cloudforet/language-pack/ko.json
@@ -1149,8 +1149,11 @@
 		"CREATE": {
 			"BLANK_DESC": "빈 대시보드 사용하여 처음부터 전체 구성",
 			"CANCEL": "취소",
+			"CONTINUE": "",
 			"CREATE": "생성",
+			"CREATE_NEW_DASHBOARD": "대시보드 생성",
 			"ENTIRE_WORKSPACES": "전체 워크스페이스",
+			"GO_BACK": "",
 			"LABEL_DEFAULT_TEMPLATE": "기본 템플릿 중 선택",
 			"LABEL_EXISTING_DASHBOARD": "저장된 대시보드 중 선택",
 			"LABEL_SCOPE": "대시보드 범위",
@@ -1163,6 +1166,9 @@
 			"PUBLIC": "공개",
 			"PUBLIC_DESC": "해당 대시보드 범위에 'View' 엑세스 권한을 갖는 모든 유저",
 			"SINGLE_PROJECT": "개별 프로젝트",
+			"STEP": "",
+			"STEP1_DESC": "",
+			"STEP2_DESC": "",
 			"TITLE": "대시보드 생성",
 			"VALIDATION_PROJECT": "프로젝트를 선택해주세요.",
 			"VALIDATION_TEMPLATE": "템플릿을 선택하세요."

--- a/src/services/dashboards/DashboardsContainer.vue
+++ b/src/services/dashboards/DashboardsContainer.vue
@@ -10,6 +10,21 @@
                 <router-view />
             </template>
         </vertical-page-layout>
+        <!-- TODO: <centered-page-layout/> to be developed -->
+        <div v-else-if="$route.meta.centeredLayout"
+             class="centered-page-layout"
+        >
+            <p-icon-button
+                class="go-back-button"
+                name="ic_close"
+                size="lg"
+                @click="$router.go(-1)"
+            />
+            <div class="page-contents">
+                <router-view />
+            </div>
+        </div>
+        <!-- // centered-page-layout-->
         <general-page-layout v-else
                              :breadcrumbs="breadcrumbs"
         >
@@ -19,6 +34,8 @@
 </template>
 
 <script lang="ts">
+import { PIconButton } from '@spaceone/design-system';
+
 import { useBreadcrumbs } from '@/common/composables/breadcrumbs';
 import GeneralPageLayout from '@/common/modules/page-layouts/GeneralPageLayout.vue';
 import VerticalPageLayout from '@/common/modules/page-layouts/VerticalPageLayout.vue';
@@ -27,7 +44,9 @@ import DashboardsLNB from '@/services/dashboards/DashboardsLNB.vue';
 
 export default {
     name: 'DashboardsContainer',
-    components: { DashboardsLNB, GeneralPageLayout, VerticalPageLayout },
+    components: {
+        DashboardsLNB, GeneralPageLayout, VerticalPageLayout, PIconButton,
+    },
     setup() {
         const { breadcrumbs } = useBreadcrumbs();
         return {
@@ -36,3 +55,18 @@ export default {
     },
 };
 </script>
+<style lang="postcss" scoped>
+.centered-page-layout {
+    @apply flex flex-col flex-grow;
+    background: url('@/assets/images/img_blurred-background.png') no-repeat 50% -$gnb-height / 90rem auto;
+    .go-back-button {
+        @apply absolute;
+        top: 0;
+        right: 1.5rem;
+    }
+    .page-contents {
+        @apply relative flex flex-col;
+        margin: auto 0;
+    }
+}
+</style>

--- a/src/services/dashboards/DashboardsContainer.vue
+++ b/src/services/dashboards/DashboardsContainer.vue
@@ -14,12 +14,6 @@
         <div v-else-if="$route.meta.centeredLayout"
              class="centered-page-layout"
         >
-            <p-icon-button
-                class="go-back-button"
-                name="ic_close"
-                size="lg"
-                @click="$router.go(-1)"
-            />
             <div class="page-contents">
                 <router-view />
             </div>
@@ -34,7 +28,6 @@
 </template>
 
 <script lang="ts">
-import { PIconButton } from '@spaceone/design-system';
 
 import { useBreadcrumbs } from '@/common/composables/breadcrumbs';
 import GeneralPageLayout from '@/common/modules/page-layouts/GeneralPageLayout.vue';
@@ -45,7 +38,7 @@ import DashboardsLNB from '@/services/dashboards/DashboardsLNB.vue';
 export default {
     name: 'DashboardsContainer',
     components: {
-        DashboardsLNB, GeneralPageLayout, VerticalPageLayout, PIconButton,
+        DashboardsLNB, GeneralPageLayout, VerticalPageLayout,
     },
     setup() {
         const { breadcrumbs } = useBreadcrumbs();
@@ -59,11 +52,6 @@ export default {
 .centered-page-layout {
     @apply flex flex-col flex-grow;
     background: url('@/assets/images/img_blurred-background.png') no-repeat 50% -$gnb-height / 90rem auto;
-    .go-back-button {
-        @apply absolute;
-        top: 0;
-        right: 1.5rem;
-    }
     .page-contents {
         @apply relative flex flex-col;
         margin: auto 0;

--- a/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -125,7 +125,7 @@ export default {
             dashboardViewerType: DASHBOARD_VIEWER.PUBLIC as DashboardViewer,
             steps: [
                 { step: 1, description: i18n.t('DASHBOARDS.CREATE.STEP1_DESC') },
-                { step: 2, description: i18n.t('DASHBOARDS.CREATE.STEP1_DESC') },
+                { step: 2, description: i18n.t('DASHBOARDS.CREATE.STEP2_DESC') },
             ],
             currentStep: 1,
             valid: computed(() => {

--- a/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -182,17 +182,11 @@ export default {
 
 <style lang="postcss" scoped>
 .button-area {
-    @apply flex justify-end;
-    margin-top: 2rem;
-    gap: 1rem;
-
-    @screen tablet {
-        @apply flex-col;
-    }
+    @apply flex justify-end mt-8 gap-4;
 }
 .dashboard-create-step1 {
     @apply w-full;
-    width: 30rem;
+    max-width: 30rem;
     padding: 2.5rem;
     margin: 0 auto;
 
@@ -203,10 +197,14 @@ export default {
 .dashboard-create-step2 {
     width: 62.5rem;
     margin: 0 auto;
-    padding: 0.25rem 1.5rem 4.0625rem;
+    padding: 2rem 1.5rem 4.0625rem;
 
     @screen tablet {
-        @apply w-full;
+        @apply w-full p-8;
+
+        .button-area {
+            @apply flex-col w-full mt-4;
+        }
     }
     .dashboard-create-header {
         @apply mb-8;

--- a/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -1,39 +1,76 @@
 <template>
     <div class="dashboard-create-page">
-        <p-heading
-            show-back-button
-            :title="$t('DASHBOARDS.CREATE.TITLE')"
-            @click-back-button="$router.go(-1)"
-        />
-        <section class="dashboard-create-form-container">
+        <div v-if="currentStep === steps[0].step"
+             class="dashboard-create-step1"
+        >
+            <dashboard-create-header
+                :description="steps[0].description"
+                :total-steps="steps.length"
+                :current-step="currentStep"
+            />
             <dashboard-scope-form :dashboard-scope.sync="dashboardScope"
                                   @set-project="setForm('dashboardProject', $event)"
             />
-            <dashboard-template-form @set-template="setForm('dashboardTemplate', $event)" />
             <dashboard-viewer-form :dashboard-viewer-type.sync="dashboardViewerType" />
-        </section>
-        <div class="dashboard-create-buttons">
-            <p-button style-type="tertiary"
-                      size="lg"
-                      @click="$router.go(-1)"
-            >
-                {{ $t('DASHBOARDS.CREATE.CANCEL') }}
-            </p-button>
-            <p-button style-type="primary"
-                      size="lg"
-                      :disabled="!isAllValid"
-                      @click="handleClickCreate"
-            >
-                {{ $t('DASHBOARDS.CREATE.CREATE') }}
-            </p-button>
+            <div class="button-area">
+                <p-button
+                    style-type="transparent"
+                    size="lg"
+                    @click="$router.go(-1)"
+                >
+                    Cancel
+                </p-button>
+                <p-button
+                    style-type="primary"
+                    size="lg"
+                    :loading="false"
+                    :disabled="!valid"
+                    @click="handleGoStep(2)"
+                >
+                    Continue
+                </p-button>
+            </div>
+        </div>
+        <div v-if="currentStep === steps[1].step"
+             class="dashboard-create-step2 max-w-lg2"
+        >
+            <dashboard-create-header
+                :description="steps[1].description"
+                :total-steps="steps.length"
+                :current-step="currentStep"
+            />
+            <dashboard-template-form
+                :dashboard-scope="dashboardScope"
+                @set-template="setForm('dashboardTemplate', $event)"
+            />
+            <div class="button-area">
+                <p-button
+                    style-type="transparent"
+                    size="lg"
+                    icon-left="ic_arrow-left"
+                    @click="handleGoStep(1)"
+                >
+                    Go to Back
+                </p-button>
+                <p-button
+                    style-type="primary"
+                    size="lg"
+                    :disabled="!isAllValid"
+                    @click="handleClickCreate"
+                >
+                    Create New Dashboard
+                </p-button>
+            </div>
         </div>
     </div>
 </template>
 
 <script lang="ts">
-import { reactive, toRefs } from 'vue';
+import { computed, reactive, toRefs } from 'vue';
 
-import { PHeading, PButton } from '@spaceone/design-system';
+import {
+    PButton,
+} from '@spaceone/design-system';
 
 import { SpaceRouter } from '@/router';
 import { i18n } from '@/translations';
@@ -45,6 +82,7 @@ import {
     DASHBOARD_VIEWER,
 } from '@/services/dashboards/config';
 import type { DashboardScope, DashboardViewer } from '@/services/dashboards/config';
+import DashboardCreateHeader from '@/services/dashboards/dashboard-create/modules/DashboardCreateHeader.vue';
 import DashboardScopeForm from '@/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue';
 import DashboardTemplateForm from '@/services/dashboards/dashboard-create/modules/DashboardTemplateForm.vue';
 import DashboardViewerForm from '@/services/dashboards/dashboard-create/modules/DashboardViewerForm.vue';
@@ -57,19 +95,16 @@ import type { ProjectItemResp } from '@/services/project/type';
 export default {
     name: 'CreateDashboardPage',
     components: {
+        DashboardCreateHeader,
         DashboardViewerForm,
         DashboardTemplateForm,
         DashboardScopeForm,
-        PHeading,
         PButton,
     },
     setup() {
         const dashboardDetailStore = useDashboardDetailInfoStore();
         const {
-            forms: {
-                dashboardTemplate,
-                dashboardProject,
-            },
+            forms: { dashboardTemplate, dashboardProject },
             setForm,
             isAllValid,
         } = useFormValidator({
@@ -88,8 +123,22 @@ export default {
         const state = reactive({
             dashboardScope: DASHBOARD_SCOPE.DOMAIN as DashboardScope,
             dashboardViewerType: DASHBOARD_VIEWER.PUBLIC as DashboardViewer,
+            steps: [
+                { step: 1, name: 'choose scope and viewer', description: 'Choose dashboard scope and viewer.' },
+                { step: 2, name: 'choose template', description: 'Choose a template or an existing dashboard to get started quickly.' },
+            ],
+            currentStep: 1,
+            valid: computed(() => {
+                if (state.dashboardScope === DASHBOARD_SCOPE.PROJECT) return !!dashboardProject.value?.id;
+                if (state.dashboardScope === DASHBOARD_SCOPE.DOMAIN) return true;
+                return false;
+            }),
         });
 
+
+        const handleGoStep = (step) => {
+            state.currentStep = step;
+        };
         const handleClickCreate = () => {
             let _dashboardTemplate;
             if (state.dashboardScope === DASHBOARD_SCOPE.PROJECT) {
@@ -125,22 +174,42 @@ export default {
             setForm,
             isAllValid,
             handleClickCreate,
+            handleGoStep,
         };
     },
 };
 </script>
 
 <style lang="postcss" scoped>
-.dashboard-create-form-container {
-    display: grid;
-    grid-gap: 1rem;
+.button-area {
+    @apply flex justify-end;
+    margin-top: 2rem;
+    gap: 1rem;
+
+    @screen tablet {
+        @apply flex-col;
+    }
 }
-.dashboard-create-buttons {
-    display: inline-flex;
-    float: right;
-    margin-top: 1rem;
-    & .p-button {
-        margin-left: 1rem;
+.dashboard-create-step1 {
+    @apply w-full;
+    width: 30rem;
+    padding: 2.5rem;
+    margin: 0 auto;
+
+    @screen tablet {
+        @apply w-full;
+    }
+}
+.dashboard-create-step2 {
+    width: 62.5rem;
+    margin: 0 auto;
+    padding: 0.25rem 1.5rem 4.0625rem;
+
+    @screen tablet {
+        @apply w-full;
+    }
+    .dashboard-create-header {
+        @apply mb-8;
     }
 }
 </style>

--- a/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -4,7 +4,7 @@
              class="dashboard-create-step1"
         >
             <dashboard-create-header
-                :description="steps[0].description"
+                :description="steps[currentStep - 1].description"
                 :total-steps="steps.length"
                 :current-step="currentStep"
             />
@@ -23,8 +23,7 @@
                 <p-button
                     style-type="primary"
                     size="lg"
-                    :loading="false"
-                    :disabled="!valid"
+                    :disabled="!isValid"
                     @click="handleGoStep(2)"
                 >
                     {{ $t('DASHBOARDS.CREATE.CONTINUE') }}
@@ -32,10 +31,10 @@
             </div>
         </div>
         <div v-if="currentStep === steps[1].step"
-             class="dashboard-create-step2 max-w-lg2"
+             class="dashboard-create-step2"
         >
             <dashboard-create-header
-                :description="steps[1].description"
+                :description="steps[currentStep - 1].description"
                 :total-steps="steps.length"
                 :current-step="currentStep"
             />
@@ -128,7 +127,7 @@ export default {
                 { step: 2, description: i18n.t('DASHBOARDS.CREATE.STEP2_DESC') },
             ],
             currentStep: 1,
-            valid: computed(() => {
+            isValid: computed(() => {
                 if (state.dashboardScope === DASHBOARD_SCOPE.PROJECT) return !!dashboardProject.value?.id;
                 if (state.dashboardScope === DASHBOARD_SCOPE.DOMAIN) return true;
                 return false;

--- a/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -18,7 +18,7 @@
                     size="lg"
                     @click="$router.go(-1)"
                 >
-                    Cancel
+                    {{ $t('DASHBOARDS.CREATE.CANCEL') }}
                 </p-button>
                 <p-button
                     style-type="primary"
@@ -27,7 +27,7 @@
                     :disabled="!valid"
                     @click="handleGoStep(2)"
                 >
-                    Continue
+                    {{ $t('DASHBOARDS.CREATE.CONTINUE') }}
                 </p-button>
             </div>
         </div>
@@ -50,7 +50,7 @@
                     icon-left="ic_arrow-left"
                     @click="handleGoStep(1)"
                 >
-                    Go to Back
+                    {{ $t('DASHBOARDS.CREATE.GO_BACK') }}
                 </p-button>
                 <p-button
                     style-type="primary"
@@ -58,7 +58,7 @@
                     :disabled="!isAllValid"
                     @click="handleClickCreate"
                 >
-                    Create New Dashboard
+                    {{ $t('DASHBOARDS.CREATE.CREATE_NEW_DASHBOARD') }}
                 </p-button>
             </div>
         </div>
@@ -124,8 +124,8 @@ export default {
             dashboardScope: DASHBOARD_SCOPE.DOMAIN as DashboardScope,
             dashboardViewerType: DASHBOARD_VIEWER.PUBLIC as DashboardViewer,
             steps: [
-                { step: 1, name: 'choose scope and viewer', description: 'Choose dashboard scope and viewer.' },
-                { step: 2, name: 'choose template', description: 'Choose a template or an existing dashboard to get started quickly.' },
+                { step: 1, description: i18n.t('DASHBOARDS.CREATE.STEP1_DESC') },
+                { step: 2, description: i18n.t('DASHBOARDS.CREATE.STEP1_DESC') },
             ],
             currentStep: 1,
             valid: computed(() => {

--- a/src/services/dashboards/dashboard-create/modules/DashboardCreateHeader.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardCreateHeader.vue
@@ -1,10 +1,10 @@
 <template>
     <div class="dashboard-create-header">
         <p class="step">
-            Step {{ props.currentStep }}/{{ props.totalSteps }}
+            {{ $t('DASHBOARDS.CREATE.STEP') }} {{ props.currentStep }}/{{ props.totalSteps }}
         </p>
         <h2 class="heading">
-            Create New Dashboard
+            {{ $t('DASHBOARDS.CREATE.TITLE') }}
         </h2>
         <p class="description">
             {{ props.description }}

--- a/src/services/dashboards/dashboard-create/modules/DashboardCreateHeader.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardCreateHeader.vue
@@ -1,0 +1,38 @@
+<template>
+    <div class="dashboard-create-header">
+        <p class="step">
+            Step {{ props.currentStep }}/{{ props.totalSteps }}
+        </p>
+        <h2 class="heading">
+            Create New Dashboard
+        </h2>
+        <p class="description">
+            {{ props.description }}
+        </p>
+    </div>
+</template>
+
+<script lang="ts" setup>
+interface Props {
+    description: string;
+    totalSteps: number;
+    currentStep: number;
+}
+
+const props = defineProps<Props>();
+
+</script>
+
+<style scoped>
+.dashboard-create-header {
+    .step {
+        @apply mb-1 text-label-sm text-gray-500;
+    }
+    .heading {
+        @apply mb-1 text-display-md text-gray-900 font-black;
+    }
+    .description {
+        @apply mt-1 text-label-md text-gray-700;
+    }
+}
+</style>

--- a/src/services/dashboards/dashboard-create/modules/DashboardCreateHeader.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardCreateHeader.vue
@@ -3,9 +3,9 @@
         <p class="step">
             {{ $t('DASHBOARDS.CREATE.STEP') }} {{ props.currentStep }}/{{ props.totalSteps }}
         </p>
-        <h2 class="heading">
+        <p-heading heading-type="main">
             {{ $t('DASHBOARDS.CREATE.TITLE') }}
-        </h2>
+        </p-heading>
         <p class="description">
             {{ props.description }}
         </p>
@@ -13,6 +13,10 @@
 </template>
 
 <script lang="ts" setup>
+import {
+    PHeading,
+} from '@spaceone/design-system';
+
 interface Props {
     description: string;
     totalSteps: number;
@@ -28,8 +32,8 @@ const props = defineProps<Props>();
     .step {
         @apply mb-1 text-label-sm text-gray-500;
     }
-    .heading {
-        @apply mb-1 text-display-md text-gray-900 font-black;
+    .p-heading {
+        @apply mb-0;
     }
     .description {
         @apply mt-1 text-label-md text-gray-700;

--- a/src/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue
@@ -1,30 +1,26 @@
 <template>
     <section class="dashboard-scope-form">
-        <p-pane-layout>
-            <p-heading heading-type="sub"
-                       :title="$t('DASHBOARDS.CREATE.LABEL_SCOPE')"
+        <p-field-title>{{ $t('DASHBOARDS.CREATE.LABEL_SCOPE') }}</p-field-title>
+        <div class="dashboard-scope-wrapper">
+            <p-radio-group direction="vertical">
+                <p-radio :selected="isDomainScope"
+                         :disabled="!workspaceManagePermission"
+                         @change="handleSelectScope(DASHBOARD_SCOPE.DOMAIN)"
+                >
+                    {{ $t('DASHBOARDS.CREATE.ENTIRE_WORKSPACES') }}
+                </p-radio>
+                <p-radio :selected="!isDomainScope"
+                         :disabled="!projectManagePermission"
+                         @change="handleSelectScope(DASHBOARD_SCOPE.PROJECT)"
+                >
+                    {{ $t('DASHBOARDS.CREATE.SINGLE_PROJECT') }}
+                </p-radio>
+            </p-radio-group>
+            <project-select-dropdown v-show="!isDomainScope"
+                                     project-selectable
+                                     @select="handleSelectProjects"
             />
-            <div class="dashboard-scope-wrapper">
-                <p-radio-group direction="vertical">
-                    <p-radio :selected="isDomainScope"
-                             :disabled="!workspaceManagePermission"
-                             @change="handleSelectScope(DASHBOARD_SCOPE.DOMAIN)"
-                    >
-                        {{ $t('DASHBOARDS.CREATE.ENTIRE_WORKSPACES') }}
-                    </p-radio>
-                    <p-radio :selected="!isDomainScope"
-                             :disabled="!projectManagePermission"
-                             @change="handleSelectScope(DASHBOARD_SCOPE.PROJECT)"
-                    >
-                        {{ $t('DASHBOARDS.CREATE.SINGLE_PROJECT') }}
-                    </p-radio>
-                </p-radio-group>
-                <project-select-dropdown v-show="!isDomainScope"
-                                         project-selectable
-                                         @select="handleSelectProjects"
-                />
-            </div>
-        </p-pane-layout>
+        </div>
     </section>
 </template>
 
@@ -35,7 +31,7 @@ import {
 } from 'vue';
 
 import {
-    PPaneLayout, PHeading, PRadio, PRadioGroup,
+    PRadio, PRadioGroup, PFieldTitle,
 } from '@spaceone/design-system';
 
 import { store } from '@/store';
@@ -52,11 +48,16 @@ import type { ProjectItemResp } from '@/services/project/type';
 export default defineComponent({
     name: 'DashboardScopeForm',
     components: {
+        PFieldTitle,
         ProjectSelectDropdown,
         PRadioGroup,
         PRadio,
-        PHeading,
-        PPaneLayout,
+    },
+    props: {
+        dashboardProject: {
+            type: String,
+            default: '',
+        },
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
@@ -64,6 +65,7 @@ export default defineComponent({
             projectManagePermission: useManagePermissionState(MENU_ID.DASHBOARDS_PROJECT),
             workspaceManagePermission: useManagePermissionState(MENU_ID.DASHBOARDS_WORKSPACE),
         });
+
 
         const handleSelectScope = (scopeType: DashboardScope) => {
             updateScope(scopeType);
@@ -102,15 +104,10 @@ export default defineComponent({
 
 <style lang="postcss" scoped>
 .dashboard-scope-form {
+    @apply mt-8;
     .dashboard-scope-wrapper {
-        .p-radio-group {
-            display: grid;
-            grid-gap: 0.875rem;
-        }
         .project-select-dropdown {
-            max-width: 30rem;
-            width: 50%;
-            margin: 0.375rem 0 0 1.125rem;
+            @apply mt-1 ml-6;
         }
 
         @screen tablet {
@@ -118,7 +115,6 @@ export default defineComponent({
                 width: 100%;
             }
         }
-        margin: 0.5rem 1rem 2.25rem;
     }
 }
 </style>

--- a/src/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue
@@ -16,7 +16,7 @@
                     {{ $t('DASHBOARDS.CREATE.SINGLE_PROJECT') }}
                 </p-radio>
             </p-radio-group>
-            <project-select-dropdown v-show="!isDomainScope"
+            <project-select-dropdown :disabled="isDomainScope"
                                      project-selectable
                                      @select="handleSelectProjects"
             />

--- a/src/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue
@@ -66,7 +66,6 @@ export default defineComponent({
             workspaceManagePermission: useManagePermissionState(MENU_ID.DASHBOARDS_WORKSPACE),
         });
 
-
         const handleSelectScope = (scopeType: DashboardScope) => {
             updateScope(scopeType);
         };

--- a/src/services/dashboards/dashboard-create/modules/DashboardTemplateForm.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardTemplateForm.vue
@@ -1,171 +1,204 @@
 <template>
-    <section>
-        <p-pane-layout>
-            <p-heading heading-type="sub"
-                       :title="$t('DASHBOARDS.CREATE.LABEL_START_FROM')"
-            />
-            <div class="dashboard-template-wrapper">
-                <div class="dashboard-template-container">
-                    <div class="card-container">
-                        <span class="card-wrapper-title">
-                            {{ $t('DASHBOARDS.CREATE.LABEL_DEFAULT_TEMPLATE') }}
-                        </span>
-                        <div class="card-wrapper">
-                            <p-board
-                                selectable
-                                style-type="cards"
-                                :style-options="{ column: 2 }"
-                                :board-sets="defaultTemplateState.boardSets"
-                                :selected-item="state.selectedTemplateName"
-                                @item-click="handleSelectTemplate"
-                            >
-                                <template #item-content="{board}">
-                                    <strong class="dashboard-name">{{ board.name }}</strong>
-                                    <div class="dashboard-label-wrapper">
-                                        <p-label v-for="(label, idx) in board.labels"
-                                                 :key="`board-${board.name}-label-${idx}`"
-                                                 :text="label"
-                                                 :click-stop="false"
-                                        />
-                                    </div>
-                                    <span class="dashboard-description-text">{{ board.description.text }}</span>
-                                </template>
-                                <template #item-overlay-content="{board}">
-                                    <router-link
-                                        v-if="board.description?.preview_image"
-                                        :to="`/images/dashboard-previews/dashboard-img_${board.description?.preview_image}--thumbnail.png`"
-                                        target="_blank"
-                                    >
-                                        <div class="dashboard-template-overlay-content">
-                                            <span class="dashboard-template-overlay-preview">{{ $t('DASHBOARDS.CREATE.PREVIEW') }}</span>
-                                            <p-i name="ic_external-link"
-                                                 height="1em"
-                                                 width="1em"
-                                            />
-                                        </div>
-                                    </router-link>
-                                </template>
-                            </p-board>
-                            <p-text-pagination
-                                v-show="defaultTemplateState.allPage >= 2"
-                                :this-page="defaultTemplateState.thisPage"
-                                :all-page="defaultTemplateState.allPage"
-                                @pageChange="handleChangePagination($event, TEMPLATE_TYPE.EXISTING)"
-                            />
-                        </div>
-                    </div>
-                    <p-divider />
-                    <div class="card-container">
-                        <span class="card-wrapper-title">
-                            {{ $t('DASHBOARDS.CREATE.LABEL_EXISTING_DASHBOARD') }}
-                        </span>
-                        <div class="card-wrapper">
-                            <p-search
-                                :value.sync="existingTemplateState.searchValue"
-                                @update:value="handleInputSearch"
-                            />
-                            <div class="existing-dashboard-board">
-                                <p-board
-                                    selectable
-                                    style-type="cards"
-                                    :style-options="{ column: 2 }"
-                                    :board-sets="existingTemplateState.boardSets"
-                                    :selected-item="state.selectedTemplateName"
-                                    @item-click="handleSelectTemplate"
-                                >
-                                    <template #item-content="{board}">
-                                        <strong class="dashboard-name">{{ board.name }}</strong>
-                                        <div class="dashboard-label-wrapper">
-                                            <p-label v-for="(label, idx) in board.labels"
-                                                     :key="`board-${board.name}-label-${idx}`"
-                                                     :text="label"
-                                                     :click-stop="false"
-                                            />
-                                        </div>
-                                    </template>
-                                    <template #item-overlay-content="{board}">
-                                        <div class="dashboard-template-overlay-content"
-                                             @click="handleOpenDashboardNewTab(board)"
-                                        >
-                                            <span class="dashboard-template-overlay-preview">{{ $t('DASHBOARDS.CREATE.PREVIEW') }}</span>
-                                            <p-i name="ic_external-link"
-                                                 height="1em"
-                                                 width="1em"
-                                            />
-                                        </div>
-                                    </template>
-                                </p-board>
-                                <p-empty
-                                    v-show="!existingTemplateState.boardSets.length"
-                                    show-image
-                                >
-                                    {{ $t('DASHBOARDS.CREATE.NO_DATA') }}
-                                </p-empty>
+    <div class="dashboard-template-wrapper">
+        <p-search
+            :value.sync="state.searchValue"
+            @update:value="handleInputSearch"
+        />
+        <div class="dashboard-template-container">
+            <div class="card-container default-dashboard-board">
+                <span class="card-wrapper-title">
+                    {{ $t('DASHBOARDS.CREATE.LABEL_DEFAULT_TEMPLATE') }}
+                </span>
+                <div class="card-wrapper">
+                    <p-board
+                        selectable
+                        style-type="cards"
+                        :style-options="{ column: 3 }"
+                        :board-sets="defaultTemplateState.boardSets"
+                        :selected-item="state.selectedTemplateName"
+                        @item-click="handleSelectTemplate"
+                    >
+                        <template #item-content="{board}">
+                            <div class="content-layout">
+                                <p-i :name="board.description.icon"
+                                     width="2rem"
+                                     height="2rem"
+                                />
+                                <strong class="dashboard-name">{{ board.name }}</strong>
+                                <div class="dashboard-label-wrapper">
+                                    <p-label v-for="(label, idx) in board.labels"
+                                             :key="`board-${board.name}-label-${idx}`"
+                                             :text="label"
+                                             :click-stop="false"
+                                    />
+                                </div>
+                                <span class="dashboard-description-text">{{ board.description.text }}</span>
                             </div>
-                            <p-text-pagination
-                                v-show="existingTemplateState.allPage >= 2"
-                                :this-page="existingTemplateState.thisPage"
-                                :all-page="existingTemplateState.allPage"
-                                @pageChange="handleChangePagination($event, TEMPLATE_TYPE.EXISTING)"
-                            />
-                        </div>
-                    </div>
+                        </template>
+                        <template #item-overlay-content="{board}">
+                            <router-link
+                                v-if="board.description?.preview_image"
+                                :to="`/images/dashboard-previews/dashboard-img_${board.description?.preview_image}--thumbnail.png`"
+                                target="_blank"
+                            >
+                                <div class="dashboard-template-overlay-content">
+                                    <span class="dashboard-template-overlay-preview">{{ $t('DASHBOARDS.CREATE.PREVIEW') }}</span>
+                                    <p-i name="ic_external-link"
+                                         height="1em"
+                                         width="1em"
+                                    />
+                                </div>
+                            </router-link>
+                        </template>
+                    </p-board>
+                    <p-empty
+                        v-show="!defaultTemplateState.boardSets.length"
+                        show-image
+                    >
+                        {{ $t('DASHBOARDS.CREATE.NO_DATA') }}
+                    </p-empty>
+                    <p-text-pagination
+                        v-show="defaultTemplateState.allPage >= 2"
+                        :this-page="defaultTemplateState.thisPage"
+                        :all-page="defaultTemplateState.allPage"
+                        @pageChange="handleChangePagination($event, TEMPLATE_TYPE.EXISTING)"
+                    />
                 </div>
             </div>
-        </p-pane-layout>
-    </section>
+            <div class="card-container existing-dashboard-board">
+                <span class="card-wrapper-title">
+                    {{ $t('DASHBOARDS.CREATE.LABEL_EXISTING_DASHBOARD') }}
+                </span>
+                <div class="card-wrapper">
+                    <p-board
+                        selectable
+                        style-type="cards"
+                        :board-sets="existingTemplateState.boardSets"
+                        :selected-item="state.selectedTemplateName"
+                        @item-click="handleSelectTemplate"
+                    >
+                        <template #item-content="{board}">
+                            <div class="content-layout">
+                                <strong class="dashboard-name">{{ board.name }}</strong>
+                                <div class="dashboard-info">
+                                    {{ board.groupLabel }}
+                                </div>
+                                <div v-if="board.labels.length > 0"
+                                     class="dashboard-label-wrapper"
+                                >
+                                    <p-label v-for="(label, idx) in board.labels"
+                                             :key="`board-${board.name}-label-${idx}`"
+                                             :text="label"
+                                             :click-stop="false"
+                                    />
+                                </div>
+                            </div>
+                        </template>
+                        <template #item-overlay-content="{board}">
+                            <div class="dashboard-template-overlay-content"
+                                 @click="handleOpenDashboardNewTab(board)"
+                            >
+                                <span class="dashboard-template-overlay-preview">{{ $t('DASHBOARDS.CREATE.PREVIEW') }}</span>
+                                <p-i name="ic_external-link"
+                                     height="1em"
+                                     width="1em"
+                                />
+                            </div>
+                        </template>
+                    </p-board>
+                    <p-empty
+                        v-show="!existingTemplateState.boardSets.length"
+                        show-image
+                    >
+                        {{ $t('DASHBOARDS.CREATE.NO_DATA') }}
+                    </p-empty>
+                    <p-text-pagination
+                        v-show="existingTemplateState.allPage >= 2"
+                        :this-page="existingTemplateState.thisPage"
+                        :all-page="existingTemplateState.allPage"
+                        @pageChange="handleChangePagination($event, TEMPLATE_TYPE.EXISTING)"
+                    />
+                </div>
+            </div>
+        </div>
+    </div>
 </template>
 
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
 import {
-    PPaneLayout, PHeading, PBoard, PLabel, PTextPagination, PSearch, PEmpty, PDivider, PI,
+    PBoard, PLabel, PTextPagination, PSearch, PEmpty, PI,
 } from '@spaceone/design-system';
 
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 
-import type { DashboardConfig } from '@/services/dashboards/config';
+import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
+
+
+import type { DashboardConfig, DashboardScope } from '@/services/dashboards/config';
+import { DASHBOARD_SCOPE } from '@/services/dashboards/config';
 import { DASHBOARD_TEMPLATES } from '@/services/dashboards/default-dashboard/template-list';
 import type { DashboardModel, DomainDashboardModel, ProjectDashboardModel } from '@/services/dashboards/model';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
-
+const DOMAIN_SCOPE_NAME = 'Workspace';
 const emit = defineEmits(['set-template']);
 
-type DashboardTemplateBoardSet = DashboardConfig & { value: string, leftIcon: string };
+type DashboardTemplateBoardSet = DashboardConfig & { value: string };
 
 const TEMPLATE_TYPE = { DEFAULT: 'DEFAULT', EXISTING: 'EXISTING' };
 type TemplateType = typeof TEMPLATE_TYPE[keyof typeof TEMPLATE_TYPE];
+interface Props {
+    dashboardScope: DashboardScope;
+}
+
+const props = defineProps<Props>();
 
 const state = reactive({
     selectedTemplateName: '',
+    searchValue: '',
 });
 const defaultTemplateState = reactive({
     thisPage: 1,
     allPage: computed<number>(() => Math.ceil(Object.values(DASHBOARD_TEMPLATES).length / 10) || 1),
-    boardSets: computed<DashboardTemplateBoardSet[]>(() => Object.values(DASHBOARD_TEMPLATES).map((d: DashboardConfig) => ({
-        ...d,
-        // below values are used only for render
-        value: `${TEMPLATE_TYPE.DEFAULT}-${d.name}`,
-        leftIcon: d.description?.icon ?? '',
-    })).slice(10 * (defaultTemplateState.thisPage - 1), 10 * defaultTemplateState.thisPage - 1)),
-});
-const existingTemplateState = reactive({
-    dashboards: computed<DashboardModel[]>(() => [...store.state.dashboard.domainItems, ...store.state.dashboard.projectItems].filter((d) => d.name.includes(existingTemplateState.searchValue))),
-    thisPage: 1,
-    allPage: computed<number>(() => Math.ceil(existingTemplateState.dashboards.length / 10) || 1),
-    boardSets: computed<DashboardTemplateBoardSet[]>(() => existingTemplateState.dashboards.map((d: DomainDashboardModel & ProjectDashboardModel) => {
-        const isProjectDashboard = Object.prototype.hasOwnProperty.call(d, 'project_dashboard_id');
-        return {
+    boardSets: computed<DashboardTemplateBoardSet[]>(() => Object.values(DASHBOARD_TEMPLATES)
+        .map((d: DashboardConfig) => ({
             ...d,
             // below values are used only for render
-            value: `${TEMPLATE_TYPE.EXISTING}-${d.name}-${isProjectDashboard ? d.project_dashboard_id : d.domain_dashboard_id}`,
-            leftIcon: d.description?.preview_image ?? '',
-        };
-    }).slice(10 * (existingTemplateState.thisPage - 1), 10 * existingTemplateState.thisPage)),
-    searchValue: '',
+            value: `${TEMPLATE_TYPE.DEFAULT}-${d.name}`,
+        }))
+        .filter((d) => d.name.includes(state.searchValue))
+        .slice(10 * (defaultTemplateState.thisPage - 1), 10 * defaultTemplateState.thisPage - 1)),
+});
+const existingTemplateState = reactive({
+    thisPage: 1,
+    allPage: computed<number>(() => Math.ceil(existingTemplateState.dashboards.length / 10) || 1),
+    boardSets: computed<DashboardTemplateBoardSet[]>(() => existingTemplateState.dashboards
+        .map((d: DomainDashboardModel & ProjectDashboardModel) => {
+            const isProjectDashboard = Object.prototype.hasOwnProperty.call(d, 'project_dashboard_id');
+            return {
+                ...d,
+                // below values are used only for render
+                value: `${TEMPLATE_TYPE.EXISTING}-${d.name}-${isProjectDashboard ? d.project_dashboard_id : d.domain_dashboard_id}`,
+                groupLabel: existingTemplateState.projectItems[d.project_id]?.label || existingTemplateState.groupLabel,
+            };
+        })
+        .slice(10 * (existingTemplateState.thisPage - 1), 10 * existingTemplateState.thisPage)),
+    projectItems: computed<ProjectReferenceMap>(() => store.getters['reference/projectItems']),
+    groupLabel: computed<string>(() => {
+        if (props.dashboardScope === DASHBOARD_SCOPE.DOMAIN) return DOMAIN_SCOPE_NAME;
+        return '';
+    }),
+    dashboards: computed<DashboardModel[]>(() => {
+        let dashboardItems;
+        if (props.dashboardScope === DASHBOARD_SCOPE.DOMAIN) dashboardItems = store.state.dashboard.domainItems;
+        else dashboardItems = store.state.dashboard.projectItems;
+
+        return dashboardItems.filter((d) => d.name.includes(state.searchValue));
+    }),
+
 });
 
 const handleOpenDashboardNewTab = (board: DashboardModel) => {
@@ -185,7 +218,6 @@ const handleOpenDashboardNewTab = (board: DashboardModel) => {
 const handleSelectTemplate = (selectedTemplate: DashboardTemplateBoardSet) => {
     state.selectedTemplateName = selectedTemplate.value;
     const _selectedTemplate: Partial<DashboardTemplateBoardSet> = { ...selectedTemplate };
-    delete _selectedTemplate.leftIcon;
     emit('set-template', _selectedTemplate as DashboardModel);
 };
 
@@ -208,43 +240,44 @@ const handleInputSearch = () => {
 
 <style lang="postcss" scoped>
 .dashboard-template-wrapper {
-    padding: 0.5rem 1rem 2.375rem 1rem;
+    @apply relative;
     .dashboard-template-container {
-        @apply bg-gray-100 border-gray-200 grid gap-5;
-        padding: 1rem 1rem 1.25rem;
-        border-width: 1px;
-        border-radius: 0.5rem;
+        @apply overflow-auto;
+        height: calc(100vh - $gnb-height - 1.5rem - 6.5rem - 2rem - 4.5rem - 4.1rem);
+        padding-bottom: 2.5rem;
+        &::-webkit-scrollbar {
+            display: none;
+        }
+        &::after {
+            @apply w-full absolute;
+            height: 2.5rem;
+            content: '';
+            bottom: 0;
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 100%);
+        }
+        .card-container {
+            @apply mt-6;
+        }
         .card-wrapper-title {
             @apply text-gray-500 !important text-xs block;
             font-weight: 700;
             margin-bottom: 0.5rem;
         }
         .dashboard-name {
-            @apply text-sm;
+            @apply text-sm block;
+        }
+        .dashboard-info {
+            @apply text-label-sm text-gray-500;
         }
         .dashboard-description-text {
             @apply text-gray-500 text-xs;
         }
         .dashboard-template-overlay-content {
+            @apply text-blue-700;
             height: 1.5rem;
         }
         .dashboard-template-overlay-preview {
-            @apply text-gray-700 text-sm mr-1;
-            &:hover {
-                @apply underline;
-            }
-        }
-        .existing-dashboard-board {
-            @apply relative;
-            min-height: 5rem;
-
-            @screen tablet {
-                min-height: 54.5rem;
-            }
-
-            @screen mobile {
-                min-height: 54.5rem;
-            }
+            @apply text-sm mr-1;
         }
         .p-empty {
             padding-top: 3.25rem;
@@ -256,11 +289,34 @@ const handleInputSearch = () => {
             @apply flex justify-center;
             margin: 0.75rem auto 0 auto;
         }
-    }
-}
 
-/* custom design-system component - p-board-item */
-:deep(.p-board-item) {
-    min-height: 5rem;
+        .default-dashboard-board {
+            .content-layout {
+                @apply flex flex-col items-center;
+            }
+            .dashboard-name {
+                margin: 0.375rem 0;
+            }
+        }
+
+        .existing-dashboard-board {
+            @apply relative;
+
+            .content-layout {
+                @apply flex flex-col row-gap-1;
+            }
+            .p-board {
+                min-height: 4.125rem;
+            }
+
+            @screen tablet {
+                min-height: 54.5rem;
+            }
+
+            @screen mobile {
+                min-height: 54.5rem;
+            }
+        }
+    }
 }
 </style>

--- a/src/services/dashboards/dashboard-create/modules/DashboardTemplateForm.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardTemplateForm.vue
@@ -21,8 +21,8 @@
                         <template #item-content="{board}">
                             <div class="content-layout">
                                 <p-i :name="board.description.icon"
-                                     width="2rem"
-                                     height="2rem"
+                                     width="2.5rem"
+                                     height="2.5rem"
                                 />
                                 <strong class="dashboard-name">{{ board.name }}</strong>
                                 <div class="dashboard-label-wrapper">
@@ -243,11 +243,8 @@ const handleInputSearch = () => {
     @apply relative;
     .dashboard-template-container {
         @apply overflow-auto;
-        height: calc(100vh - $gnb-height - 1.5rem - 6.5rem - 2rem - 4.5rem - 4.1rem);
+        height: calc(100vh - $gnb-height - 2.5rem - 6.5rem - 2rem - 4.5rem - 4.1rem);
         padding-bottom: 2.5rem;
-        &::-webkit-scrollbar {
-            display: none;
-        }
         &::after {
             @apply w-full absolute;
             height: 2.5rem;
@@ -297,6 +294,21 @@ const handleInputSearch = () => {
             .dashboard-name {
                 margin: 0.375rem 0;
             }
+
+            @screen tablet {
+                .content-layout {
+                    @apply relative items-start;
+                    padding-left: 3.25rem;
+                    min-height: 2.5rem;
+                    .p-i-icon {
+                        @apply absolute;
+                        left: 0;
+                    }
+                }
+                .dashboard-name {
+                    margin: 0;
+                }
+            }
         }
 
         .existing-dashboard-board {
@@ -307,14 +319,6 @@ const handleInputSearch = () => {
             }
             .p-board {
                 min-height: 4.125rem;
-            }
-
-            @screen tablet {
-                min-height: 54.5rem;
-            }
-
-            @screen mobile {
-                min-height: 54.5rem;
             }
         }
     }

--- a/src/services/dashboards/dashboard-create/modules/DashboardViewerForm.vue
+++ b/src/services/dashboards/dashboard-create/modules/DashboardViewerForm.vue
@@ -1,36 +1,37 @@
 <template>
-    <section>
-        <p-pane-layout>
-            <p-heading heading-type="sub"
-                       :title="$t('DASHBOARDS.CREATE.LABEL_VIEWERS')"
-            />
-            <div class="dashboard-viewers-wrapper">
-                <p-radio-group direction="vertical">
-                    <div>
-                        <p-radio
-                            :selected="isPublicViewer"
-                            @change="handleSelectViewer(DASHBOARD_VIEWER.PUBLIC)"
-                        >
-                            {{ $t('DASHBOARDS.CREATE.PUBLIC') }}
-                        </p-radio>
-                        <p class="viewer-description">
-                            {{ $t('DASHBOARDS.CREATE.PUBLIC_DESC') }}
-                        </p>
-                    </div>
-                    <div>
-                        <p-radio
-                            :selected="!isPublicViewer"
-                            @change="handleSelectViewer(DASHBOARD_VIEWER.PRIVATE)"
-                        >
-                            {{ $t('DASHBOARDS.CREATE.PRIVATE') }}
-                        </p-radio>
-                        <p class="viewer-description">
-                            {{ $t('DASHBOARDS.CREATE.PRIVATE_DESC') }}
-                        </p>
-                    </div>
-                </p-radio-group>
-            </div>
-        </p-pane-layout>
+    <section class="dashboard-viewers-form">
+        <p-field-title>{{ $t('DASHBOARDS.CREATE.LABEL_VIEWERS') }}</p-field-title>
+        <div class="dashboard-viewers-wrapper">
+            <p-radio-group direction="vertical">
+                <div>
+                    <p-radio
+                        :selected="isPublicViewer"
+                        @change="handleSelectViewer(DASHBOARD_VIEWER.PUBLIC)"
+                    >
+                        {{ $t('DASHBOARDS.CREATE.PUBLIC') }}
+                    </p-radio>
+                    <p class="viewer-description">
+                        {{ $t('DASHBOARDS.CREATE.PUBLIC_DESC') }}
+                    </p>
+                </div>
+                <div>
+                    <p-radio
+                        :selected="!isPublicViewer"
+                        @change="handleSelectViewer(DASHBOARD_VIEWER.PRIVATE)"
+                    >
+                        <p-i name="ic_lock-filled"
+                             width="0.875rem"
+                             height="0.875rem"
+                             class="mr-1 mb-1 ml-1"
+                        />
+                        {{ $t('DASHBOARDS.CREATE.PRIVATE') }}
+                    </p-radio>
+                    <p class="viewer-description">
+                        {{ $t('DASHBOARDS.CREATE.PRIVATE_DESC') }}
+                    </p>
+                </div>
+            </p-radio-group>
+        </div>
     </section>
 </template>
 
@@ -39,7 +40,7 @@ import type { SetupContext } from 'vue';
 import { reactive, toRefs } from 'vue';
 
 import {
-    PPaneLayout, PHeading, PRadioGroup, PRadio,
+    PFieldTitle, PRadioGroup, PRadio, PI,
 } from '@spaceone/design-system';
 
 import { DASHBOARD_VIEWER } from '@/services/dashboards/config';
@@ -48,10 +49,10 @@ import type { DashboardViewer } from '@/services/dashboards/config';
 export default {
     name: 'DashboardViewerForm',
     components: {
-        PHeading,
-        PPaneLayout,
+        PFieldTitle,
         PRadioGroup,
         PRadio,
+        PI,
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
@@ -73,16 +74,15 @@ export default {
 </script>
 
 <style lang="postcss" scoped>
-.dashboard-viewers-wrapper {
-    padding: 0.5rem 1rem 2.5rem;
-    .p-radio-group {
-        display: grid;
-        grid-gap: 0.815rem;
-    }
-    .viewer-description {
-        @apply text-xs text-gray-500;
-        font-weight: 400;
-        margin: 0.25rem 0 0 1.5rem;
+.dashboard-viewers-form {
+    @apply mt-6;
+    .dashboard-viewers-wrapper {
+        .viewer-description {
+            @apply text-xs text-gray-500;
+            font-weight: 400;
+            margin: 0.25rem 0 0 1.5rem;
+        }
     }
 }
+
 </style>

--- a/src/services/dashboards/routes.ts
+++ b/src/services/dashboards/routes.ts
@@ -39,6 +39,7 @@ const dashboardsRoute: RouteConfig = {
                     path: 'create',
                     name: DASHBOARDS_ROUTE.CREATE._NAME,
                     meta: {
+                        centeredLayout: true,
                         translationId: 'DASHBOARDS.CREATE.TITLE',
                         accessLevel: ACCESS_LEVEL.MANAGE_PERMISSION,
                         accessInfo: {

--- a/src/shims-vue-router.d.ts
+++ b/src/shims-vue-router.d.ts
@@ -27,6 +27,7 @@ import {
   }
   interface RouteMeta {
     lnbVisible?: boolean;
+    centeredLayout?: boolean;
     menuId?: string;
     label?: string|RouteLabelFormatter;
     translationId?: string|RouteTranslationIdFormatter;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [X] New feature
- [ ] Bug fixes
- [X] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [X] `Error / Warning / Lint / Type`

### Description
* Add `<div class="centered-page-layout"/>` to show new page layout.
    <img width="300" alt="image" src="https://user-images.githubusercontent.com/19162140/226841549-5bcafea5-d34f-42b1-8d08-12d802e3c739.png">

* Separate create dashboard page into two steps.
* Show dashboard template lists depending on selected scope on first step.

### Things to Talk About
* `<centered-page-layout/>` component will be developed in the other quest. Because it will be reused reset password page and workspace page. And there are different things from existing page layout components (`<general-page-layout/>`, `<vertical-page-layout/>`). I think it's better to add new layout rather than to customize existing page layout components
    * New layout has no LNB and FNB. 
    * Content of New layout has `max-width`.

* ~~I will add translation code.~~