### PR TITLE
feat(settings-store): change the structure of settingsStore

### DIFF
--- a/apps/web/src/common/modules/navigations/gnb/modules/gnb-noti/modules/GNBNotificationsTab.vue
+++ b/apps/web/src/common/modules/navigations/gnb/modules/gnb-noti/modules/GNBNotificationsTab.vue
@@ -274,7 +274,7 @@ export default {
                 await store.dispatch('settings/setItem', {
                     key: 'lastNotificationReadTime',
                     value: dayjs.utc().toISOString(),
-                    path: '/gnb',
+                    path: 'gnb',
                 }, { root: true });
             } catch (e: any) {
                 if (!axios.isCancel(e.axiosError)) {

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -52,6 +52,9 @@ pinia.use(resetStore);
         components: {
             App,
         },
+        created() {
+            store.dispatch('settings/initSettings');
+        },
         template: '<App/>',
         pinia,
     });

--- a/apps/web/src/store/modules/display/actions.ts
+++ b/apps/web/src/store/modules/display/actions.ts
@@ -120,7 +120,7 @@ export const checkNotification: Action<DisplayState, any> = async ({
         notificationListApiToken = axios.CancelToken.source();
 
         const currentTime = dayjs.tz(dayjs.utc(), rootState.user.timezone);
-        const lastNotificationReadTimeStr = rootGetters['settings/getItem']('lastNotificationReadTime', '/gnb');
+        const lastNotificationReadTimeStr = rootGetters['settings/getItem']('lastNotificationReadTime', 'gnb');
         const lastNotificationReadTime = lastNotificationReadTimeStr ? dayjs(lastNotificationReadTimeStr).tz(rootState.user.timezone) : undefined;
         const param = getNotificationListParam(
             rootState.user.userId,
@@ -213,14 +213,14 @@ const storeCurrencyRates = (rates, dispatch: Dispatch) => {
     dispatch('settings/setItem', {
         key: 'currencyRates',
         value: currencyRatesStoreData,
-        path: '/common',
+        path: 'common',
     }, { root: true });
 };
 
 export const loadCurrencyRates: Action<DisplayState, any> = async ({
     commit, dispatch, rootGetters,
 }) => {
-    const storedData: CurrencyRatesStoredData|undefined = rootGetters['settings/getItem']('currencyRates', '/common');
+    const storedData: CurrencyRatesStoredData|undefined = rootGetters['settings/getItem']('currencyRates', 'common');
     const now = dayjs();
     const storedDate = storedData?.timestamp ? dayjs.unix(storedData?.timestamp) : undefined;
     const storedRates = storedData?.rates ?? {};

--- a/apps/web/src/store/modules/settings/actions.ts
+++ b/apps/web/src/store/modules/settings/actions.ts
@@ -1,5 +1,21 @@
 import type { SetItemRequest } from './type';
 
-export const setItem = ({ commit }, item: SetItemRequest): void => {
-    commit('setItem', item);
+export const setItem = ({ commit, rootState }, item: SetItemRequest): void => {
+    const userId = rootState?.user?.userId;
+    if (userId) commit('setUserSetting', { item });
+};
+
+export const initSettings = ({ commit, rootState }): void => {
+    const userId = rootState?.user?.userId;
+    if (!window.localStorage.getItem('spaceConnector/accessToken')) return;
+    try {
+        const settings = window.localStorage.getItem(userId);
+
+        if (settings) {
+            const settingsObj = JSON.parse(settings);
+            commit('initUserSettings', { item: settingsObj });
+        }
+    } catch (e) {
+        window.localStorage.removeItem(userId);
+    }
 };

--- a/apps/web/src/store/modules/settings/getters.ts
+++ b/apps/web/src/store/modules/settings/getters.ts
@@ -1,6 +1,6 @@
 import type { SettingsState } from './type';
 
-export const getItem = (state: SettingsState): any => {
-    const items = state.items;
-    return (key: string, path = '/') => items[`${path}:${key}`];
+export const getItem = (state: SettingsState): any => (key: string, path = '') => {
+    if (!path.length) return state.user[key];
+    return state.user[`${path}:${key}`];
 };

--- a/apps/web/src/store/modules/settings/index.ts
+++ b/apps/web/src/store/modules/settings/index.ts
@@ -1,20 +1,10 @@
 import * as actions from './actions';
 import * as getters from './getters';
 import * as mutations from './mutations';
-import type { SettingItem, SettingsState } from './type';
-
-export const STORAGE_KEY = 'store/settings';
-
-let storedSettingsState: SettingItem = {};
-
-try {
-    storedSettingsState = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}');
-} catch (e) {
-    window.localStorage.removeItem(STORAGE_KEY);
-}
+import type { SettingsState } from './type';
 
 const state: SettingsState = {
-    items: storedSettingsState.items || {},
+    user: {},
 };
 
 export default {

--- a/apps/web/src/store/modules/settings/mutations.ts
+++ b/apps/web/src/store/modules/settings/mutations.ts
@@ -1,12 +1,19 @@
 import type { SettingsState, SetItemRequest } from './type';
 
-export const setItem = (state: SettingsState, item: SetItemRequest): void => {
+export const setUserSetting = (state: SettingsState, { item }: {item: SetItemRequest, userId: string}): void => {
     if (!item.path) {
-        item.path = '/';
+        state.user = {
+            ...state.user,
+            [item.key]: item.value,
+        };
+    } else {
+        state.user = {
+            ...state.user,
+            [`${item.path}:${item.key}`]: item.value,
+        };
     }
+};
 
-    state.items = {
-        ...state.items,
-        [`${item.path}:${item.key}`]: item.value,
-    };
+export const initUserSettings = (state: SettingsState, { item }: {item: SettingsState['user']}): void => {
+    state.user = item;
 };

--- a/apps/web/src/store/modules/settings/plugins.ts
+++ b/apps/web/src/store/modules/settings/plugins.ts
@@ -1,11 +1,9 @@
 import type { Store } from 'vuex';
 
-import { STORAGE_KEY } from '@/store/modules/settings';
-
 const localStoragePlugin = (store: Store<any>) => {
     store.subscribe((mutation, state) => {
-        if (mutation.type === 'settings/setItem') {
-            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state.settings));
+        if (mutation.type === 'settings/setUserSetting') {
+            window.localStorage.setItem(state.user.userId, JSON.stringify(state.settings.user));
         }
     });
 };

--- a/apps/web/src/store/modules/settings/type.ts
+++ b/apps/web/src/store/modules/settings/type.ts
@@ -7,5 +7,5 @@ export interface SetItemRequest {
 export type SettingItem = Record<string, any>;
 
 export interface SettingsState {
-    items: SettingItem;
+    user: SettingItem;
 }

--- a/apps/web/src/store/modules/user/actions.ts
+++ b/apps/web/src/store/modules/user/actions.ts
@@ -95,7 +95,7 @@ const getUserRoleBindings = async (userId: string): Promise<Array<UserRole>> => 
     }
 };
 
-export const signIn = async ({ commit }, signInRequest: SignInRequest): Promise<void> => {
+export const signIn = async ({ commit, dispatch }, signInRequest: SignInRequest): Promise<void> => {
     const response = await SpaceConnector.client.identity.token.issue({
         domain_id: signInRequest.domainId,
         user_id: signInRequest.userId || null, // user_id is nullable
@@ -117,6 +117,7 @@ export const signIn = async ({ commit }, signInRequest: SignInRequest): Promise<
         const userRoles = await getUserRoleBindings(userId);
         commit('setRoles', userRoles);
     }
+    await dispatch('settings/initSettings', null, { root: true });
 
     commit('setIsSessionExpired', false);
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
I changed settingsStore and localStorage structure.

**Changed**
- Browser can save each user's settings as below.
    `store/settings : SettingsStoreState`    ->     `[userId]: SettingsStoreState`
    ![image](https://user-images.githubusercontent.com/50662170/230865790-22addc6e-f813-4385-bd45-98c611698bf7.png)

- Removed slash(`/`) before gnb and common properties.
- Two initialization points were added for the `settingsStore`.
   - (If user is logged in) When App Component is rendered
   - (if user was before login) When user logs in successfully



### Things to Talk About
