### PR TITLE
feat(my-page): apply error message when the current password is the same

### DIFF
--- a/apps/web/src/services/my-page/my-account/user-account/modules/ChangePassword.vue
+++ b/apps/web/src/services/my-page/my-account/user-account/modules/ChangePassword.vue
@@ -171,8 +171,13 @@ const updateUser = async (userParam: UpdateUserRequest) => {
         if (!state.isCheckedToken) return;
         await store.dispatch('user/setUser', userParam);
         showSuccessMessage(i18n.t('IDENTITY.USER.MAIN.ALT_S_UPDATE_USER'), '');
-    } catch (e) {
-        showErrorMessage(i18n.t('IDENTITY.USER.MAIN.ALT_E_UPDATE_USER'), e);
+    } catch (e: any) {
+        const errorDetail = e.axiosError.response.data.detail;
+        if (errorDetail.code === 'ERROR_PASSWORD_NOT_CHANGED') {
+            showErrorMessage(errorDetail.message, '');
+        } else {
+            showErrorMessage(i18n.t('IDENTITY.USER.MAIN.ALT_E_UPDATE_USER'), e);
+        }
     }
 };
 </script>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
- apply error message when the current password is the same
![image](https://user-images.githubusercontent.com/83805167/233886242-6f68f10d-253f-497e-9aa4-2c831a94379b.png)


### Things to Talk About
