### PR TITLE
fix(manage-variable-overlay): change overlay escape scenario

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-manage-variable-overlay/DashboardManageVariableOverlay.vue
@@ -151,10 +151,7 @@ const handleConfirmModalAction = () => {
     if (deleteModalState.type === 'DELETE') {
         deleteVariable();
     } else if (deleteModalState.type === 'ESCAPE') {
-        SpaceRouter.router.replace({
-            name: dashboardDetailStore.isProjectDashboard ? DASHBOARDS_ROUTE.PROJECT.CUSTOMIZE._NAME : DASHBOARDS_ROUTE.WORKSPACE.CUSTOMIZE._NAME,
-            params: { dashboardId: dashboardDetailState.dashboardId ?? '' },
-        });
+        state.contentType = 'LIST';
     }
     resetDeleteModalState();
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
[Quest-13-dashboard-variable QA-462](https://pyengine.atlassian.net/browse/QA-462)

In `Edit` and `Add` type content, when clicking go-back button, changing to `LIST` type overlay, not closing overlay
