### PR TITLE
fix(dashboard-variable): add `convertDashboardInfoByChangedVariableSchema` action to handle legacy variable data

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/VariableSelectorDropdown.vue
@@ -100,12 +100,6 @@ const state = reactive({
         // Selected options data from backend can be undefined or string not string[]. Convert them to Array.
         const arrayOfSelectedOptions = flattenDeep([dashboardDetailState.variables[props.propertyName] ?? []]);
 
-        // Handle Legacy Variable Options
-        if (state.variableProperty.variable_type === 'MANAGED' && !state.variableProperty.options) {
-            return arrayOfSelectedOptions.map((d) => ({ name: d, label: props.referenceMap[d]?.label ?? props.referenceMap[d]?.name ?? d }));
-        }
-
-        // Handle Current Variable Options
         if (state.variableProperty.options?.type === 'REFERENCE_RESOURCE') {
             return arrayOfSelectedOptions.map((d) => ({ name: d, label: props.referenceMap[d]?.label ?? props.referenceMap[d]?.name ?? d }));
         }
@@ -119,16 +113,6 @@ const state = reactive({
     options: computed<MenuItem[]>(() => {
         let result;
 
-        // Handle Legacy Variable Options
-        if (Array.isArray(state.variableProperty.options)) {
-            result = state.variableProperty.options?.map((d) => ({ name: d, label: d }));
-        } else if (state.variableProperty.variable_type === 'MANAGED' && !state.variableProperty.options) {
-            result = Object.entries(props.referenceMap).map(([referenceKey, referenceItem]) => ({
-                name: referenceKey, label: referenceItem?.label ?? referenceItem?.name ?? referenceKey,
-            }));
-        }
-
-        // Handle Current Variable Options
         if (state.variableProperty.options?.type === 'REFERENCE_RESOURCE') {
             result = Object.entries(props.referenceMap).map(([referenceKey, referenceItem]) => ({
                 name: referenceKey, label: referenceItem?.label ?? referenceItem?.name ?? referenceKey,

--- a/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
+++ b/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
@@ -63,6 +63,7 @@ interface DashboardDetailInfoStoreActions {
     deleteWidget: any;
     resetVariables: any;
     updateWidgetValidation: any;
+    convertDashboardInfoByChangedVariableSchema: any;
 }
 const DEFAULT_REFRESH_INTERVAL = '5m';
 const DASHBOARD_DEFAULT = Object.freeze<{ settings: DashboardSettings }>({
@@ -207,6 +208,8 @@ export const useDashboardDetailInfoStore = defineStore<string, DashboardDetailIn
                 } else {
                     result = await SpaceConnector.clientV2.dashboard.domainDashboard.get({ domain_dashboard_id: this.dashboardId });
                 }
+                const resultWithConvertedVariableSchema = this.convertDashboardInfoByChangedVariableSchema(result);
+                this.setDashboardInfo(resultWithConvertedVariableSchema);
                 this.setDashboardInfo(result);
             } catch (e) {
                 this.resetDashboardData();
@@ -275,6 +278,26 @@ export const useDashboardDetailInfoStore = defineStore<string, DashboardDetailIn
         },
         updateWidgetValidation(isValid: boolean, widgetKey: string) {
             this.widgetValidMap[widgetKey] = isValid;
+        },
+        // This action is for handling dashbaord data that does not reflect schema changes.
+        convertDashboardInfoByChangedVariableSchema(dashboardInfo: DashboardModel) {
+            const _dashboardInfo = cloneDeep(dashboardInfo);
+            Object.entries(_dashboardInfo.variables_schema.properties).forEach(([k, v]) => {
+                if (!v.options) {
+                    _dashboardInfo.variables_schema.properties[k] = {
+                        ...managedDashboardVariablesSchema.properties[k],
+                    };
+                } else if (Array.isArray(v.options)) {
+                    _dashboardInfo.variables_schema.properties[k] = {
+                        ...v,
+                        options: {
+                            type: 'ENUM',
+                            values: v.options.map((d) => ({ key: d, label: d })),
+                        },
+                    };
+                }
+            });
+            return _dashboardInfo;
         },
     },
 });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description

Add `convertDashboardInfoByChangedVariableSchema` action in `dashboard-detail-info.ts`.
- This work in `getDashboardInfo` action, before `setDashboardInfo` action.
- This makes legacy `variable_schema` data (from backend) compatible.
