### PR TITLE
ci: add dev and preview dockerfiles for skaffold run

### DIFF
--- a/apps/web/dev.dockerfile
+++ b/apps/web/dev.dockerfile
@@ -1,0 +1,14 @@
+FROM node:16-alpine
+RUN apk add --no-cache libc6-compat
+RUN apk update
+# Set working directory
+WORKDIR /app
+COPY . .
+
+RUN npm install
+
+ENV NODE_ENV development
+
+EXPOSE 8080
+
+ENTRYPOINT ["npm", "run", "dev", "--workspace=web"]

--- a/apps/web/dev.dockerfile.dockerignore
+++ b/apps/web/dev.dockerfile.dockerignore
@@ -1,0 +1,35 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+
+# lint
+**/.eslintrc.js
+**/.eslintrc.cjs
+**/.eslintignore
+**/.lintstagedrc.cjs
+
+# tests
+**/tests
+**/playwright
+**/playwright.config.ts
+
+#misc
+*.swp
+*.bak
+**/.git
+**/.DS_Store
+**/.husky
+**/commitlint.config.cjs
+**/LICENSE
+**/AUTHORS
+**/VERSION
+**/README.md
+**/deploy
+**/Dockerfile
+**/*.dockerfile
+**/*.dockerignore
+
+#cache
+**/node_modules/.vite/deps_temp

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "description": "Cloudforet Console Web Application",
   "author": "Cloudforet",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "NODE_OPTIONS=--max_old_space_size=8192 vite build",
     "preview": "vite preview --host",
     "test": "vitest run",

--- a/apps/web/preview.dockerfile
+++ b/apps/web/preview.dockerfile
@@ -1,0 +1,21 @@
+FROM node:16-alpine
+RUN apk add --no-cache libc6-compat
+RUN apk update
+# Set working directory
+WORKDIR /app
+COPY . .
+
+RUN npm install -D turbo
+
+ENV NODE_ENV production
+
+# Uncomment and use build args to enable remote caching
+ARG TURBO_TEAM
+ENV TURBO_TEAM=$TURBO_TEAM
+
+ARG TURBO_TOKEN
+ENV TURBO_TOKEN=$TURBO_TOKEN
+
+RUN npx turbo build --filter=web...
+
+ENTRYPOINT ["npm", "run", "preview", "--workspace=web"]

--- a/apps/web/preview.dockerfile.dockerignore
+++ b/apps/web/preview.dockerfile.dockerignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+
+# lint
+**/.eslintrc.js
+**/.eslintrc.cjs
+**/.eslintignore
+**/.lintstagedrc.cjs
+
+# tests
+**/tests
+**/playwright
+**/playwright.config.ts
+
+#misc
+*.swp
+*.bak
+**/.git
+**/.DS_Store
+**/.husky
+**/commitlint.config.cjs
+**/LICENSE
+**/AUTHORS
+**/VERSION
+**/README.md
+**/deploy
+**/Dockerfile
+**/*.dockerfile
+**/*.dockerignore


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [x] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

Those files enable to use different dockerfiles in multiple situations.

When we want to share outputs with coworkers very quickly in dev mode by using local `node_modules`, we can use `dev.dockerfile` by running command below:

```bash
docker build -f apps/web/dev.dockerfile -t console-web:dev .

docker run -d -p 8080:8080 --rm --name console-web console-web:dev 
```

If we want to share outputs for preview in prod mode pretty quickly by using local `node_modules`, then we can use `preview.dockerfile` by running command below:

```bash
docker build -f apps/web/preview.dockerfile -t console-web:preview . --build-arg TURBO_TEAM="<team_name>" --build-arg TURBO_TOKEN="<token>"

docker run -d -p 8080:8080 --rm --name console-web console-web:preview
```

If we want to share outputs which is exactly the same with the production env, we can use `Dockerfile` by running command below:

```bash
docker build -f apps/web/Dockerfile -t console-web:prod . --build-arg TURBO_TEAM="<team_name>" --build-arg TURBO_TOKEN="<token>"

docker run -d -p 8080:80 --rm --name console-web console-web:prod
```

### Things to Talk About
