### PR TITLE
feat(dashboard-variable): create MANUAL options form

### DIFF
--- a/apps/web/src/services/dashboards/config.ts
+++ b/apps/web/src/services/dashboards/config.ts
@@ -74,7 +74,13 @@ export interface DashboardConfig {
 }
 
 // variables
-export type DashboardVariables = Record<string, string|string[]>;
+export type DashboardVariables = SingleSelectDashboardVariables | MultiSelectDashboardVariables;
+interface SingleSelectDashboardVariables {
+    [key: string]: string;
+}
+interface MultiSelectDashboardVariables {
+    [key: string]: string[];
+}
 
 export const VARIABLE_SELECTION_TYPES = ['SINGLE', 'MULTI'] as const;
 export type VariableSelectionType = typeof VARIABLE_SELECTION_TYPES[number];
@@ -83,6 +89,22 @@ export const VARIABLE_TYPES = ['MANAGED', 'CUSTOM'] as const;
 export type VariableType = typeof VARIABLE_TYPES[number];
 
 
+interface DefaultOptions {
+    value: { key: string; label: string; }[];
+    data_source: any;
+    // data_source: {
+    //     resource_type: string;
+    //     provider: string;
+    //     cloud_service_group?: string;
+    // }
+}
+export interface ManualOptions extends DefaultOptions{
+    type: 'MANUAL';
+}
+interface SearchDataSourceOptions extends DefaultOptions{
+    type: 'DATA_SOURCE';
+}
+type LegacyOptions = string[];
 
 // variables schema
 export interface DashboardVariableSchemaProperty {
@@ -92,7 +114,8 @@ export interface DashboardVariableSchemaProperty {
     selection_type: VariableSelectionType;
     description?: string;
     disabled?: boolean;
-    options?: string[];
+    options?: ManualOptions | SearchDataSourceOptions | LegacyOptions;
+    version?: string;
 }
 export interface DashboardVariablesSchema {
     properties: {

--- a/apps/web/src/services/dashboards/config.ts
+++ b/apps/web/src/services/dashboards/config.ts
@@ -89,8 +89,12 @@ export const VARIABLE_TYPES = ['MANAGED', 'CUSTOM'] as const;
 export type VariableType = typeof VARIABLE_TYPES[number];
 
 
-interface DefaultOptions {
-    value: { key: string; label: string; }[];
+export interface ManualOptions {
+    type: 'MANUAL';
+    values: { key: string; label: string; }[];
+}
+export interface SearchDataSourceOptions {
+    type: 'DATA_SOURCE';
     data_source: any;
     // data_source: {
     //     resource_type: string;
@@ -98,13 +102,8 @@ interface DefaultOptions {
     //     cloud_service_group?: string;
     // }
 }
-export interface ManualOptions extends DefaultOptions{
-    type: 'MANUAL';
-}
-interface SearchDataSourceOptions extends DefaultOptions{
-    type: 'DATA_SOURCE';
-}
 type LegacyOptions = string[];
+export type VarialbeOptions = ManualOptions | SearchDataSourceOptions | LegacyOptions;
 
 // variables schema
 export interface DashboardVariableSchemaProperty {
@@ -114,8 +113,7 @@ export interface DashboardVariableSchemaProperty {
     selection_type: VariableSelectionType;
     description?: string;
     disabled?: boolean;
-    options?: ManualOptions | SearchDataSourceOptions | LegacyOptions;
-    version?: string;
+    options?: VarialbeOptions;
 }
 export interface DashboardVariablesSchema {
     properties: {

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -113,7 +113,11 @@ const state = reactive({
             result = Object.entries(props.referenceMap).map(([referenceKey, referenceItem]) => ({
                 name: referenceKey, label: referenceItem?.label ?? referenceItem?.name ?? referenceKey,
             }));
-        } else result = state.variableProperty.options?.map((d) => ({ name: d, label: d }));
+        } else if (Array.isArray(state.variableProperty.options)) {
+            result = state.variableProperty.options?.map((d) => ({ name: d, label: d }));
+        } else {
+            result = state.variableProperty.options.value.map((d) => ({ name: d.key, label: d.label }));
+        }
         return result;
     }),
 });

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -109,15 +109,17 @@ const state = reactive({
     }),
     options: computed<MenuItem[]>(() => {
         let result;
+        // MANAGED variable CASE: options
         if (state.variableProperty.variable_type === 'MANAGED') {
             result = Object.entries(props.referenceMap).map(([referenceKey, referenceItem]) => ({
                 name: referenceKey, label: referenceItem?.label ?? referenceItem?.name ?? referenceKey,
             }));
         } else if (Array.isArray(state.variableProperty.options)) {
             result = state.variableProperty.options?.map((d) => ({ name: d, label: d }));
-        } else {
+        } else if (state.variableProperty.options?.type === 'MANUAL') {
             result = state.variableProperty.options.value.map((d) => ({ name: d.key, label: d.label }));
         }
+        // TODO: need to handle DATA_SOURCE type CASE
         return result;
     }),
 });

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -105,7 +105,7 @@ const state = reactive({
 
         if (state.variableProperty.variable_type === 'MANAGED') {
             return arrayOfSelectedOptions.map((d) => ({ name: d, label: props.referenceMap[d]?.label ?? props.referenceMap[d]?.name ?? d }));
-        } return arrayOfSelectedOptions.map((d) => ({ name: d, label: d }));
+        } return arrayOfSelectedOptions.map((d) => ({ name: d, label: state.options.find((optionItem) => optionItem.name === d).label }));
     }),
     options: computed<MenuItem[]>(() => {
         let result;
@@ -117,10 +117,10 @@ const state = reactive({
         } else if (Array.isArray(state.variableProperty.options)) {
             result = state.variableProperty.options?.map((d) => ({ name: d, label: d }));
         } else if (state.variableProperty.options?.type === 'MANUAL') {
-            result = state.variableProperty.options.value.map((d) => ({ name: d.key, label: d.label }));
+            result = state.variableProperty.options.values.map((d) => ({ name: d.key, label: d.label }));
         }
         // TODO: need to handle DATA_SOURCE type CASE
-        return result;
+        return result ?? [];
     }),
 });
 

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableForm.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableForm.vue
@@ -25,47 +25,17 @@
                                :selected.sync="selectionType"
             />
         </p-field-group>
-        <p-field-group class="options-field"
-                       :label="$t('DASHBOARDS.CUSTOMIZE.VARIABLES.LABEL_OPTIONS')"
-                       required
+        <p-field-group class="description-field"
+                       :label="$t('Description')"
         >
-            <div class="options-wrapper">
-                <p-button class="option-add-button"
-                          icon-left="ic_plus_bold"
-                          style-type="secondary"
-                          @click="handleAddOption"
-                >
-                    {{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.ADD_OPTIONS') }}
-                </p-button>
-                <draggable :list="options"
-                           class="draggable-wrapper"
-                           ghost-class="ghost"
-                >
-                    <div v-for="(option, index) in options"
-                         :key="`drag-item-${option.key}`"
-                         class="draggable-item"
-                    >
-                        <p-i class="grab-area"
-                             name="ic_drag-handle"
-                             width="1rem"
-                             height="1rem"
-                        />
-                        <p-text-input :value="option.value"
-                                      class="option-input"
-                                      :placeholder="$t('DASHBOARDS.CUSTOMIZE.VARIABLES.PLACEHOLDER_OPTIONS')"
-                                      :invalid="option.error"
-                                      @update:value="handleChangeOptionValue(index, $event)"
-                        />
-                        <div class="option-delete-area">
-                            <p-icon-button v-if="options.length > 1"
-                                           name="ic_delete"
-                                           @click="handleDeleteOption(option.key)"
-                            />
-                        </div>
-                    </div>
-                </draggable>
-            </div>
+            <p-text-input class="description-input"
+                          :value="description"
+                          @update:value="setForm('description', $event)"
+            />
         </p-field-group>
+        <dashboard-manage-variable-options-field :is-manual-options-type.sync="isManualOptionsType"
+                                                 :options.sync="options"
+        />
         <div class="button-wrapper">
             <p-button style-type="tertiary"
                       @click="handleCancel"
@@ -83,12 +53,12 @@
 
 <script setup lang="ts">
 import {
-    computed, onMounted, reactive, toRefs,
+    computed, onMounted, reactive, toRefs, watch,
 } from 'vue';
 import draggable from 'vuedraggable';
 
 import {
-    PButton, PFieldGroup, PIconButton, PSelectDropdown, PTextInput, PI, useProxyValue,
+    PButton, PFieldGroup, PSelectDropdown, PTextInput, useProxyValue,
 } from '@spaceone/design-system';
 
 import { i18n } from '@/translations';
@@ -98,8 +68,11 @@ import { getUUID } from '@/lib/component-util/getUUID';
 import { useFormValidator } from '@/common/composables/form-validator';
 
 import type { DashboardVariableSchemaProperty } from '@/services/dashboards/config';
+import DashboardManageVariableOptionsField
+    from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue';
 import type {
     OverlayStatus,
+    OptionItem,
 } from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type';
 
 interface Props {
@@ -112,11 +85,6 @@ interface EmitFn {
     (e: 'save-click', value: DashboardVariableSchemaProperty): void;
     (e: 'cancel-click'): void;
 }
-type OptionItem = {
-    key: string;
-    value: string;
-    error?: boolean;
-};
 
 const props = defineProps<Props>();
 const emit = defineEmits<EmitFn>();
@@ -124,12 +92,14 @@ const emit = defineEmits<EmitFn>();
 const {
     forms: {
         name,
+        description,
     },
     setForm,
     invalidState,
     invalidTexts,
 } = useFormValidator({
     name: '',
+    description: '',
 }, {
     name(value: string) {
         if (props.variableNames.includes(value)) {
@@ -151,6 +121,7 @@ const checkOptionsChanged = (subject: string[] = [], target: {key: string, value
 const state = reactive({
     proxyContentType: useProxyValue('contentType', props, emit),
     selectionType: 'MULTI',
+    isManualOptionsType: true,
     options: [
         { key: getUUID(), value: '' },
     ] as OptionItem[],
@@ -158,17 +129,17 @@ const state = reactive({
         { name: 'MULTI', label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.MULTI_SELECT') },
         { name: 'SINGLE', label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.SINGLE_SELECT') },
     ]),
-
 });
 
 const formInvalidState = reactive({
     baseInvalid: computed<boolean>(() => (invalidState.name ?? true) || (state.options.filter((d) => d.value !== '').length === 0) || state.options.some((option) => option.error)),
     isChanged: computed<boolean>(() => {
         const isNameChanged = (props.selectedVariable?.name ?? '') === name.value;
+        const isDescriptionChanged = (props.selectedVariable?.description ?? '') === description.value;
         const isSelectionTypeChanged = (props.selectedVariable?.selection_type ?? 'MULTI') === state.selectionType;
         const isOptionChanged = checkOptionsChanged(props.selectedVariable?.options ?? [], state.options);
 
-        return isNameChanged && isSelectionTypeChanged && isOptionChanged;
+        return isNameChanged && isDescriptionChanged && isSelectionTypeChanged && isOptionChanged;
     }),
     formInvalid: computed<boolean>(() => {
         if (props.contentType === 'ADD') {
@@ -186,12 +157,6 @@ const handleCancel = () => {
     }
     state.proxyContentType = 'LIST';
 };
-const handleAddOption = () => {
-    state.options = [...state.options, { key: getUUID(), value: '' }];
-};
-const handleDeleteOption = (key: string) => {
-    state.options = state.options.filter((d) => d.key !== key);
-};
 
 const handleSave = () => {
     const variableToSave = {
@@ -199,34 +164,33 @@ const handleSave = () => {
         name: name.value,
         use: false,
         selection_type: state.selectionType,
+        description: description.value,
         options: state.options.map((d) => d.value).filter((value) => value !== ''),
     } as DashboardVariableSchemaProperty;
     emit('save-click', variableToSave);
 };
 
-const handleChangeOptionValue = (index: number, value: string) => {
-    state.options[index].error = state.options.some((option, _index) => {
-        if (index === _index || value === '') return false;
-        return option.value === value;
-    });
-    state.options[index].value = value;
-};
-
 onMounted(() => {
     if (props.contentType === 'EDIT') {
         setForm('name', props.selectedVariable?.name ?? '');
+        setForm('description', props.selectedVariable?.description ?? '');
         state.selectionType = props.selectedVariable?.selection_type ?? 'MULTI';
         state.options = (props.selectedVariable?.options ?? []).map((d) => ({ key: getUUID(), value: d })) ?? [{ key: getUUID(), value: '' }];
     }
     if (props.contentType === 'CLONE') {
         setForm('name', `Copy - ${props.selectedVariable?.name}` ?? '');
+        setForm('description', props.selectedVariable?.description ?? '');
         state.selectionType = props.selectedVariable?.selection_type ?? 'MULTI';
         state.options = (props.selectedVariable?.options ?? []).map((d) => ({ key: getUUID(), value: d })) ?? [{ key: getUUID(), value: '' }];
     }
 });
 
+watch(() => state.options, (changed) => {
+    console.debug(changed);
+}, { immediate: true });
+
 const {
-    selectionType, options, selectionMenu,
+    selectionType, options, selectionMenu, isManualOptionsType,
 } = toRefs(state);
 
 </script>
@@ -249,45 +213,15 @@ const {
         }
     }
 
-    .options-field {
+    .description-field {
         @apply w-1/2;
-
-        .options-wrapper {
-            @apply w-full bg-gray-100 rounded-md;
-            padding: 0.5rem;
-
-            .option-add-button {
-                margin-bottom: 0.5rem;
-            }
-            .draggable-wrapper {
-                @apply border border-gray-200 rounded flex flex-col bg-white;
-                padding: 0.75rem 0.375rem;
-                gap: 0.5rem;
-                .draggable-item {
-                    @apply flex items-center bg-white;
-                    .grab-area {
-                        cursor: grab;
-                        &:active {
-                            cursor: grabbing;
-                        }
-                    }
-                    .option-input {
-                        @apply w-full;
-                    }
-                    .option-delete-area {
-                        width: 2rem;
-                        height: 2rem;
-                    }
-                }
-                .ghost {
-                    @apply bg-blue-200;
-                }
-            }
+        .description-input {
+            @apply w-full;
         }
     }
 
     @screen tablet {
-        .name-field, .selection-type-field, .options-field {
+        .name-field, .selection-type-field, .description-field {
             @apply w-full;
         }
     }

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue
@@ -1,0 +1,147 @@
+<template>
+    <p-field-group class="dashboard-manage-variable-options-field"
+                   :label="$t('DASHBOARDS.CUSTOMIZE.VARIABLES.LABEL_OPTIONS')"
+                   required
+    >
+        <p-radio-group>
+            <p-radio :selected="state.isManualOption">
+                {{ $t('Manual Entry') }}
+            </p-radio>
+            <p-radio :selected="!state.isManualOption">
+                {{ $t('Search Data Source') }}
+            </p-radio>
+        </p-radio-group>
+        <div class="options-wrapper">
+            <p-button class="option-add-button"
+                      icon-left="ic_plus_bold"
+                      style-type="secondary"
+                      @click="handleAddOption"
+            >
+                {{ $t('DASHBOARDS.CUSTOMIZE.VARIABLES.ADD_OPTIONS') }}
+            </p-button>
+            <draggable :list="state.proxyOptions"
+                       class="draggable-wrapper"
+                       ghost-class="ghost"
+            >
+                <div v-for="(option, index) in state.proxyOptions"
+                     :key="`drag-item-${option.key}`"
+                     class="draggable-item"
+                >
+                    <p-i class="grab-area"
+                         name="ic_drag-handle"
+                         width="1rem"
+                         height="1rem"
+                    />
+                    <p-text-input :value="option.value"
+                                  class="option-input"
+                                  :placeholder="$t('DASHBOARDS.CUSTOMIZE.VARIABLES.PLACEHOLDER_OPTIONS')"
+                                  :invalid="option.error"
+                                  @update:value="handleChangeOptionValue(index, $event)"
+                    />
+                    <div class="option-delete-area">
+                        <p-icon-button v-if="options.length > 1"
+                                       name="ic_delete"
+                                       @click="handleDeleteOption(option.key)"
+                        />
+                    </div>
+                </div>
+            </draggable>
+        </div>
+    </p-field-group>
+</template>
+
+<script setup lang="ts">
+
+import { reactive } from 'vue';
+import draggable from 'vuedraggable';
+
+import {
+    PButton, PFieldGroup, PIconButton, PRadio, PRadioGroup, PTextInput, PI, useProxyValue,
+} from '@spaceone/design-system';
+
+import { getUUID } from '@/lib/component-util/getUUID';
+
+import type { OptionItem } from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type';
+
+
+interface Props {
+    options: OptionItem[];
+    isManualOptionsType: boolean;
+}
+interface EmitFn {
+    (e: string, value: string): void;
+    (e: 'save-click', value: string): void;
+    (e: 'cancel-click'): void;
+}
+const props = defineProps<Props>();
+const emit = defineEmits<EmitFn>();
+
+const state = reactive({
+    proxyOptions: useProxyValue('options', props, emit),
+    isManualOption: true,
+});
+
+// const handleChangeOptionType = () => {
+//
+// };
+
+const handleChangeOptionValue = (index: number, value: string) => {
+    state.proxyOptions[index].error = state.proxyOptions.some((option, _index) => {
+        if (index === _index || value === '') return false;
+        return option.value === value;
+    });
+    state.proxyOptions[index].value = value;
+};
+const handleAddOption = () => {
+    state.proxyOptions = [...state.proxyOptions, { key: getUUID(), value: '' }];
+};
+const handleDeleteOption = (key: string) => {
+    state.proxyOptions = state.proxyOptions.filter((d) => d.key !== key);
+};
+
+</script>
+
+<style scoped lang="postcss">
+.dashboard-manage-variable-options-field {
+    @apply w-1/2;
+
+    .options-wrapper {
+        @apply w-full bg-gray-100 rounded-md;
+        padding: 0.5rem;
+
+        .option-add-button {
+            margin-bottom: 0.5rem;
+        }
+        .draggable-wrapper {
+            @apply border border-gray-200 rounded flex flex-col bg-white;
+            padding: 0.75rem 0.375rem;
+            gap: 0.5rem;
+            .draggable-item {
+                @apply flex items-center bg-white;
+                .grab-area {
+                    cursor: grab;
+                    &:active {
+                        cursor: grabbing;
+                    }
+                }
+                .option-input {
+                    @apply w-full;
+                }
+                .option-delete-area {
+                    width: 2rem;
+                    height: 2rem;
+                }
+            }
+            .ghost {
+                @apply bg-blue-200;
+            }
+        }
+    }
+}
+@screen tablet {
+    .dashboard-manage-variable-options-field {
+        @apply w-full
+    }
+}
+
+</style>

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue
@@ -24,19 +24,27 @@
                        ghost-class="ghost"
             >
                 <div v-for="(option, index) in state.proxyOptions"
-                     :key="`drag-item-${option.key}`"
+                     :key="`drag-item-${option._key}`"
                      class="draggable-item"
                 >
-                    <p-i class="grab-area"
-                         name="ic_drag-handle"
-                         width="1rem"
-                         height="1rem"
-                    />
-                    <p-text-input :value="option.value"
+                    <div class="grab-area">
+                        <p-i name="ic_drag-handle"
+                             width="1rem"
+                             height="1rem"
+                        />
+                    </div>
+                    <p-text-input :value="option.key"
                                   class="option-input"
                                   :placeholder="$t('DASHBOARDS.CUSTOMIZE.VARIABLES.PLACEHOLDER_OPTIONS')"
                                   :invalid="option.error"
                                   @update:value="handleChangeOptionValue(index, $event)"
+                    />
+                    <span class="option-colon">:</span>
+                    <p-text-input :value="option.label"
+                                  class="option-input"
+                                  :placeholder="$t('Enter option label')"
+                                  :invalid="option.error"
+                                  @update:value="handleChangeOptionLabel(index, $event)"
                     />
                     <div class="option-delete-area">
                         <p-icon-button v-if="options.length > 1"
@@ -77,26 +85,31 @@ const props = defineProps<Props>();
 const emit = defineEmits<EmitFn>();
 
 const state = reactive({
-    proxyOptions: useProxyValue('options', props, emit),
+    proxyOptions: useProxyValue<OptionItem[]>('options', props, emit),
     isManualOption: true,
 });
 
-// const handleChangeOptionType = () => {
-//
-// };
-
 const handleChangeOptionValue = (index: number, value: string) => {
-    state.proxyOptions[index].error = state.proxyOptions.some((option, _index) => {
-        if (index === _index || value === '') return false;
-        return option.value === value;
-    });
-    state.proxyOptions[index].value = value;
+    // TODO: reactor with planning
+    // state.proxyOptions[index].error = state.proxyOptions.some((option, _index) => {
+    //     if (index === _index || value === '') return false;
+    //     return option.key === value;
+    // });
+    state.proxyOptions[index].key = value;
+};
+const handleChangeOptionLabel = (index: number, value: string) => {
+    // TODO: reactor with planning
+    // state.proxyOptions[index].error = state.proxyOptions.some((option, _index) => {
+    //     if (index === _index || value === '') return false;
+    //     return option.label === value;
+    // });
+    state.proxyOptions[index].label = value;
 };
 const handleAddOption = () => {
-    state.proxyOptions = [...state.proxyOptions, { key: getUUID(), value: '' }];
+    state.proxyOptions = [...state.proxyOptions, { _key: getUUID(), key: '', label: '' }];
 };
-const handleDeleteOption = (key: string) => {
-    state.proxyOptions = state.proxyOptions.filter((d) => d.key !== key);
+const handleDeleteOption = (_key: string) => {
+    state.proxyOptions = state.proxyOptions.filter((d) => d._key !== _key);
 };
 
 </script>
@@ -119,6 +132,8 @@ const handleDeleteOption = (key: string) => {
             .draggable-item {
                 @apply flex items-center bg-white;
                 .grab-area {
+                    width: 1.25rem;
+                    height: 1.25rem;
                     cursor: grab;
                     &:active {
                         cursor: grabbing;
@@ -126,6 +141,10 @@ const handleDeleteOption = (key: string) => {
                 }
                 .option-input {
                     @apply w-full;
+                }
+                .option-colon {
+                    @apply text-label-md text-gray-300;
+                    margin: 0 0.125rem;
                 }
                 .option-delete-area {
                     width: 2rem;

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue
@@ -24,7 +24,7 @@
                        ghost-class="ghost"
             >
                 <div v-for="(option, index) in state.proxyOptions"
-                     :key="`drag-item-${option._key}`"
+                     :key="`drag-item-${option.draggableItemId}`"
                      class="draggable-item"
                 >
                     <div class="grab-area">
@@ -106,10 +106,10 @@ const handleChangeOptionLabel = (index: number, value: string) => {
     state.proxyOptions[index].label = value;
 };
 const handleAddOption = () => {
-    state.proxyOptions = [...state.proxyOptions, { _key: getUUID(), key: '', label: '' }];
+    state.proxyOptions = [...state.proxyOptions, { draggableItemId: getUUID(), key: '', label: '' }];
 };
-const handleDeleteOption = (_key: string) => {
-    state.proxyOptions = state.proxyOptions.filter((d) => d._key !== _key);
+const handleDeleteOption = (draggableItemId: string) => {
+    state.proxyOptions = state.proxyOptions.filter((d) => d.draggableItemId !== draggableItemId);
 };
 
 </script>

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type.ts
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type.ts
@@ -1,7 +1,9 @@
 export type OverlayStatus = 'LIST' | 'ADD' | 'CLONE' | 'EDIT';
 
 export interface OptionItem {
-    _key: string;
+    // For drag-item-key, it was named `key` before.
+    // As MANUAL option got `key` property, this changed to `draggableItemKey`.
+    draggableItemId: string;
     key: string;
     label: string;
     error?: boolean;

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type.ts
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type.ts
@@ -1,7 +1,8 @@
 export type OverlayStatus = 'LIST' | 'ADD' | 'CLONE' | 'EDIT';
 
 export interface OptionItem {
+    _key: string;
     key: string;
-    value: string;
+    label: string;
     error?: boolean;
 }

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type.ts
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/type.ts
@@ -1,1 +1,7 @@
 export type OverlayStatus = 'LIST' | 'ADD' | 'CLONE' | 'EDIT';
+
+export interface OptionItem {
+    key: string;
+    value: string;
+    error?: boolean;
+}


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

Create `Manual Entry` options form.
This code is subject to change in next PR with `Search Data Source` options.
For compatibility with legacy options, discussion is necessary.
This is temporary code.

Breaking Changes
- Options: `string[]` => `Object[]` (this need discussion and revision)
- Form's options field is separated from Form component.


**Can be changed**
- Type (`config.ts`)
- Option Validation
- **Code that handles legacy options type**
- etc..

https://user-images.githubusercontent.com/83635051/227507781-8812bd40-44c6-4d0d-9828-5d5f3d746eb9.mov

