### PR TITLE
feat(reset-password_notification-email): planning qa

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -67,7 +67,7 @@
                 :user-id="userId"
                 :verified="isEmailVerified"
                 :email="email"
-                :visible.sync="isVisible"
+                :visible.sync="notificationEmailModalVisible"
                 @refresh-user="updateUser"
             />
             <notice-popup v-if="!$store.getters['user/hasSystemRole']" />
@@ -141,7 +141,7 @@ export default defineComponent({
             userId: computed(() => store.state.user.userId),
             email: computed(() => store.state.user.email),
             domainId: computed(() => store.state.domain.domainId),
-            isVisible: false,
+            notificationEmailModalVisible: false,
         });
         const goToSignIn = () => {
             const res: Location = {
@@ -157,9 +157,9 @@ export default defineComponent({
         };
 
         watch(() => vm.$route, (value) => {
-            state.isVisible = !state.isEmailVerified && !window.localStorage.getItem('hideNotificationEmailModal') && getRouteAccessLevel(value) >= ACCESS_LEVEL.AUTHENTICATED;
+            state.notificationEmailModalVisible = !state.isEmailVerified && !window.localStorage.getItem('hideNotificationEmailModal') && getRouteAccessLevel(value) >= ACCESS_LEVEL.AUTHENTICATED;
         });
-        watch(() => state.isVisible, async (value) => {
+        watch(() => state.notificationEmailModalVisible, async (value) => {
             if (value) {
                 const userParam = {
                     email: state.email,

--- a/apps/web/src/common/modules/button/verify-button/VerifyButton.vue
+++ b/apps/web/src/common/modules/button/verify-button/VerifyButton.vue
@@ -71,7 +71,7 @@ const props = withDefaults(defineProps<Props>(), {
     isAdministration: false,
 });
 
-const emit = defineEmits<{(e: 'refresh-user'): void}>();
+const emit = defineEmits<{(e: 'refresh-user', userId: string): void}>();
 
 const state = reactive({
     loading: false,
@@ -79,19 +79,19 @@ const state = reactive({
     loginUserId: computed(() => store.state.user.userId),
 });
 const handleGetUserDetailEmit = () => {
-    emit('refresh-user');
+    emit('refresh-user', props.userId);
 };
 
 /* API */
 const handleClickVerifiedEmail = async () => {
-    const userParam: UpdateUserRequest = {
-        user_id: props.userId,
-        email: props.email,
-        domain_id: props.domainId,
-    };
+    state.loading = true;
     try {
         if (props.verified) return;
-        state.loading = true;
+        const userParam: UpdateUserRequest = {
+            user_id: props.userId,
+            email: props.email,
+            domain_id: props.domainId,
+        };
         await postValidationEmail(userParam);
         if (state.loginUserId === props.userId) {
             await store.dispatch('user/setUser', { email: props.email });

--- a/apps/web/src/common/modules/modals/NotificationEmailModal.vue
+++ b/apps/web/src/common/modules/modals/NotificationEmailModal.vue
@@ -44,7 +44,7 @@
                                  color="inherit"
                             />
                             <p class="email-text">
-                                {{ formState.newNotificationEmail }}
+                                {{ props.isAdministration ? formState.newNotificationEmail : state.email }}
                             </p>
                         </div>
                     </div>
@@ -92,7 +92,7 @@
 
 <script lang="ts" setup>
 import {
-    computed, reactive, watch,
+    computed, reactive,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
@@ -140,10 +140,11 @@ const state = reactive({
     isCollapsed: true,
     isEditMode: props.verified,
     myId: computed(() => store.state.user.userId),
+    email: computed(() => props.email),
     proxyVisible: useProxyValue('visible', props, emit),
 });
 const formState = reactive({
-    newNotificationEmail: props.isAdministration ? props.email : store.state.user.email || '',
+    newNotificationEmail: state.email || '',
     verificationCode: '',
 });
 const validationState = reactive({
@@ -158,8 +159,9 @@ const handleEditButton = () => {
     formState.newNotificationEmail = '';
 };
 const handleClickCancel = () => {
-    state.proxyVisible = false;
     resetFormData();
+    state.proxyVisible = false;
+    state.isEditMode = props.verified;
     emit('refresh-user');
     window.localStorage.setItem('hideNotificationEmailModal', 'true');
 };
@@ -188,6 +190,9 @@ const handleClickSendEmailButton = async (resend?: boolean) => {
                 await store.dispatch('user/setUser', { emailVerified: false, email: formState.newNotificationEmail });
             }
         }
+        if (!props.isAdministration) {
+            emit('refresh-user');
+        }
         state.isEditMode = false;
     } catch (e: any) {
         ErrorHandler.handleError(e);
@@ -214,11 +219,6 @@ const handleClickConfirmButton = async () => {
         state.loading = false;
     }
 };
-
-/* Watcher */
-watch(() => props.verified, (value) => {
-    state.isEditMode = value;
-});
 </script>
 
 <style lang="postcss" scoped>

--- a/apps/web/src/common/modules/page-layouts/CenteredPageLayout.vue
+++ b/apps/web/src/common/modules/page-layouts/CenteredPageLayout.vue
@@ -43,7 +43,7 @@ const props = withDefaults(defineProps<Props>(), {
         left: 1.25rem;
     }
     .layout-contents {
-        @apply absolute;
+        @apply absolute flex items-center justify-center;
         top: 0;
         left: 0;
         right: 0;

--- a/apps/web/src/services/administration/iam/user/modules/UserManagementTable.vue
+++ b/apps/web/src/services/administration/iam/user/modules/UserManagementTable.vue
@@ -328,10 +328,10 @@ export default {
                 await SpaceConnector.client.identity.user.create({
                     ...item,
                 });
+                showSuccessMessage(i18n.t('IDENTITY.USER.MAIN.ALT_S_ADD_USER'), '');
                 if (roleId.length > 0 || roleId !== '') {
                     await bindRole(item.user_id, roleId);
                 }
-                showSuccessMessage(i18n.t('IDENTITY.USER.MAIN.ALT_S_ADD_USER'), '');
             } catch (e) {
                 ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.MAIN.ALT_E_ADD_USER'));
             } finally {

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
@@ -56,6 +56,7 @@
                     />
                     <password-form
                         :item="state.data"
+                        :is-valid-email="state.data.email_verified"
                         @change-input="handleChangeInputs"
                     />
                     <admin-role

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
@@ -55,7 +55,6 @@
                         @change-verify="handleChangeVerify"
                     />
                     <password-form
-                        :is-valid-email="state.data.email_verified"
                         :item="state.data"
                         @change-input="handleChangeInputs"
                     />
@@ -200,7 +199,7 @@ export default {
             const data = {
                 user_id: formState.userId,
                 name: formState.name,
-                email: formState.email,
+                email: formState.email || formState.userId,
                 password: formState.password || '',
                 tags: formState.tags || {},
                 reset_password: formState.passwordType === PASSWORD_TYPE.RESET,

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/NotificationEmailForm.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/NotificationEmailForm.vue
@@ -46,7 +46,6 @@
                             <span>{{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.CHANGE') }}</span>
                         </p-button>
                         <p-button v-else
-                                  ref="sendEmailButtonEl"
                                   style-type="tertiary"
                                   class="send-mail-button"
                                   :loading="state.loading"
@@ -141,7 +140,7 @@
 
 <script setup lang="ts">
 import {
-    computed, reactive, ref, watch,
+    computed, reactive, watch,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
@@ -176,8 +175,6 @@ const userPageStore = useUserPageStore();
 const userPageState = userPageStore.$state;
 
 const emit = defineEmits(['change-input', 'change-verify']);
-
-const sendEmailButtonEl = ref();
 
 const state = reactive({
     loading: false,
@@ -217,8 +214,10 @@ const handleClickChange = () => {
         state.isFocused = true;
     }
 };
-const handleFocusOutInput = () => {
-    state.isFocused = false;
+const handleFocusOutInput = (e) => {
+    if (!e.relatedTarget.matches('.send-mail-button')) {
+        state.isFocused = false;
+    }
 };
 const handleEditButton = () => {
     state.isSent = false;
@@ -247,6 +246,7 @@ const handleClickSend = async () => {
         ErrorHandler.handleError(e);
     } finally {
         state.loading = false;
+        state.isFocused = false;
     }
 };
 const handleChangeVerify = async () => {

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/NotificationEmailForm.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/NotificationEmailForm.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="notification-email-form-wrapper">
-        <p-field-group v-if="!state.isSent"
-                       :label="$t('IDENTITY.USER.FORM.NOTIFICATION_EMAIL')"
+        <p-field-group :label="$t('IDENTITY.USER.FORM.NOTIFICATION_EMAIL')"
                        :invalid="invalidState.email"
                        :invalid-text="invalidTexts.email"
                        class="input-form-view"
@@ -51,13 +50,7 @@
                                   :loading="state.loading"
                                   @click="handleClickSend"
                         >
-                            <p-i name="ic_paper-airplane"
-                                 height="1rem"
-                                 width="1rem"
-                                 class="send-icon"
-                                 color="inherit transparent"
-                            />
-                            <span>{{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.SEND_MAIL') }}</span>
+                            <span>{{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.VERIFY') }}</span>
                         </p-button>
                     </div>
                 </div>
@@ -77,64 +70,6 @@
                 </p-tooltip>
             </template>
         </p-field-group>
-        <div v-else>
-            <div class="contents-wrapper">
-                <div>
-                    <p>{{ $t('COMMON.NOTIFICATION_MODAL.SENT_DESC') }}</p>
-                    <div class="email-wrapper">
-                        <p-i name="ic_envelope-filled"
-                             height="0.875rem"
-                             width="0.875rem"
-                             color="inherit"
-                        />
-                        <p class="email-text">
-                            {{ email }}
-                        </p>
-                    </div>
-                </div>
-                <p-icon-button name="ic_edit"
-                               size="md"
-                               class="edit-icon"
-                               @click="handleEditButton"
-                />
-            </div>
-            <p-field-group :label="$t('COMMON.NOTIFICATION_MODAL.VERIFICATION_CODE')"
-                           :invalid="validationState.isValidationCodeValid"
-                           :invalid-text="validationState.validationCodeInvalidText"
-                           class="input-form-view"
-            >
-                <div class="input-form">
-                    <p-text-input id="verificationCode"
-                                  :value="verificationCode"
-                                  :invalid="validationState.isValidationCodeValid"
-                                  @update:value="setForm('verificationCode', $event)"
-                    />
-                    <p-button style-type="positive"
-                              :loading="state.loading"
-                              @click="handleChangeVerify"
-                    >
-                        <span>{{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.VERIFY') }}</span>
-                    </p-button>
-                </div>
-            </p-field-group>
-            <div class="collapsible-wrapper">
-                <p-collapsible-toggle v-if="state.isCollapsed"
-                                      v-model="state.isCollapsed"
-                >
-                    {{ $t('COMMON.NOTIFICATION_MODAL.COLLAPSE_TITLE') }}
-                </p-collapsible-toggle>
-                <p v-if="!state.isCollapsed"
-                   class="collapsed-contents"
-                >
-                    {{ $t('COMMON.NOTIFICATION_MODAL.COLLAPSE_DESC') }}
-                    <p-button class="send-code-button"
-                              @click="handleClickSend"
-                    >
-                        <span class="emphasis">{{ $t('COMMON.NOTIFICATION_MODAL.SEND_NEW_CODE') }}</span>
-                    </p-button>
-                </p>
-            </div>
-        </div>
     </div>
 </template>
 
@@ -142,17 +77,16 @@
 import {
     computed, reactive, watch,
 } from 'vue';
-import type { TranslateResult } from 'vue-i18n';
 
 import {
-    PFieldGroup, PTextInput, PTooltip, PI, PButton, PCollapsibleToggle, PIconButton, PBadge,
+    PFieldGroup, PTextInput, PTooltip, PI, PButton, PBadge,
 } from '@spaceone/design-system';
 
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
 import { emailValidator } from '@/lib/helper/user-validation-helper';
-import { postValidationCode, postValidationEmail } from '@/lib/helper/verify-email-helper';
+import { postValidationEmail } from '@/lib/helper/verify-email-helper';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 import { useFormValidator } from '@/common/composables/form-validator';
@@ -195,12 +129,7 @@ const {
 }, {
     email(value: string) { return !emailValidator(value) ? '' : i18n.t('IDENTITY.USER.FORM.EMAIL_INVALID'); },
 });
-const { email, verificationCode } = forms;
-
-const validationState = reactive({
-    isValidationCodeValid: undefined as undefined | boolean,
-    validationCodeInvalidText: '' as TranslateResult | string,
-});
+const { email } = forms;
 
 /* Components */
 const handleChangeInput = (e) => {
@@ -218,10 +147,6 @@ const handleFocusOutInput = (e) => {
     if (!e.relatedTarget.matches('.send-mail-button')) {
         state.isFocused = false;
     }
-};
-const handleEditButton = () => {
-    state.isSent = false;
-    state.isEdit = true;
 };
 const initForm = () => {
     setForm('email', props.item.email || '');
@@ -247,27 +172,6 @@ const handleClickSend = async () => {
     } finally {
         state.loading = false;
         state.isFocused = false;
-    }
-};
-const handleChangeVerify = async () => {
-    state.loading = true;
-    try {
-        await postValidationCode({
-            user_id: props.item.user_id,
-            domain_id: props.item.domain_id,
-            code: verificationCode.value,
-        }, state.loginUserId === props.item.user_id);
-        if (userPageState.visibleUpdateModal) {
-            state.isSent = false;
-            state.isEdit = false;
-            state.isCollapsed = true;
-            emit('change-verify', true);
-        }
-    } catch (e) {
-        validationState.isValidationCodeValid = true;
-        validationState.validationCodeInvalidText = i18n.t('COMMON.NOTIFICATION_MODAL.INVALID_CODE');
-    } finally {
-        state.loading = false;
     }
 };
 
@@ -307,6 +211,7 @@ watch(() => props.isValidEmail, (value) => {
                 padding-left: 0.75rem;
                 &.send-mail-button {
                     min-width: initial;
+                    height: 2.125rem;
                     .send-icon {
                         @apply text-gray-900;
                         margin-right: 0.25rem;
@@ -331,33 +236,15 @@ watch(() => props.isValidEmail, (value) => {
         :deep(.p-text-input) {
             width: 100%;
 
+            .input-container {
+                height: 2.125rem;
+            }
+
             .tag-container {
                 padding: 0;
                 .p-badge {
                     margin-left: 0.5rem;
                 }
-            }
-        }
-    }
-    .contents-wrapper {
-        @apply flex justify-between bg-gray-100 rounded text-label-md text-gray-700;
-        margin-bottom: 1rem;
-        padding: 0.5rem;
-        .email-wrapper {
-            @apply flex items-center font-bold;
-            gap: 0.375rem;
-        }
-    }
-    .collapsible-wrapper {
-        margin-top: 1rem;
-        .collapsed-contents {
-            @apply text-paragraph-sm text-gray-500;
-            .send-code-button {
-                @apply text-label-xs font-normal text-blue-700;
-                height: 1rem;
-                background: initial;
-                padding: 0;
-                margin: 0;
             }
         }
     }

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/PasswordForm.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/PasswordForm.vue
@@ -10,6 +10,7 @@
                              :key="type.name"
                              v-model="state.passwordStatus"
                              :value="idx"
+                             :disabled="type.disabled"
                              @change="handleClickRadio(idx)"
                     >
                         {{ type.label }}
@@ -97,9 +98,11 @@ import { useUserPageStore } from '@/services/administration/store/user-page-stor
 
 interface Props {
     item?: User;
+    isValidEmail?: boolean;
 }
 const props = withDefaults(defineProps<Props>(), {
     item: undefined,
+    isValidEmail: false,
 });
 
 const userPageStore = useUserPageStore();
@@ -119,6 +122,7 @@ const state = reactive({
                 {
                     name: PASSWORD_TYPE.RESET,
                     label: i18n.t('COMMON.PROFILE.SEND_LINK'),
+                    disabled: !props.isValidEmail,
                 },
                 {
                     name: PASSWORD_TYPE.MANUALLY,

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/PasswordForm.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/PasswordForm.vue
@@ -10,7 +10,6 @@
                              :key="type.name"
                              v-model="state.passwordStatus"
                              :value="idx"
-                             :disabled="type.disabled"
                              @change="handleClickRadio(idx)"
                     >
                         {{ type.label }}
@@ -98,11 +97,9 @@ import { useUserPageStore } from '@/services/administration/store/user-page-stor
 
 interface Props {
     item?: User;
-    isValidEmail?: boolean;
 }
 const props = withDefaults(defineProps<Props>(), {
     item: undefined,
-    isValidEmail: false,
 });
 
 const userPageStore = useUserPageStore();
@@ -122,7 +119,6 @@ const state = reactive({
                 {
                     name: PASSWORD_TYPE.RESET,
                     label: i18n.t('COMMON.PROFILE.SEND_LINK'),
-                    disabled: !props.isValidEmail,
                 },
                 {
                     name: PASSWORD_TYPE.MANUALLY,

--- a/apps/web/src/services/auth/password/PasswordPage.vue
+++ b/apps/web/src/services/auth/password/PasswordPage.vue
@@ -256,17 +256,12 @@ const initStatesByUrlSSOToken = async () => {
 
 <style lang="postcss" scoped>
 .password-page {
-    @apply relative justify-center;
-    width: 100%;
-    height: 100%;
+    width: auto;
     .contents-wrapper {
-        @apply absolute flex flex-col;
+        @apply flex flex-col;
         gap: 2.5rem;
         width: 25rem;
         min-width: 17.5rem;
-        top: 45%;
-        left: 50%;
-        transform: translate(-50%, -50%);
         .headline-wrapper {
             @apply flex flex-col;
             width: 100%;

--- a/apps/web/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/apps/web/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -184,9 +184,7 @@ export default {
     @apply flex justify-end mt-8 gap-4;
 }
 .dashboard-create-page {
-    @apply flex items-center justify-center;
     width: 100%;
-    height: 100%;
     .dashboard-create-step1 {
         @apply w-full;
         max-width: 30rem;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- App
   - Re-send verification email when user sign-in
   
- Administration
   - Create user
      - Show success message
   - Update user
      - Add verification status badge
      <img width="707" alt="image" src="https://user-images.githubusercontent.com/83805167/234238617-cb23f41b-6630-4604-bc11-7739a3b77c2b.png">
      - Change conditions for enabling reset password radio button based on email verification status
      
- Reset password
   - Limit animation loop upon successful verification email transmission

### Things to Talk About
