### PR TITLE
feat: add dashboard currency dropdown which has `DEFAULT` value

### DIFF
--- a/apps/web/src/services/dashboards/config.ts
+++ b/apps/web/src/services/dashboards/config.ts
@@ -1,6 +1,6 @@
 import type { TranslateResult } from 'vue-i18n';
 
-import type { Currency } from '@/store/modules/display/config';
+import type { CURRENCY } from '@/store/modules/display/config';
 
 import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/_configs/config';
 
@@ -47,13 +47,14 @@ export interface DateRange {
 
 
 // dashboard configs
+export type DashboardCurrency = 'DEFAULT' | typeof CURRENCY[keyof typeof CURRENCY];
 export interface DashboardSettings {
     date_range: {
         enabled: boolean;
     } & DateRange;
     currency: {
         enabled: boolean;
-        value?: Currency;
+        value?: DashboardCurrency;
     };
     refresh_interval_option: RefreshIntervalOption;
 }

--- a/apps/web/src/services/dashboards/modules/dashboard-toolset/DashboardCurrencySelectDropdown.vue
+++ b/apps/web/src/services/dashboards/modules/dashboard-toolset/DashboardCurrencySelectDropdown.vue
@@ -1,0 +1,88 @@
+<template>
+    <p-select-dropdown :items="state.currencyItems"
+                       :selected="currency"
+                       style-type="transparent"
+                       menu-position="right"
+                       class="currency-select-dropdown"
+                       @select="handleSelectCurrency"
+    >
+        <template #default="{ item }">
+            <span>
+                <span>{{ item.label }}</span>
+                <p-badge v-if="item.badge"
+                         style-type="indigo100"
+                         badge-type="subtle"
+                         shape="round"
+                >
+                    {{ item.badge }}
+                </p-badge>
+            </span>
+        </template>
+        <template #menu-item--format="{ item }">
+            <span>
+                <span>{{ item.label }}</span>
+                <p-badge v-if="item.badge"
+                         style-type="indigo100"
+                         badge-type="subtle"
+                         shape="round"
+                >
+                    {{ item.badge }}
+                </p-badge>
+            </span>
+        </template>
+    </p-select-dropdown>
+</template>
+
+<script setup lang="ts">
+import {
+    computed, defineProps, reactive,
+} from 'vue';
+
+import { PSelectDropdown, PBadge } from '@spaceone/design-system';
+import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
+
+import { store } from '@/store';
+import { i18n } from '@/translations';
+
+import type { Currency } from '@/store/modules/display/config';
+import { CURRENCY_SYMBOL } from '@/store/modules/display/config';
+
+import type { DashboardCurrency } from '@/services/dashboards/config';
+
+
+interface DashboardCurrencySelectDropdownProps {
+    currency?: DashboardCurrency;
+}
+const props = withDefaults(defineProps<DashboardCurrencySelectDropdownProps>(), {
+    currency: undefined,
+});
+const emit = defineEmits<{(e: 'update:currency', currency: DashboardCurrency): void}>();
+const state = reactive({
+    defaultCurrency: computed<Currency>(() => store.state.display.currency),
+    currency: computed(() => props.currency || store.state.display.currency),
+    currencyItems: computed<MenuItem[]>(() => {
+        const defaultMenu = {
+            type: 'item',
+            name: 'DEFAULT',
+            label: `${CURRENCY_SYMBOL[state.defaultCurrency]}${state.defaultCurrency}`,
+            badge: i18n.t('DASHBOARDS.DETAIL.DEFAULT'),
+        };
+        const currencyMenuItems = Object.keys(store.state.display.currencyRates).map((currency) => ({
+            type: 'item',
+            name: currency,
+            label: `${CURRENCY_SYMBOL[currency]}${currency}`,
+        }));
+        return [defaultMenu, ...currencyMenuItems];
+    }),
+});
+
+const handleSelectCurrency = (currency: DashboardCurrency) => {
+    emit('update:currency', currency);
+};
+</script>
+
+<style lang="postcss" scoped>
+.p-badge {
+    margin-left: 0.25rem;
+}
+</style>

--- a/apps/web/src/services/dashboards/modules/dashboard-toolset/DashboardCurrencySelectDropdown.vue
+++ b/apps/web/src/services/dashboards/modules/dashboard-toolset/DashboardCurrencySelectDropdown.vue
@@ -1,6 +1,6 @@
 <template>
     <p-select-dropdown :items="state.currencyItems"
-                       :selected="currency"
+                       :selected="state.currency"
                        style-type="transparent"
                        menu-position="right"
                        class="currency-select-dropdown"

--- a/apps/web/src/services/dashboards/modules/dashboard-toolset/DashboardToolset.vue
+++ b/apps/web/src/services/dashboards/modules/dashboard-toolset/DashboardToolset.vue
@@ -7,10 +7,9 @@
                                  :date-range="dashboardDetailState.settings.date_range"
                                  @update:date-range="handleUpdateDateRange"
         />
-        <currency-select-dropdown v-show="dashboardDetailState.settings.currency.enabled"
-                                  default-currency-mode
-                                  :currency="dashboardDetailState.settings.currency.value"
-                                  @update:currency="handleUpdateCurrency"
+        <dashboard-currency-select-dropdown v-show="dashboardDetailState.settings.currency.enabled"
+                                            :currency="dashboardDetailState.settings.currency.value"
+                                            @update:currency="handleUpdateCurrency"
         />
     </div>
 </template>
@@ -18,9 +17,8 @@
 <script setup lang="ts">
 import type { Currency } from '@/store/modules/display/config';
 
-import CurrencySelectDropdown from '@/common/modules/dropdown/currency-select-dropdown/CurrencySelectDropdown.vue';
-
 import type { DashboardSettings } from '@/services/dashboards/config';
+import DashboardCurrencySelectDropdown from '@/services/dashboards/modules/dashboard-toolset/DashboardCurrencySelectDropdown.vue';
 import DashboardDateDropdown from '@/services/dashboards/modules/dashboard-toolset/DashboardDateDropdown.vue';
 import DashboardDateRangeBadge from '@/services/dashboards/modules/dashboard-toolset/DashboardDateRangeBadge.vue';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';

--- a/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
+++ b/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
@@ -8,6 +8,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
+import { store } from '@/store';
+
+import type { Currency } from '@/store/modules/display/config';
 import { CURRENCY } from '@/store/modules/display/config';
 
 import type {
@@ -51,6 +54,7 @@ type DashboardDetailInfoStoreGetters = _GettersTree<{
     isProjectDashboard: boolean;
     dashboardViewer: DashboardViewer;
     isWidgetLayoutValid: boolean;
+    dashboardCurrency: Currency;
 }> & _GettersTree<DashboardDetailInfoStoreState>;
 interface DashboardDetailInfoStoreActions {
     resetDashboardData: any;
@@ -135,6 +139,10 @@ export const useDashboardDetailInfoStore = defineStore<string, DashboardDetailIn
         },
         dashboardViewer: (state) => state.dashboardInfo?.viewers ?? DASHBOARD_VIEWER.PRIVATE,
         isWidgetLayoutValid: (state) => Object.values(state.widgetValidMap).every((d) => d === true),
+        dashboardCurrency: (state) => {
+            if (state.settings.currency.value === 'DEFAULT') return store.state.display.currency;
+            return state.settings.currency.value;
+        },
     },
     actions: {
         resetDashboardData() {

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget-state.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget-state.ts
@@ -145,7 +145,7 @@ export function useWidgetState<Data = any>(
             props.dashboardVariables,
             state.optionsErrorMap,
         )),
-        currency: computed(() => state.settings?.currency?.value ?? CURRENCY.USD),
+        currency: computed(() => dashboardDetailStore.dashboardCurrency ?? CURRENCY.USD),
         groupBy: computed(() => state.options?.group_by),
         granularity: computed(() => state.options?.granularity),
         chartType: computed<ChartType|undefined>(() => state.options?.chart_type),


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
Added "**DEFAULT**" currency!! This currency depends on the user's currency.

(`DashboardCurrencySelectDropdown.vue` is almost like a `CurrencySelectDropdown.vue`. So you don't have to look carefully.)

https://user-images.githubusercontent.com/18563857/234820923-ae4d9ff7-0899-470d-86f8-d583164deda9.mov

