### PR TITLE
feat(reset-password_notification-email): planning qa, changed scenario

### DIFF
--- a/apps/web/src/lib/helper/verify-email-helper.ts
+++ b/apps/web/src/lib/helper/verify-email-helper.ts
@@ -3,21 +3,24 @@ import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
-import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
+import { showErrorMessage, showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
 export const postValidationEmail = async (body): Promise<void|Error> => {
-    const { email, user_id, domain_id } = body;
+    const {
+        email, user_id, domain_id, force,
+    } = body;
     try {
         await SpaceConnector.clientV2.identity.user.verifyEmail({
             user_id,
             email,
             domain_id,
+            force,
         });
         return undefined;
     } catch (e: any) {
-        ErrorHandler.handleError(e);
+        showErrorMessage(e.axiosError.response.data.detail.message, e);
         throw e;
     }
 };

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/NotificationEmailForm.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/NotificationEmailForm.vue
@@ -17,7 +17,7 @@
                     >
                         <div v-if="userPageState.visibleUpdateModal && (email !== '' && !state.isFocused && !state.loading)"
                              class="email-status-badge"
-                             @click="handleClickChange"
+                             @click="handleClickBadge"
                         >
                             <span>{{ email }}</span>
                             <p-badge class="selected-text"
@@ -113,7 +113,6 @@ const emit = defineEmits(['change-input', 'change-verify']);
 const state = reactive({
     loading: false,
     isEdit: false,
-    isSent: false,
     isCollapsed: true,
     isFocused: false,
     loginUserId: computed(() => store.state.user.userId),
@@ -143,6 +142,11 @@ const handleClickChange = () => {
         state.isFocused = true;
     }
 };
+const handleClickBadge = () => {
+    if (state.isEdit) {
+        state.isFocused = true;
+    }
+};
 const handleFocusOutInput = (e) => {
     if (!e.relatedTarget.matches('.send-mail-button')) {
         state.isFocused = false;
@@ -159,14 +163,13 @@ const handleClickSend = async () => {
         await postValidationEmail({
             user_id: props.item.user_id,
             email: email.value,
-            domain_id: props.item.domain_id,
+            force: true,
         });
-        emit('change-verify', false);
+        emit('change-verify', true);
 
         if (state.loginUserId === props.item.user_id) {
             await store.dispatch('user/setUser', { email: email.value });
         }
-        state.isSent = true;
     } catch (e) {
         ErrorHandler.handleError(e);
     } finally {

--- a/apps/web/src/services/auth/password/PasswordPage.vue
+++ b/apps/web/src/services/auth/password/PasswordPage.vue
@@ -36,13 +36,12 @@
                     <p-button
                         v-if="props.status === PASSWORD_STATUS.RESET"
                         :disabled="
-                            passwordInput === ''
-                                || confirmPasswordInput === ''
+                            !passwordInput
+                                || !confirmPasswordInput
                                 || passwordInput !== confirmPasswordInput
                                 || passwordInput.length < 8
                         "
                         @click="handleClickButton"
-                        @keyup.enter="handleClickButton"
                     >
                         {{ $t('AUTH.PASSWORD.RESET.RESET_PASSWORD') }}
                     </p-button>
@@ -50,7 +49,6 @@
                         v-else
                         :disabled="userIdInput === ''"
                         @click="handleClickButton"
-                        @keyup.enter="handleClickButton"
                     >
                         {{ $t('AUTH.PASSWORD.FIND.SEND') }}
                     </p-button>
@@ -163,13 +161,10 @@ const handleClickButton = () => {
         }
         sendResetEmail(userIdInput.value, state.domainId);
     } else {
-        const {
-            userId, email,
-        } = state.userInfo;
+        const { userId } = state.userInfo;
         const request = {
             user_id: userId,
             password: passwordInput.value,
-            email,
         };
         postResetPassword(request);
     }

--- a/apps/web/src/services/auth/password/modules/PasswordForm.vue
+++ b/apps/web/src/services/auth/password/modules/PasswordForm.vue
@@ -140,7 +140,10 @@ const handleChangeInput = (type: string, e: string) => {
     emit('change-input', { userIdInput, passwordInput, confirmPasswordInput });
 };
 const handleClickUtil = (type: string) => {
-    emit('click-button', type);
+    if (type !== 'userId') {
+        if (passwordInput.value === '' || invalidState.passwordInput || confirmPasswordInput.value === '' || invalidState.confirmPasswordInput) return;
+    }
+    emit('click-button');
 };
 
 /* Expose */


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- Change the notification email verification scenario API condition during user update.
![image](https://user-images.githubusercontent.com/83805167/234455347-0e5674bb-fcec-4f58-8018-3d4114afe4aa.png)
- Modify the enter event during password reset.
- Display verify email error message when user does not have permission.
![image](https://user-images.githubusercontent.com/83805167/234456067-f89eb968-5ec4-4632-be61-023de6b50606.png)



### Things to Talk About
