### PR TITLE
fix(widget-form): apply outside click & add badge type in filterable dropdown

### DIFF
--- a/packages/mirinae/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-on-click-outside="hideMenu"
+    <div ref="containerRef"
          class="p-filterable-dropdown"
          :class="{ disabled, opened: proxyVisibleMenu, invalid }"
     >
@@ -23,6 +23,7 @@
                     {{ displayValueOnDropdownButton }}
                     <p-badge v-if="displayBadgeValueOnDropdownButton"
                              :style-type="disabled ? 'gray200' : 'blue200'"
+                             :badge-type="disabled ? 'solid' : 'subtle'"
                     >
                         {{ displayBadgeValueOnDropdownButton }}
                     </p-badge>
@@ -99,10 +100,7 @@ import {
     computed, watch, useSlots, ref, toRef,
 } from 'vue';
 
-// CAUTION: this vOnClickOutside is using !! Please do not remove.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { vOnClickOutside } from '@vueuse/components';
-import { useFocus } from '@vueuse/core';
+import { onClickOutside, useFocus } from '@vueuse/core';
 import { debounce, isEqual, reduce } from 'lodash';
 
 import PBadge from '@/data-display/badge/PBadge.vue';
@@ -200,6 +198,9 @@ const toggleMenu = () => {
     if (proxyVisibleMenu.value) hideMenu();
     else showMenu();
 };
+
+const containerRef = ref<HTMLElement|null>(null);
+onClickOutside(containerRef, hideMenu);
 
 /* context menu controller */
 const menuRef = ref<any|null>(null);

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -1,19 +1,19 @@
 <template>
-    <div v-click-outside="handleClickOutside"
+    <div ref="containerRef"
          class="p-select-dropdown"
          :class="{
              [styleType] : true,
              invalid,
              disabled,
              'read-only': readOnly,
-             active: proxyVisibleMenu && !readOnly,
+             active: state.proxyVisibleMenu && !readOnly,
              [size] : true,
          }"
     >
         <p-icon-button v-if="styleType === SELECT_DROPDOWN_STYLE_TYPE.ICON_BUTTON"
                        ref="targetRef"
-                       :name="buttonIcon || (proxyVisibleMenu ? 'ic_chevron-up' : 'ic_chevron-down')"
-                       :activated="proxyVisibleMenu"
+                       :name="buttonIcon || (state.proxyVisibleMenu ? 'ic_chevron-up' : 'ic_chevron-down')"
+                       :activated="state.proxyVisibleMenu"
                        :disabled="disabled"
                        color="inherit"
                        class="icon-button"
@@ -27,27 +27,27 @@
                 @keydown.down="handlePressDownKey"
         >
             <span class="text"
-                  :class="{placeholder: !selectedItem}"
+                  :class="{placeholder: !state.selectedItem}"
             >
                 <slot name="default"
-                      v-bind="{item: selectedItem}"
+                      v-bind="{item: state.selectedItem}"
                 >
                     {{
-                        selectedItem ?
-                            (selectedItem.label || selectedItem.name || '') :
+                        state.selectedItem ?
+                            (state.selectedItem?.label || state.selectedItem?.name || '') :
                             (placeholder || $t('COMPONENT.SELECT_DROPDOWN.SELECT'))
                     }}
                 </slot>
             </span>
             <p-i v-if="!(styleType === SELECT_DROPDOWN_STYLE_TYPE.TRANSPARENT && readOnly)"
-                 :name="proxyVisibleMenu ? 'ic_chevron-up' : 'ic_chevron-down'"
-                 :activated="proxyVisibleMenu"
+                 :name="state.proxyVisibleMenu ? 'ic_chevron-up' : 'ic_chevron-down'"
+                 :activated="state.proxyVisibleMenu"
                  :disabled="disabled"
                  color="inherit"
                  class="dropdown-icon"
             />
         </button>
-        <p-context-menu v-show="proxyVisibleMenu"
+        <p-context-menu v-show="state.proxyVisibleMenu"
                         ref="contextMenuRef"
                         :class="{ [menuPosition]: !useFixedMenuStyle }"
                         :menu="items"
@@ -61,7 +61,7 @@
                         no-select-indication
                         @select="onSelectMenu"
         >
-            <template v-for="(_, slot) of menuSlots"
+            <template v-for="(_, slot) of state.menuSlots"
                       #[slot]="scope"
             >
                 <slot :name="`menu-${slot}`"
@@ -72,17 +72,14 @@
     </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import {
     computed,
-    defineComponent,
     reactive,
-    toRefs,
-    nextTick, toRef,
+    nextTick, toRef, ref, useSlots,
 } from 'vue';
-import type { DirectiveFunction, SetupContext, PropType } from 'vue';
 
-import { vOnClickOutside } from '@vueuse/components';
+import { onClickOutside } from '@vueuse/core';
 import { groupBy, reduce } from 'lodash';
 
 
@@ -92,169 +89,120 @@ import { useContextMenuFixedStyle } from '@/hooks/context-menu-fixed-style';
 import PIconButton from '@/inputs/buttons/icon-button/PIconButton.vue';
 import PContextMenu from '@/inputs/context-menu/PContextMenu.vue';
 import type { MenuItem } from '@/inputs/context-menu/type';
-import type { SelectDropdownProps, SelectDropdownSize } from '@/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenu, SelectDropdownSize } from '@/inputs/dropdown/select-dropdown/type';
 import {
     SELECT_DROPDOWN_STYLE_TYPE,
     CONTEXT_MENU_POSITION, SELECT_DROPDOWN_SIZE,
 } from '@/inputs/dropdown/select-dropdown/type';
 
+interface SelectDropdownProps {
+    items?: SelectDropdownMenu[];
+    selected?: string | number;
+    invalid?: boolean;
+    disabled?: boolean;
+    loading?: boolean;
+    indexMode?: boolean;
+    placeholder?: string;
+    styleType?: SELECT_DROPDOWN_STYLE_TYPE;
+    buttonIcon?: string;
+    readOnly?: boolean;
+    // context menu fixed style props
+    useFixedMenuStyle?: boolean;
+    visibleMenu?: boolean;
+    size?: SelectDropdownSize;
+    menuPosition?: CONTEXT_MENU_POSITION;
+}
 
-export default defineComponent<SelectDropdownProps>({
-    name: 'PSelectDropdown',
-    directives: {
-        clickOutside: vOnClickOutside as DirectiveFunction,
-    },
-    components: {
-        PI,
-        PIconButton,
-        PContextMenu,
-    },
-    model: {
-        prop: 'selected',
-        event: 'update:selected',
-    },
-    props: {
-        /* context menu fixed style props */
-        useFixedMenuStyle: {
-            type: Boolean,
-            default: false,
-        },
-        visibleMenu: {
-            type: Boolean,
-            default: undefined,
-        },
-        /* context menu props */
-        invalid: {
-            type: Boolean,
-            default: false,
-        },
-        loading: {
-            type: Boolean,
-            default: false,
-        },
-        /* select dropdown props */
-        items: {
-            type: Array,
-            default: () => [],
-        },
-        selected: {
-            type: [String, Number],
-            default: undefined,
-        },
-        disabled: {
-            type: Boolean,
-            default: false,
-        },
-        indexMode: {
-            type: Boolean,
-            default: false,
-        },
-        placeholder: {
-            type: String,
-            default: '',
-        },
-        styleType: {
-            type: String,
-            default: SELECT_DROPDOWN_STYLE_TYPE.DEFAULT,
-            validator: (value: SELECT_DROPDOWN_STYLE_TYPE) => Object.values(SELECT_DROPDOWN_STYLE_TYPE).includes(value),
-        },
-        buttonIcon: {
-            type: String,
-            default: undefined,
-        },
-        menuPosition: {
-            type: String,
-            default: CONTEXT_MENU_POSITION.LEFT,
-            validator: (value: CONTEXT_MENU_POSITION) => Object.values(CONTEXT_MENU_POSITION).includes(value),
-        },
-        readOnly: {
-            type: Boolean,
-            default: false,
-        },
-        size: {
-            type: String as PropType<SelectDropdownSize>,
-            default: SELECT_DROPDOWN_SIZE.md,
-            validator(size: SelectDropdownSize) {
-                return Object.values(SELECT_DROPDOWN_SIZE).includes(size);
-            },
-        },
-    },
-    setup(props, { emit, slots }: SetupContext) {
-        const state = reactive({
-            proxyVisibleMenu: useProxyValue<boolean | undefined>('visibleMenu', props, emit),
-            contextMenuRef: null as null|any,
-            proxySelected: useProxyValue('selected', props, emit),
-            selectedItem: computed<MenuItem|null>(() => {
-                if (!Array.isArray(props.items)) return null;
-
-                if (props.indexMode) return props.items[state.proxySelected ?? ''] || null;
-
-                const data = groupBy(props.items, 'name')[state.proxySelected ?? ''];
-                if (Array.isArray(data)) return data[0] || null;
-
-                return null;
-            }),
-            menuSlots: computed(() => reduce(slots, (res, d, name) => {
-                if (name.startsWith('menu-')) res[`${name.substring(5)}`] = d;
-                return res;
-            }, {})),
-            buttonSlots: computed(() => reduce(slots, (res, d, name) => {
-                if (name.startsWith('button-') || name === 'button-default') {
-                    res[`${name.substring(7)}`] = d;
-                }
-                return res;
-            }, {})),
-        });
-
-        const {
-            targetRef, targetElement, contextMenuStyle,
-        } = useContextMenuFixedStyle({
-            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: toRef(state, 'proxyVisibleMenu'),
-        });
-        const contextMenuFixedStyleState = reactive({
-            targetRef, targetElement, contextMenuStyle,
-        });
-
-        /* Event Handlers */
-        const onSelectMenu = (item: MenuItem, index, event) => {
-            if (props.indexMode) {
-                emit('select', index, event);
-                state.proxySelected = index;
-            } else {
-                emit('select', item.name, event);
-                state.proxySelected = item.name;
-            }
-            state.proxyVisibleMenu = false;
-        };
-        const handleClick = (e: MouseEvent) => {
-            if (props.readOnly || props.disabled) return;
-            state.proxyVisibleMenu = !state.proxyVisibleMenu;
-            e.stopPropagation();
-        };
-        const handleClickOutside = (): void => {
-            state.proxyVisibleMenu = false;
-        };
-        const handlePressDownKey = () => {
-            if (!state.proxyVisibleMenu) state.proxyVisibleMenu = true;
-            nextTick(() => {
-                if (state.contextMenuRef) {
-                    if (slots['menu-menu']) emit('focus-menu');
-                    else state.contextMenuRef.focus();
-                }
-            });
-        };
-        return {
-            ...toRefs(state),
-            ...toRefs(contextMenuFixedStyleState),
-            handleClickOutside,
-            onSelectMenu,
-            handleClick,
-            handlePressDownKey,
-            SELECT_DROPDOWN_STYLE_TYPE,
-        };
-    },
+const props = withDefaults(defineProps<SelectDropdownProps>(), {
+    /* context menu fixed style props */
+    useFixedMenuStyle: false,
+    /* context menu props */
+    invalid: false,
+    loading: false,
+    /* select dropdown props */
+    items: () => [],
+    disabled: false,
+    indexMode: false,
+    placeholder: '',
+    styleType: SELECT_DROPDOWN_STYLE_TYPE.DEFAULT,
+    menuPosition: CONTEXT_MENU_POSITION.LEFT,
+    readOnly: false,
+    size: SELECT_DROPDOWN_SIZE.md,
 });
+
+const emit = defineEmits<{(e: 'select', value: string | number, event?: any): void;
+    (e: 'update:selected', value: string | number): void;
+    (e: 'focus-menu'): void;
+}>();
+
+const slots = useSlots();
+
+
+const state = reactive({
+    proxyVisibleMenu: useProxyValue<boolean | undefined>('visibleMenu', props, emit),
+    contextMenuRef: null as null|any,
+    proxySelected: useProxyValue('selected', props, emit),
+    selectedItem: computed<MenuItem|null>(() => {
+        if (!Array.isArray(props.items)) return null;
+
+        if (props.indexMode) return props.items[state.proxySelected ?? ''] || null;
+
+        const data = groupBy(props.items, 'name')[state.proxySelected ?? ''];
+        if (Array.isArray(data)) return data[0] || null;
+
+        return null;
+    }),
+    menuSlots: computed(() => reduce(slots, (res, d, name) => {
+        if (name.startsWith('menu-')) res[`${name.substring(5)}`] = d;
+        return res;
+    }, {})),
+    buttonSlots: computed(() => reduce(slots, (res, d, name) => {
+        if (name.startsWith('button-') || name === 'button-default') {
+            res[`${name.substring(7)}`] = d;
+        }
+        return res;
+    }, {})),
+});
+
+const {
+    targetRef, contextMenuStyle,
+} = useContextMenuFixedStyle({
+    useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
+    visibleMenu: toRef(state, 'proxyVisibleMenu'),
+});
+
+/* Event Handlers */
+const onSelectMenu = (item: MenuItem, index, event) => {
+    if (props.indexMode) {
+        emit('select', index, event);
+        state.proxySelected = index;
+    } else {
+        emit('select', item.name, event);
+        state.proxySelected = item.name;
+    }
+    state.proxyVisibleMenu = false;
+};
+const handleClick = (e: MouseEvent) => {
+    if (props.readOnly || props.disabled) return;
+    state.proxyVisibleMenu = !state.proxyVisibleMenu;
+    e.stopPropagation();
+};
+const handleClickOutside = (): void => {
+    state.proxyVisibleMenu = false;
+};
+const handlePressDownKey = () => {
+    if (!state.proxyVisibleMenu) state.proxyVisibleMenu = true;
+    nextTick(() => {
+        if (state.contextMenuRef) {
+            if (slots['menu-menu']) emit('focus-menu');
+            else state.contextMenuRef.focus();
+        }
+    });
+};
+
+const containerRef = ref<HTMLElement|null>(null);
+onClickOutside(containerRef, handleClickOutside);
+
 </script>
 
 <style lang="postcss">


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description

[Quest-13-dashboard-variable QA-461](https://pyengine.atlassian.net/browse/QA-461)

- Apply `onClickOutside`
- Refactor `PSelectDropdown` to `script setup`
- Add `badge-type` in `PFilterableDropdown`