### PR TITLE
fix(dashboard-variables): set additional managed variable & renewal variable schema

### DIFF
--- a/apps/web/src/services/dashboards/config.ts
+++ b/apps/web/src/services/dashboards/config.ts
@@ -93,17 +93,17 @@ export interface ManualOptions {
     type: 'MANUAL';
     values: { key: string; label: string; }[];
 }
-export interface SearchDataSourceOptions {
-    type: 'DATA_SOURCE';
-    data_source: any;
-    // data_source: {
-    //     resource_type: string;
-    //     provider: string;
-    //     cloud_service_group?: string;
-    // }
+export interface SearchResourceOptions {
+    type: 'SEARCH_RESOURCE';
+    resource_key: string;
 }
+export interface ResourceOptions {
+    type: 'RESOURCE',
+    reference_key: string;
+}
+
 type LegacyOptions = string[];
-type VariableOptions = ManualOptions | SearchDataSourceOptions | LegacyOptions;
+type VariableOptions = ManualOptions|SearchResourceOptions|ResourceOptions|LegacyOptions;
 
 // variables schema
 export interface DashboardVariableSchemaProperty {

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -138,9 +138,9 @@ const state = reactive({
             result = Object.entries(props.referenceMap).map(([referenceKey, referenceItem]) => ({
                 name: referenceKey, label: referenceItem?.label ?? referenceItem?.name ?? referenceKey,
             }));
-        } else if (state.variableProperty.options.type === 'SEARCH_RESOURCE') {
+        } else if (state.variableProperty.options?.type === 'SEARCH_RESOURCE') {
             result = state.searchResourceOptions;
-        } else if (state.variableProperty.options.type === 'MANUAL') {
+        } else if (state.variableProperty.options?.type === 'MANUAL') {
             result = state.variableProperty.options.values.map((d) => ({ name: d.key, label: d.label }));
         }
         return result ?? [];
@@ -206,7 +206,7 @@ const handleUpdateSearchText = debounce((text: string) => {
 }, 200);
 
 const loadSearchResourceOptionsByCostAnalysis = async () => {
-    if (state.variableProperty.options.type === 'SEARCH_RESOURCE') {
+    if (state.variableProperty.options?.type === 'SEARCH_RESOURCE') {
         const { results } = await SpaceConnector.client.addOns.autocomplete.distinct({
             resource_type: 'cost_analysis.Cost',
             distinct_key: state.variableProperty.options.resource_key,

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -63,7 +63,7 @@
 <script setup lang="ts">
 import { onClickOutside } from '@vueuse/core';
 import {
-    computed,
+    computed, onMounted,
     reactive, ref, toRef, toRefs, watch,
 } from 'vue';
 
@@ -72,6 +72,8 @@ import {
 } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
 import { cloneDeep, debounce } from 'lodash';
+
+import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
 import type { ReferenceMap } from '@/store/modules/reference/type';
 
@@ -93,38 +95,44 @@ const state = reactive({
     contextMenuRef: null as any|null,
     searchText: '',
     variableProperty: computed<DashboardVariableSchemaProperty>(() => dashboardDetailState.variablesSchema.properties[props.propertyName]),
-    variableSelectedOptions: computed<undefined|string|string[]>(() => dashboardDetailState.variables[props.propertyName]),
+    variableSelectedOptions: computed<undefined|string|string[]>(() => {
+        const selectedOtpions = dashboardDetailState.variables[props.propertyName];
+        if (!selectedOtpions) return [];
+        if (Array.isArray(selectedOtpions)) {
+            return selectedOtpions;
+        }
+        return [selectedOtpions];
+    }),
     variableName: computed(() => state.variableProperty?.name),
     selected: computed<MenuItem[]>(() => {
-        const option = state.variableSelectedOptions;
-        if (!option) return [];
-        let arrayOfSelectedOptions;
-        if (Array.isArray(option)) {
-            arrayOfSelectedOptions = option;
-        } else arrayOfSelectedOptions = [option];
+        const arrayOfSelectedOptions = state.variableSelectedOptions;
 
-        if (state.variableProperty.variable_type === 'MANAGED') {
+        if (state.variableProperty.options.type === 'RESOURCE') {
             return arrayOfSelectedOptions.map((d) => ({ name: d, label: props.referenceMap[d]?.label ?? props.referenceMap[d]?.name ?? d }));
+        }
+        if (state.variableProperty.options.type === 'SEARCH_RESOURCE') {
+            return arrayOfSelectedOptions.map((d) => ({ name: d, label: d }));
         } return arrayOfSelectedOptions.map((d) => ({ name: d, label: state.options.find((optionItem) => optionItem.name === d).label }));
     }),
+    // Options State
+    searchResourceOptions: [],
     options: computed<MenuItem[]>(() => {
         let result;
-        // MANAGED variable CASE: options
-        if (state.variableProperty.variable_type === 'MANAGED') {
+        if (Array.isArray(state.variableProperty.options)) {
+            // Handle Legacy Options
+            result = state.variableProperty.options?.map((d) => ({ name: d, label: d }));
+        } else if (state.variableProperty.options.type === 'RESOURCE') {
             result = Object.entries(props.referenceMap).map(([referenceKey, referenceItem]) => ({
                 name: referenceKey, label: referenceItem?.label ?? referenceItem?.name ?? referenceKey,
             }));
-        } else if (Array.isArray(state.variableProperty.options)) {
-            result = state.variableProperty.options?.map((d) => ({ name: d, label: d }));
-        } else if (state.variableProperty.options?.type === 'MANUAL') {
+        } else if (state.variableProperty.options.type === 'SEARCH_RESOURCE') {
+            result = state.searchResourceOptions;
+        } else if (state.variableProperty.options.type === 'MANUAL') {
             result = state.variableProperty.options.values.map((d) => ({ name: d.key, label: d.label }));
         }
-        // TODO: need to handle DATA_SOURCE type CASE
         return result ?? [];
     }),
 });
-
-
 
 const {
     visibleMenu,
@@ -184,11 +192,25 @@ const handleUpdateSearchText = debounce((text: string) => {
     reloadMenu();
 }, 200);
 
+const loadSearchResourceOptionsByCostAnalysis = async () => {
+    if (state.variableProperty.options.type === 'SEARCH_RESOURCE') {
+        const { results } = await SpaceConnector.client.addOns.autocomplete.distinct({
+            resource_type: 'cost_analysis.Cost',
+            distinct_key: state.variableProperty.options.resource_key,
+        });
+        state.searchResourceOptions = results.map((d) => ({ name: d.name, label: d.name }));
+    }
+};
+
 watch(visibleMenu, (_visibleMenu) => {
     if (_visibleMenu) {
         initiateMenu();
     } else state.searchText = '';
 }, { immediate: true });
+
+onMounted(() => {
+    loadSearchResourceOptionsByCostAnalysis();
+});
 
 const {
     targetRef,

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -107,10 +107,15 @@ const state = reactive({
     selected: computed<MenuItem[]>(() => {
         const arrayOfSelectedOptions = state.variableSelectedOptions;
 
-        if (state.variableProperty.options.type === 'RESOURCE') {
+        // Handle Legacy Variable Options
+        if (state.variableProperty.variable_type === 'MANAGED' && !state.variableProperty.options) {
             return arrayOfSelectedOptions.map((d) => ({ name: d, label: props.referenceMap[d]?.label ?? props.referenceMap[d]?.name ?? d }));
         }
-        if (state.variableProperty.options.type === 'SEARCH_RESOURCE') {
+
+        if (state.variableProperty.options?.type === 'RESOURCE') {
+            return arrayOfSelectedOptions.map((d) => ({ name: d, label: props.referenceMap[d]?.label ?? props.referenceMap[d]?.name ?? d }));
+        }
+        if (state.variableProperty.options?.type === 'SEARCH_RESOURCE') {
             return arrayOfSelectedOptions.map((d) => ({ name: d, label: d }));
         } return arrayOfSelectedOptions.map((d) => ({ name: d, label: state.options.find((optionItem) => optionItem.name === d).label }));
     }),
@@ -118,10 +123,18 @@ const state = reactive({
     searchResourceOptions: [],
     options: computed<MenuItem[]>(() => {
         let result;
+
+        // Handle Legacy Variable Options
         if (Array.isArray(state.variableProperty.options)) {
-            // Handle Legacy Options
             result = state.variableProperty.options?.map((d) => ({ name: d, label: d }));
-        } else if (state.variableProperty.options.type === 'RESOURCE') {
+        } else if (state.variableProperty.variable_type === 'MANAGED' && !state.variableProperty.options) {
+            result = Object.entries(props.referenceMap).map(([referenceKey, referenceItem]) => ({
+                name: referenceKey, label: referenceItem?.label ?? referenceItem?.name ?? referenceKey,
+            }));
+        }
+
+        // Handle Current Variable Options
+        if (state.variableProperty.options?.type === 'RESOURCE') {
             result = Object.entries(props.referenceMap).map(([referenceKey, referenceItem]) => ({
                 name: referenceKey, label: referenceItem?.label ?? referenceItem?.name ?? referenceKey,
             }));

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableForm.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableForm.vue
@@ -69,7 +69,7 @@ import { getUUID } from '@/lib/component-util/getUUID';
 import { useFormValidator } from '@/common/composables/form-validator';
 
 import type {
-    DashboardVariableSchemaProperty, ManualOptions, SearchDataSourceOptions,
+    DashboardVariableSchemaProperty, ManualOptions, SearchResourceOptions,
 } from '@/services/dashboards/config';
 import DashboardManageVariableOptionsField
     from '@/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue';
@@ -137,7 +137,7 @@ const state = reactive({
     options: [
         { draggableItemId: getUUID(), key: '', label: '' },
     ] as OptionItem[],
-    dataSource: '', // TODO: need to refactor
+    resourceKey: '', // TODO: setting resource key in 'RESOURCE' option type
     selectionMenu: computed(() => [
         { name: 'MULTI', label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.MULTI_SELECT') },
         { name: 'SINGLE', label: i18n.t('DASHBOARDS.CUSTOMIZE.VARIABLES.SINGLE_SELECT') },
@@ -185,9 +185,9 @@ const handleSave = () => {
         } as ManualOptions;
     } else {
         options = {
-            type: 'DATA_SOURCE',
-            data_source: '',
-        } as SearchDataSourceOptions;
+            type: 'SEARCH_RESOURCE',
+            resource_key: '',
+        } as SearchResourceOptions;
     }
     const variableToSave = {
         variable_type: 'CUSTOM',
@@ -206,7 +206,7 @@ onMounted(() => {
         setForm('name', `${namePrefix}${props.selectedVariable?.name}` ?? '');
         setForm('description', props.selectedVariable?.description ?? '');
         state.selectionType = props.selectedVariable?.selection_type ?? 'MULTI';
-        // TODO: refactor & add DATA SOURCE case
+        // TODO: add RESOURCE & SEARCH_RESOURCE case
         if (Array.isArray(props.selectedVariable?.options)) {
             state.options = (props.selectedVariable?.options ?? []).map((d) => ({ draggableItemId: getUUID(), key: d, label: d })) ?? [{ draggableItemId: getUUID(), key: '', label: '' }];
         } else if (props.selectedVariable?.options?.type === 'MANUAL') {

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableOptionsField.vue
@@ -81,7 +81,7 @@ import type { OptionItem } from '@/services/dashboards/dashboard-customize/modul
 
 interface Props {
     options: OptionItem[];
-    optionsType: 'MANUAL' | 'DATA_SOURCE';
+    optionsType: 'MANUAL' | 'SEARCH_RESOURCE';
 }
 interface EmitFn {
     (e: string, value: string): void;

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/modules/DashboardManageVariableTable.vue
@@ -153,7 +153,6 @@ const convertAndUpdateVariablesForTable = (order: string[]) => {
             return {
                 ...properties[d],
                 propertyName: d,
-                options: Object.keys(state.allReferenceTypeInfo[d].referenceMap),
             };
         }
         return {

--- a/apps/web/src/services/dashboards/managed-variables-schema.ts
+++ b/apps/web/src/services/dashboards/managed-variables-schema.ts
@@ -1,6 +1,22 @@
 import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
 
+import { GROUP_BY_ITEM_MAP } from '@/services/cost-explorer/lib/config';
 import type { DashboardVariablesSchema } from '@/services/dashboards/config';
+
+export const COST_VARIABLES_INFO = {
+    group_by: {
+        key: 'group_by',
+        name: 'Group By',
+    },
+    product: {
+        key: 'product',
+        name: 'Product',
+    },
+    account: {
+        key: 'account',
+        name: 'Account',
+    },
+} as const;
 
 export const managedDashboardVariablesSchema: DashboardVariablesSchema = {
     properties: {
@@ -9,25 +25,80 @@ export const managedDashboardVariablesSchema: DashboardVariablesSchema = {
             variable_type: 'MANAGED',
             use: true,
             selection_type: 'MULTI',
+            description: 'Project Description',
+            options: {
+                type: 'RESOURCE',
+                reference_key: REFERENCE_TYPE_INFO.project.type,
+            },
         },
         [REFERENCE_TYPE_INFO.provider.type]: {
             name: REFERENCE_TYPE_INFO.provider.name,
             variable_type: 'MANAGED',
             use: true,
             selection_type: 'MULTI',
+            description: 'Provider Description',
+            options: {
+                type: 'RESOURCE',
+                reference_key: REFERENCE_TYPE_INFO.provider.type,
+            },
         },
         [REFERENCE_TYPE_INFO.service_account.type]: {
             name: REFERENCE_TYPE_INFO.service_account.name,
             variable_type: 'MANAGED',
             use: true,
             selection_type: 'MULTI',
+            description: 'Service Account Description',
+            options: {
+                type: 'RESOURCE',
+                reference_key: REFERENCE_TYPE_INFO.service_account.type,
+            },
         },
         [REFERENCE_TYPE_INFO.region.type]: {
             name: REFERENCE_TYPE_INFO.region.name,
             variable_type: 'MANAGED',
             use: true,
             selection_type: 'MULTI',
+            description: 'Region Description',
+            options: {
+                type: 'RESOURCE',
+                reference_key: REFERENCE_TYPE_INFO.region.type,
+            },
         },
+        // Variable for Cost
+        [COST_VARIABLES_INFO.product.key]: {
+            name: COST_VARIABLES_INFO.product.name,
+            variable_type: 'MANAGED',
+            use: true,
+            selection_type: 'MULTI',
+            description: 'Product Description',
+            options: {
+                type: 'SEARCH_RESOURCE',
+                resource_key: COST_VARIABLES_INFO.product.key,
+            },
+        },
+        [COST_VARIABLES_INFO.account.key]: {
+            name: COST_VARIABLES_INFO.account.name,
+            variable_type: 'MANAGED',
+            use: true,
+            selection_type: 'MULTI',
+            description: 'Account Description',
+            options: {
+                type: 'SEARCH_RESOURCE',
+                resource_key: COST_VARIABLES_INFO.account.key,
+            },
+        },
+        [COST_VARIABLES_INFO.group_by.key]: {
+            name: COST_VARIABLES_INFO.group_by.name,
+            variable_type: 'MANAGED',
+            use: true,
+            selection_type: 'MULTI',
+            description: 'Group By Description',
+            options: {
+                type: 'MANUAL',
+                values: Object.values(GROUP_BY_ITEM_MAP).map((d) => ({ key: d.name, label: d.label })),
+            },
+        },
+        // Not used
         // [REFERENCE_TYPE_INFO.user.type]: {
         //     name: REFERENCE_TYPE_INFO.user.name,
         //     variable_type: 'MANAGED',
@@ -45,8 +116,11 @@ export const managedDashboardVariablesSchema: DashboardVariablesSchema = {
         REFERENCE_TYPE_INFO.project.type,
         REFERENCE_TYPE_INFO.provider.type,
         REFERENCE_TYPE_INFO.service_account.type,
+        REFERENCE_TYPE_INFO.region.type,
+        COST_VARIABLES_INFO.product.key,
+        COST_VARIABLES_INFO.account.key,
+        COST_VARIABLES_INFO.group_by.key,
         // REFERENCE_TYPE_INFO.user.type,
         // REFERENCE_TYPE_INFO.cloud_service_type.type,
-        REFERENCE_TYPE_INFO.region.type,
     ],
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description

### Variable schema is changed.
- `options` property is **required**.
- options type is changed. `RESOURCE` | `SEARCH_RESOURCE` | `MANUAL`
- Previously, options were branched by `variable_type`, but now by **option type**.

### Variable Option type
Previously, `MANAGED` variable had only `RESOURCE` type options, but now `MANAGED` variable can have all type options. `variable_type` is now used as role to distinguish between `MANAGED` and `CUSTOM`. `variable_type`'s role has diminished.
(`variable_type` : `MANAGED` | `CUSTOM`)

**RESOURCE**
- Use reference data. (previously played `MANAGED`)

**SEARCH_RESOURCE**
- Search data source.
- Variables for cost such as `Product`, `Account`.
- This type will be added `CUSTOM` variable soon in next quest.

**MANUAL**
- Manually written options (previously played `CUSTOM`)
- I want to change this type name to `ENUM`. Label for user is `MANUAL`, but I want to use `ENUM` internally (Discussion is necessary). Because, in case of **Group By** `MANAGED` variable, I think role of `MANUAL` options fits well. However, `Group By` is not semantically `MANUAL`. 

### New `MANAGED` variables
- Product (`SEARCH_RESOURCE`)
- Account (`SEARCH_RESOURCE`)
- Group By (`MANUAL`)

