### PR TITLE
chore(language): jp/ko translation added

### DIFF
--- a/packages/language-pack/console-translation.babel
+++ b/packages/language-pack/console-translation.babel
@@ -437,15 +437,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -458,15 +458,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -479,15 +479,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -500,15 +500,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -521,15 +521,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -542,15 +542,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -563,15 +563,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -586,15 +586,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -610,15 +610,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -631,15 +631,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -652,15 +652,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -673,15 +673,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -699,15 +699,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -720,15 +720,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -741,15 +741,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -768,15 +768,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -789,15 +789,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -810,15 +810,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -831,15 +831,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -852,15 +852,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -873,15 +873,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -894,15 +894,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -915,15 +915,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -936,15 +936,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -957,15 +957,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -978,15 +978,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -999,15 +999,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -1020,15 +1020,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -1046,15 +1046,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -1067,15 +1067,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -1088,15 +1088,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -1109,15 +1109,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -1130,15 +1130,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -1151,15 +1151,15 @@
                                                         <translations>
                                                             <translation>
                                                                 <language>en-US</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ja-JP</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                             <translation>
                                                                 <language>ko-KR</language>
-                                                                <approved>false</approved>
+                                                                <approved>true</approved>
                                                             </translation>
                                                         </translations>
                                                     </concept_node>
@@ -1176,15 +1176,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -1218,15 +1218,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -1260,15 +1260,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -16263,15 +16263,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16284,15 +16284,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16305,15 +16305,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16326,15 +16326,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16347,15 +16347,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16368,15 +16368,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16389,15 +16389,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16410,15 +16410,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16452,15 +16452,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16572,15 +16572,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16677,15 +16677,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16824,15 +16824,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16908,15 +16908,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16950,15 +16950,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -16971,15 +16971,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -17558,15 +17558,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -21765,15 +21765,15 @@
                                 <translations>
                                     <translation>
                                         <language>en-US</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ja-JP</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                     <translation>
                                         <language>ko-KR</language>
-                                        <approved>false</approved>
+                                        <approved>true</approved>
                                     </translation>
                                 </translations>
                             </concept_node>
@@ -28947,15 +28947,15 @@
                                                 <translations>
                                                     <translation>
                                                         <language>en-US</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ja-JP</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ko-KR</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                 </translations>
                                             </concept_node>
@@ -28968,15 +28968,15 @@
                                                 <translations>
                                                     <translation>
                                                         <language>en-US</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ja-JP</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ko-KR</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                 </translations>
                                             </concept_node>
@@ -28989,15 +28989,15 @@
                                                 <translations>
                                                     <translation>
                                                         <language>en-US</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ja-JP</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ko-KR</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                 </translations>
                                             </concept_node>
@@ -29010,15 +29010,15 @@
                                                 <translations>
                                                     <translation>
                                                         <language>en-US</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ja-JP</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ko-KR</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                 </translations>
                                             </concept_node>
@@ -29031,15 +29031,15 @@
                                                 <translations>
                                                     <translation>
                                                         <language>en-US</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ja-JP</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ko-KR</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                 </translations>
                                             </concept_node>
@@ -29052,15 +29052,15 @@
                                                 <translations>
                                                     <translation>
                                                         <language>en-US</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ja-JP</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ko-KR</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                 </translations>
                                             </concept_node>
@@ -29073,15 +29073,15 @@
                                                 <translations>
                                                     <translation>
                                                         <language>en-US</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ja-JP</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ko-KR</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                 </translations>
                                             </concept_node>
@@ -29094,15 +29094,15 @@
                                                 <translations>
                                                     <translation>
                                                         <language>en-US</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ja-JP</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                     <translation>
                                                         <language>ko-KR</language>
-                                                        <approved>false</approved>
+                                                        <approved>true</approved>
                                                     </translation>
                                                 </translations>
                                             </concept_node>
@@ -29589,15 +29589,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -29862,15 +29862,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -29883,15 +29883,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -30114,15 +30114,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -30324,15 +30324,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>
@@ -31699,15 +31699,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>

--- a/packages/language-pack/en.json
+++ b/packages/language-pack/en.json
@@ -33,30 +33,30 @@
 				"BACK_TO_SIGN_IN": "Back to Sign-in",
 				"FORGOT_PASSWORD": "Forgot password?",
 				"HELP_TEXT": "Enter your User ID, then we'll send you a link to reset password again.",
-				"INVALID_EMAIL_FORMAT": "Invalid email format.",
+				"INVALID_EMAIL_FORMAT": "Invalid email format or Single Sign-On account.",
 				"SEND": "Send Password Reset Email",
 				"TITLE": "Forgot your password?",
 				"USER_ID": "User ID"
 			},
 			"INVALID_LINK": "The link is invalid",
 			"MOBILE": {
-				"MOBILE_GUIDE_MODAL_DESC_1": "You must",
-				"MOBILE_GUIDE_MODAL_DESC_2": "reset password on Desktop or Laptop environment",
+				"MOBILE_GUIDE_MODAL_DESC_1": "You must reset password",
+				"MOBILE_GUIDE_MODAL_DESC_2": "on Desktop or Laptop environment",
 				"MOBILE_GUIDE_MODAL_DESC_3": "before loggin on the first time.",
 				"MOBILE_GUIDE_MODAL_TITLE": "Not supported on Mobile"
 			},
 			"RESET": {
 				"CONFIRM_PASSWORD": "Confirm Password",
 				"DESC": "At least 8 characters",
-				"DONE": "Your password has been \nreset successfully!",
+				"DONE": "Your password has been reset successfully!",
 				"EMAIL": {
 					"DONE": {
 						"CLICK_HERE": "Click here",
 						"COLLAPSED": "Didn't receive an email?",
 						"DESC_1": "An email has been sent",
 						"DESC_2": "Follow the directions in the email to reset your password.",
-						"EXTENSION_CONTACT": "contact your domain administrators.",
-						"EXTENSION_DESC_1": "Your notification email may not be the same as your user ID. if you've forgotten the exact email address, please",
+						"EXTENSION_CONTACT": "please contact your domain administrators.",
+						"EXTENSION_DESC_1": "Your notification email may not be the same as your user ID. if you've forgotten the exact email address, ",
 						"EXTENSION_REASON_1": "Please wait a bit longer... It could take couple of minutes to show up in your inbox.",
 						"EXTENSION_REASON_2": "Check your spam.",
 						"EXTENSION_REASON_3": "to re-send the email.",
@@ -67,8 +67,8 @@
 					},
 					"FAIL": {
 						"DESC_1": "No email address found",
-						"DESC_2": "on your account to send password \nreset link. Please",
-						"DESC_3": "contact your domain administrators",
+						"DESC_2": "on your account to send password \nreset link. ",
+						"DESC_3": "Please contact your domain administrators",
 						"DESC_4": "and\nrequest to change password.",
 						"GO_BACK": "Go Back",
 						"TITLE": "Unable to reset password"
@@ -76,7 +76,7 @@
 				},
 				"GO_TO_SIGN_IN": "Go to Sign-in",
 				"HELP_TEXT": "Enter a new password for account:",
-				"NOT_MATCHING": "Not matching",
+				"NOT_MATCHING": "Not matching.",
 				"RESET_PASSWORD": "Reset Password",
 				"TITLE": "Reset Password"
 			}
@@ -929,7 +929,7 @@
 			"TIME_RANGE": "Time Range"
 		},
 		"NOTIFICATION_MODAL": {
-			"COLLAPSE_DESC": "Check your junk mail folder or wait a few minutes. if you're still having\ntrouble.",
+			"COLLAPSE_DESC": "Check your junk mail folder or wait a few minutes. if you're still having\ntrouble,",
 			"COLLAPSE_TITLE": "Didn't get verification code?",
 			"INVALID_CODE": "Invalid code. Please check the email try again.",
 			"NOTIFICATION_EMAIL": "Notification Email",
@@ -1655,7 +1655,7 @@
 					"HELP_TEXT": "Enter email address to receive important account and system-related information.",
 					"NOT_VERIFIED": "Not Verified",
 					"SEND_MAIL": "Send Verification Code",
-					"SUCCESS": "Successfully verified notification email.",
+					"SUCCESS": "Notification email successfully verified",
 					"TITLE": "Notification Email",
 					"VERIFIED": "Verified",
 					"VERIFY": "Verify"

--- a/packages/language-pack/ja.json
+++ b/packages/language-pack/ja.json
@@ -30,55 +30,55 @@
 	"AUTH": {
 		"PASSWORD": {
 			"FIND": {
-				"BACK_TO_SIGN_IN": "",
-				"FORGOT_PASSWORD": "",
-				"HELP_TEXT": "",
-				"INVALID_EMAIL_FORMAT": "",
-				"SEND": "",
-				"TITLE": "",
-				"USER_ID": ""
+				"BACK_TO_SIGN_IN": "ログインする",
+				"FORGOT_PASSWORD": "パスワードをお忘れですか？",
+				"HELP_TEXT": "ユーザーIDを入力すると、パスワードリセットリンクがメールで送信されます。",
+				"INVALID_EMAIL_FORMAT": "無効なメール形式またはSingle Sign-Onアカウントです。",
+				"SEND": "パスワードリセットメール送信",
+				"TITLE": "パスワードをお忘れですか？",
+				"USER_ID": "ユーザーID"
 			},
-			"INVALID_LINK": "",
+			"INVALID_LINK": "無効なリンクです",
 			"MOBILE": {
-				"MOBILE_GUIDE_MODAL_DESC_1": "",
-				"MOBILE_GUIDE_MODAL_DESC_2": "",
-				"MOBILE_GUIDE_MODAL_DESC_3": "",
-				"MOBILE_GUIDE_MODAL_TITLE": ""
+				"MOBILE_GUIDE_MODAL_DESC_1": "デスクトップまたはノートパソコン環境で",
+				"MOBILE_GUIDE_MODAL_DESC_2": "初期パスワードを再設定した後",
+				"MOBILE_GUIDE_MODAL_DESC_3": "ログインできます。",
+				"MOBILE_GUIDE_MODAL_TITLE": "モバイル環境には対応していません"
 			},
 			"RESET": {
-				"CONFIRM_PASSWORD": "",
-				"DESC": "",
-				"DONE": "",
+				"CONFIRM_PASSWORD": "パスワード確認",
+				"DESC": "{min}文字以上で入力してください。",
+				"DONE": "パスワードのリセットが完了しました!",
 				"EMAIL": {
 					"DONE": {
-						"CLICK_HERE": "",
-						"COLLAPSED": "",
-						"DESC_1": "",
-						"DESC_2": "",
-						"EXTENSION_CONTACT": "",
-						"EXTENSION_DESC_1": "",
-						"EXTENSION_REASON_1": "",
-						"EXTENSION_REASON_2": "",
-						"EXTENSION_REASON_3": "",
-						"EXTENSION_TITLE_1": "",
-						"EXTENSION_TITLE_2": "",
-						"GO_BACK_TO_CONSOLE": "",
-						"TITLE": ""
+						"CLICK_HERE": "こちら",
+						"COLLAPSED": "メールが届かない場合は、",
+						"DESC_1": "メール送信完了",
+						"DESC_2": "送信されたガイドに従ってパスワードを変更してください。",
+						"EXTENSION_CONTACT": "ドメイン管理者にお問い合わせください。",
+						"EXTENSION_DESC_1": "それでもメールが届かない場合は通知メールアドレスとユーザーIDが異なる場合があります。もし、通知メールアドレスがわからない場合は、",
+						"EXTENSION_REASON_1": "もうしばらくお待ちください。受信トレイに反映されるまで、10分以上かかる場合があります。",
+						"EXTENSION_REASON_2": "迷惑メールボックスを含めてご確認下さい。",
+						"EXTENSION_REASON_3": "をクリックして、メールを再送信してください。",
+						"EXTENSION_TITLE_1": "メールが届かない場合は、",
+						"EXTENSION_TITLE_2": "まだメールを受け取っていないですか？",
+						"GO_BACK_TO_CONSOLE": "コンソールログイン",
+						"TITLE": "パスワードリセットメールを送信する"
 					},
 					"FAIL": {
-						"DESC_1": "",
-						"DESC_2": "",
-						"DESC_3": "",
-						"DESC_4": "",
-						"GO_BACK": "",
-						"TITLE": ""
+						"DESC_1": "リクエストされたアカウントには、",
+						"DESC_2": "パスワードリセットリンクを送信するための通知メールが認証されていません。",
+						"DESC_3": "ドメイン管理者に連絡して、",
+						"DESC_4": "パスワードリセットをリクエストしてください。",
+						"GO_BACK": "戻る",
+						"TITLE": "パスワードリセットができません"
 					}
 				},
-				"GO_TO_SIGN_IN": "",
+				"GO_TO_SIGN_IN": "ログインする",
 				"HELP_TEXT": "アカウントの新しいパスワード入力:",
-				"NOT_MATCHING": "",
+				"NOT_MATCHING": "一致しません。",
 				"RESET_PASSWORD": "パスワード再設定",
-				"TITLE": ""
+				"TITLE": "パスワード再設定"
 			}
 		}
 	},
@@ -929,16 +929,16 @@
 			"TIME_RANGE": "時間範囲"
 		},
 		"NOTIFICATION_MODAL": {
-			"COLLAPSE_DESC": "",
-			"COLLAPSE_TITLE": "",
-			"INVALID_CODE": "",
-			"NOTIFICATION_EMAIL": "",
-			"SEND_CODE": "",
-			"SEND_NEW_CODE": "",
-			"SENT_DESC": "",
-			"TITLE": "",
-			"VERIFICATION_CODE": "",
-			"VERIFY_NOW": ""
+			"COLLAPSE_DESC": "迷惑メールボックスを含めてご確認下さい。それでもメールが届かない場合は、",
+			"COLLAPSE_TITLE": "認証コードが届きませんか？",
+			"INVALID_CODE": "無効なコードです。もう一度メールを確認してください。",
+			"NOTIFICATION_EMAIL": "お知らせメール",
+			"SEND_CODE": "認証コードを送信",
+			"SEND_NEW_CODE": "再送信",
+			"SENT_DESC": "認証コードが入力したメールアドレスに送信されました:",
+			"TITLE": "通知メールを確認する",
+			"VERIFICATION_CODE": "認証コード",
+			"VERIFY_NOW": "認証"
 		},
 		"POPUP": {
 			"NOTICE": {
@@ -949,26 +949,26 @@
 		"PROFILE": {
 			"ALT_E_UPDATE": "個人情報編集に失敗",
 			"ALT_S_UPDATE": "個人情報編集完了",
-			"CURRENT_PASSWORD": "",
+			"CURRENT_PASSWORD": "現在のパスワード",
 			"EMAIL": "メールアドレス",
 			"EMAIL_REQUIRED": "メールアドレスを入力してください",
 			"GROUP": "グループ/会社",
 			"ID": "ID",
-			"KEEP_PASSWORD": "",
+			"KEEP_PASSWORD": "現在のパスワードを維持する",
 			"LANGUAGE": "言語",
 			"MAX_LENGTH_INVALID": "{max}文字以内で入力してください",
 			"MIN_LENGTH_INVALID": "{min}文字以上で入力してください",
 			"MOBILE": "電話番号",
 			"NAME": "お名前",
 			"NAME_REQUIRED": "お名前を入力してください。",
-			"NEW_PASSWORD": "",
+			"NEW_PASSWORD": "新しいパスワード",
 			"PASSWORD": "パスワード",
 			"PASSWORD_CHECK": "パスワードの確認",
 			"PASSWORD_CHECK_INVALID": "同じパスワードを入力してください",
-			"PASSWORD_HELP_TEXT": "",
+			"PASSWORD_HELP_TEXT": "認証済みの通知専用メールアドレスがあるアカウントの場合に限り、パスワードリセットリンクの受信が可能です。",
 			"ROLE": "権限",
-			"SEND_LINK": "",
-			"SET_MANUALLY": "",
+			"SEND_LINK": "パスワードリセットメール送信",
+			"SET_MANUALLY": "管理者がパスワードを設定する",
 			"TIMEZONE": "タイムゾーン",
 			"TITLE": "個人情報"
 		},
@@ -1003,7 +1003,7 @@
 			"VERSION": "バージョン"
 		},
 		"TAGS": {
-			"ADD": "",
+			"ADD": "追加",
 			"ADD_TAG": "タグの追加",
 			"ADD_TAG_DESC": "タグを追加して、リソースを管理します",
 			"ALT_E_UPDATE": "タグの編集に失敗",
@@ -1228,7 +1228,7 @@
 			"PUBLIC": "公開",
 			"PUBLIC_DESC": "該当するダッシュボード範囲に「view」アクセス権限を持つすべてのユーザー",
 			"SINGLE_PROJECT": "個別プロジェクト",
-			"STEP": "",
+			"STEP": "ステップ",
 			"STEP1_DESC": "ダッシュボードの範囲と公開の有無を選択します",
 			"STEP2_DESC": "基本テンプレートと既存のダッシュボードを活用し、素早い作成が可能です。",
 			"TITLE": "新規ダッシュボード作成",
@@ -1651,14 +1651,14 @@
 				"BASE_INFORMATION": "基本情報",
 				"CHANGE_PASSWORD": "パスワード変更",
 				"NOTIFICATION_EMAIL": {
-					"CHANGE": "",
-					"HELP_TEXT": "",
-					"NOT_VERIFIED": "",
-					"SEND_MAIL": "",
-					"SUCCESS": "",
-					"TITLE": "",
-					"VERIFIED": "",
-					"VERIFY": ""
+					"CHANGE": "変更",
+					"HELP_TEXT": "アカウントやシステムに関する重要な情報を受け取るためのメールアドレスを入力してください。",
+					"NOT_VERIFIED": "認証されていません",
+					"SEND_MAIL": "認証コード送信",
+					"SUCCESS": "通知専用メールの認証が完了しました",
+					"TITLE": "お知らせメール",
+					"VERIFIED": "認証済みです",
+					"VERIFY": "認証"
 				},
 				"SAVE_CHANGES": "変更事項を保存"
 			},
@@ -1686,7 +1686,7 @@
 			"FORM": {
 				"ADD_TITLE": "ユーザー追加",
 				"ALREADY_EXISTS": "すでに存在しています",
-				"ASSIGN_DOMAIN_ROLE": "",
+				"ASSIGN_DOMAIN_ROLE": "ドメイン·ロールの割り当てる",
 				"CHECK_USER_ID": "ユーザ名を確認",
 				"DOMAIN_ADMIN": "ドメイン管理者",
 				"EMAIL_INVALID": "無効なメール形式です",
@@ -1699,8 +1699,8 @@
 				"NAME": "お名前",
 				"NAME_PLACEHOLDER": "ユーザ名を入力",
 				"NAME_VALID": "使用可能なIDです",
-				"NOTIFICATION_EMAIL": "",
-				"NOTIFICATION_TOOLTIP": "",
+				"NOTIFICATION_EMAIL": "お知らせメール",
+				"NOTIFICATION_TOOLTIP": "アカウントやシステムに関する重要な情報を受け取るためのメールアドレスを入力してください。",
 				"NOT_SELECT_ROLE": "ロールが選択されていません",
 				"NO_RESULTS_FOUND": "検索結果が見つかりません",
 				"NO_RESULTS_FOUND_HELP_TEXT": "検索キーワードに一致する項目が見つかりません",
@@ -1711,7 +1711,7 @@
 				"PASSWORD_CHECK": "パスワード確認",
 				"PASSWORD_CHECK_INVALID": "同じパスワードを入力してください。",
 				"PASSWORD_HELP_TEXT": "パスワードは、5〜12文字で入力してください。",
-				"PASSWORD_INVALID": "",
+				"PASSWORD_INVALID": "8文字以上で入力してください。",
 				"REQUIRED_FIELD": "該当する情報を入力してください。",
 				"TAGS": "タグ",
 				"TAGS_HELP_TEXT1": "タグを追加してリソースを管理してください",
@@ -1721,7 +1721,7 @@
 				"TOO_MANY_RESULTS": "検索結果が多すぎます。 別のキーワードを使用してください",
 				"UPDATE_TITLE": "ユーザー編集",
 				"USER_ID": "User ID",
-				"USER_ID_DUPLICATED": "",
+				"USER_ID_DUPLICATED": "すでに存在しています",
 				"USER_ID_INVALID": "同じIDが存在します。",
 				"USER_ID_NOT_EXIST": "IDがありません"
 			},
@@ -1790,7 +1790,7 @@
 				"MY_ACCOUNT": "マイアカウント",
 				"NAME": "名前",
 				"NOTIFICATION": "アラート",
-				"NOTIFICATION_EMAIL": "",
+				"NOTIFICATION_EMAIL": "お知らせメール",
 				"NO_SELECTED": "ユーザーを選択すると、詳細な情報が表示されます。",
 				"ROOT_ACCOUNT": "Root account",
 				"SELECTED_DATA": "選択したデータ",

--- a/packages/language-pack/ko.json
+++ b/packages/language-pack/ko.json
@@ -30,55 +30,55 @@
 	"AUTH": {
 		"PASSWORD": {
 			"FIND": {
-				"BACK_TO_SIGN_IN": "",
-				"FORGOT_PASSWORD": "",
-				"HELP_TEXT": "",
-				"INVALID_EMAIL_FORMAT": "",
-				"SEND": "",
-				"TITLE": "",
-				"USER_ID": ""
+				"BACK_TO_SIGN_IN": "로그인 하러 가기",
+				"FORGOT_PASSWORD": "비밀번호를 잊어버리셨나요?",
+				"HELP_TEXT": "사용자 아이디를 입력하시면, 비밀번호 재설정 링크를 이메일로 보내드립니다.",
+				"INVALID_EMAIL_FORMAT": "잘못된 이메일 형식 또는 \bSingle Sign-On 계정입니다. ",
+				"SEND": "비밀번호 재설정 이메일 발송",
+				"TITLE": "비밀번호를 잊어버리셨나요?",
+				"USER_ID": "사용자 아이디"
 			},
-			"INVALID_LINK": "",
+			"INVALID_LINK": "유효하지 않\u001e은 링크입니다",
 			"MOBILE": {
-				"MOBILE_GUIDE_MODAL_DESC_1": "",
-				"MOBILE_GUIDE_MODAL_DESC_2": "",
-				"MOBILE_GUIDE_MODAL_DESC_3": "",
-				"MOBILE_GUIDE_MODAL_TITLE": ""
+				"MOBILE_GUIDE_MODAL_DESC_1": "데스크탑 또는 노트북 환경에서",
+				"MOBILE_GUIDE_MODAL_DESC_2": "초기 비밀번호 재설정 후 ",
+				"MOBILE_GUIDE_MODAL_DESC_3": "로그인을 하실 수 있습니다.",
+				"MOBILE_GUIDE_MODAL_TITLE": "모바일 환경 지원불가"
 			},
 			"RESET": {
-				"CONFIRM_PASSWORD": "",
-				"DESC": "",
-				"DONE": "",
+				"CONFIRM_PASSWORD": "비밀번호 확인",
+				"DESC": "{min}자 이상 입력해주세요.",
+				"DONE": "비밀번호 재설정 완료!",
 				"EMAIL": {
 					"DONE": {
-						"CLICK_HERE": "",
-						"COLLAPSED": "",
-						"DESC_1": "",
-						"DESC_2": "",
-						"EXTENSION_CONTACT": "",
-						"EXTENSION_DESC_1": "",
-						"EXTENSION_REASON_1": "",
-						"EXTENSION_REASON_2": "",
-						"EXTENSION_REASON_3": "",
-						"EXTENSION_TITLE_1": "",
-						"EXTENSION_TITLE_2": "",
-						"GO_BACK_TO_CONSOLE": "",
-						"TITLE": ""
+						"CLICK_HERE": "이 곳",
+						"COLLAPSED": "이메일을 받지 못하셨나요?",
+						"DESC_1": "이메일 발송 완료",
+						"DESC_2": "전달드린 가이드에 따라 비밀번호를 변경해주세요.",
+						"EXTENSION_CONTACT": "도메인 관리자에게 문의해주세요. ",
+						"EXTENSION_DESC_1": "알림 전용 이메일은 사용자 아이디와 다를 수 있습니다. 만약, 알림 전용 이메일을 잊으셨다면, ",
+						"EXTENSION_REASON_1": "조금만 더 기다려 주세요. 수신함에 확인될 때까지 10분 이상 소요될 수 있습니다. ",
+						"EXTENSION_REASON_2": "스팸 메일을 확인해주세요. ",
+						"EXTENSION_REASON_3": "을 클릭하여, 이메일을 재전송을 시도하세요. ",
+						"EXTENSION_TITLE_1": "이메일을 받지 못하셨나요?",
+						"EXTENSION_TITLE_2": "아직도 이메일을 받지 못하셨나요? ",
+						"GO_BACK_TO_CONSOLE": "콘솔 로그인 하러 가기",
+						"TITLE": "비밀번호 재설정 이메일 발송 완료"
 					},
 					"FAIL": {
-						"DESC_1": "",
-						"DESC_2": "",
-						"DESC_3": "",
-						"DESC_4": "",
-						"GO_BACK": "",
-						"TITLE": ""
+						"DESC_1": "요청하신 계정에는",
+						"DESC_2": "비밀번호 재설정 링크 발송을 위한 알림전용 이메일이 인증되어 있지 않습니다. ",
+						"DESC_3": "도메인 관리자에게 문의하시어, ",
+						"DESC_4": "비밀번호 재설정을 요청해주세요.  ",
+						"GO_BACK": "뒤로가기",
+						"TITLE": "비밀번호 재설정 불가"
 					}
 				},
-				"GO_TO_SIGN_IN": "",
+				"GO_TO_SIGN_IN": "로그인 하러 가기",
 				"HELP_TEXT": "다음 계정의 새로운 비밀번호 입력 필요: ",
-				"NOT_MATCHING": "",
+				"NOT_MATCHING": "일치하지 않습니다.",
 				"RESET_PASSWORD": "비밀번호 재설정",
-				"TITLE": ""
+				"TITLE": "비밀번호 재설정"
 			}
 		}
 	},
@@ -929,16 +929,16 @@
 			"TIME_RANGE": "시간 범위"
 		},
 		"NOTIFICATION_MODAL": {
-			"COLLAPSE_DESC": "",
-			"COLLAPSE_TITLE": "",
-			"INVALID_CODE": "",
-			"NOTIFICATION_EMAIL": "",
-			"SEND_CODE": "",
-			"SEND_NEW_CODE": "",
-			"SENT_DESC": "",
-			"TITLE": "",
-			"VERIFICATION_CODE": "",
-			"VERIFY_NOW": ""
+			"COLLAPSE_DESC": "스팸 메일을 확인하거나 조금만 더 기다려 주세요. 만일 아직도 이메일을 받지 못한 경우, ",
+			"COLLAPSE_TITLE": "인증 코드를 받지 못하셨나요?",
+			"INVALID_CODE": "잘못된 인증 코드 입니다. 이메일을 다시 확인 해주세요.",
+			"NOTIFICATION_EMAIL": "알림 전용 이메일",
+			"SEND_CODE": "인증 코드 전송",
+			"SEND_NEW_CODE": "인증 코드 재전송",
+			"SENT_DESC": "인증코드가 입력한 이메일로 발송 되었습니다: ",
+			"TITLE": "알림전용 이메일 인증",
+			"VERIFICATION_CODE": "인증 코드",
+			"VERIFY_NOW": "인증"
 		},
 		"POPUP": {
 			"NOTICE": {
@@ -949,26 +949,26 @@
 		"PROFILE": {
 			"ALT_E_UPDATE": "개인 정보 수정 실패",
 			"ALT_S_UPDATE": "개인 정보 수정 완료",
-			"CURRENT_PASSWORD": "",
+			"CURRENT_PASSWORD": "현재 비밀번호",
 			"EMAIL": "이메일",
 			"EMAIL_REQUIRED": "이메일을 입력해주세요.",
 			"GROUP": "소속",
 			"ID": "아이디",
-			"KEEP_PASSWORD": "",
+			"KEEP_PASSWORD": "현재 비밀번호 유지",
 			"LANGUAGE": "언어",
 			"MAX_LENGTH_INVALID": "{max}자 이하로 입력해 주세요.",
 			"MIN_LENGTH_INVALID": "{min}자 이상 입력해 주세요.",
 			"MOBILE": "전화번호",
 			"NAME": "이름 ",
 			"NAME_REQUIRED": "이름을 입력해 주세요.",
-			"NEW_PASSWORD": "",
+			"NEW_PASSWORD": "새 비밀번호",
 			"PASSWORD": "비밀번호",
 			"PASSWORD_CHECK": "비밀번호 확인",
 			"PASSWORD_CHECK_INVALID": "동일한 비밀번호를 입력해 주세요.",
-			"PASSWORD_HELP_TEXT": "",
+			"PASSWORD_HELP_TEXT": "인증된 알림 전용 이메일이 있는 계정일 경우에만 비밀번호 재설정 링크 수신이 가능합니다.",
 			"ROLE": "권한",
-			"SEND_LINK": "",
-			"SET_MANUALLY": "",
+			"SEND_LINK": "사용자에게 비밀번호 재설정 이메일 발송",
+			"SET_MANUALLY": "관리자가 대신 비밀번호 설정",
 			"TIMEZONE": "타임존",
 			"TITLE": "개인 정보"
 		},
@@ -1003,7 +1003,7 @@
 			"VERSION": "버전 "
 		},
 		"TAGS": {
-			"ADD": "",
+			"ADD": "추가",
 			"ADD_TAG": "태그 추가",
 			"ADD_TAG_DESC": "태그를 추가하여 리소스를 관리하세요.",
 			"ALT_E_UPDATE": "태그 수정 실패",
@@ -1228,7 +1228,7 @@
 			"PUBLIC": "공개",
 			"PUBLIC_DESC": "해당 대시보드 범위에 'View' 엑세스 권한을 갖는 모든 유저",
 			"SINGLE_PROJECT": "개별 프로젝트",
-			"STEP": "",
+			"STEP": "단계",
 			"STEP1_DESC": "대시보드 범위와 공개 여부를 선택하세요.",
 			"STEP2_DESC": "템플릿 또는 기존의 저장된 대시보드를 활용하여 빠르게 시작할 수 있습니다.",
 			"TITLE": "대시보드 생성",
@@ -1651,14 +1651,14 @@
 				"BASE_INFORMATION": "기본 정보",
 				"CHANGE_PASSWORD": "비밀번호 변경 ",
 				"NOTIFICATION_EMAIL": {
-					"CHANGE": "",
-					"HELP_TEXT": "",
-					"NOT_VERIFIED": "",
-					"SEND_MAIL": "",
-					"SUCCESS": "",
-					"TITLE": "",
-					"VERIFIED": "",
-					"VERIFY": ""
+					"CHANGE": "변경",
+					"HELP_TEXT": "계정 및 시스템 관련 주요 정보를 받으실 이메일 주소를 입력하세요.",
+					"NOT_VERIFIED": "인증되지 않음",
+					"SEND_MAIL": "인증 코드 전송",
+					"SUCCESS": "알림 전용 이메일 인증 완료",
+					"TITLE": "알림 전용 이메일",
+					"VERIFIED": "인증됨",
+					"VERIFY": "인증"
 				},
 				"SAVE_CHANGES": "변경사항 저장 "
 			},
@@ -1686,7 +1686,7 @@
 			"FORM": {
 				"ADD_TITLE": "사용자 추가",
 				"ALREADY_EXISTS": "이미 추가됨",
-				"ASSIGN_DOMAIN_ROLE": "",
+				"ASSIGN_DOMAIN_ROLE": "어드민 역할(Role)",
 				"CHECK_USER_ID": "아이디 확인",
 				"DOMAIN_ADMIN": "도메인 관리자 ",
 				"EMAIL_INVALID": "잘못된 이메일 형식입니다. ",
@@ -1699,8 +1699,8 @@
 				"NAME": "이름",
 				"NAME_PLACEHOLDER": "아이디 입력",
 				"NAME_VALID": "사용 가능한 아이디입니다.",
-				"NOTIFICATION_EMAIL": "",
-				"NOTIFICATION_TOOLTIP": "",
+				"NOTIFICATION_EMAIL": "알림 전용 이메일",
+				"NOTIFICATION_TOOLTIP": "계정 및 시스템 관련 주요 정보를 받으실 이메일 주소를 입력하세요.",
 				"NOT_SELECT_ROLE": "역할을 선택하지 않음 ",
 				"NO_RESULTS_FOUND": "검색결과가 없습니다.",
 				"NO_RESULTS_FOUND_HELP_TEXT": "검색결과가 없습니다.",
@@ -1711,7 +1711,7 @@
 				"PASSWORD_CHECK": "비밀번호 확인",
 				"PASSWORD_CHECK_INVALID": "동일한 비밀번호를 입력해주세요.",
 				"PASSWORD_HELP_TEXT": "비밀번호는 5 ~ 12 자로 입력해주세요",
-				"PASSWORD_INVALID": "",
+				"PASSWORD_INVALID": "8자 이상 입력해주세요.",
 				"REQUIRED_FIELD": "해당 정보를 입력해주세요.",
 				"TAGS": "태그",
 				"TAGS_HELP_TEXT1": "태그를 추가하여 리소스를 관리하세요.",
@@ -1721,7 +1721,7 @@
 				"TOO_MANY_RESULTS": "검색결과가 너무 많습니다. 다른 검색어로 검색해보세요.",
 				"UPDATE_TITLE": "사용자 수정",
 				"USER_ID": "유저 아이디",
-				"USER_ID_DUPLICATED": "",
+				"USER_ID_DUPLICATED": "이미 사용중입니다.",
 				"USER_ID_INVALID": "같은 아이디가 존재합니다.",
 				"USER_ID_NOT_EXIST": "아이디가 없습니다."
 			},
@@ -1790,7 +1790,7 @@
 				"MY_ACCOUNT": "내 계정 ",
 				"NAME": "이름",
 				"NOTIFICATION": "알림",
-				"NOTIFICATION_EMAIL": "",
+				"NOTIFICATION_EMAIL": "알림 전용 이메일",
 				"NO_SELECTED": "사용자를 선택하면 자세한 정보를 볼 수 있습니다.",
 				"ROOT_ACCOUNT": "루트 어카운트 ",
 				"SELECTED_DATA": "선택한 데이터",


### PR DESCRIPTION
### To Reviewers
- [x] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [x] Others (performance improvement, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description

jp/ko translation updated

### Things to Talk About

- @skdud4659, I'd suggest that you don't split a sentence into more than two language codes. Due to different word orders in different languages, it could be hard to apply translation as intended. Thanks.
ex) AUTH.PASSWORD.MOBILE.MOBILE_GUIDE_MODAL_DESC_1 ~ 4, AUTH.PASSWORD.RESET.EMAIL.DONE.EXTENSION_REASON_1 ~ 4
 
