### PR TITLE
feat: move view mode modal from `WidgetFrame` to `DashboardDetailPage`

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/apps/web/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -75,6 +75,7 @@
         <dashboard-clone-modal :visible.sync="state.cloneModalVisible"
                                :dashboard="dashboardDetailState"
         />
+        <widget-view-mode-modal :visible="dashboardDetailState.widgetViewModeModalVisible" />
     </div>
 </template>
 
@@ -120,6 +121,7 @@ import DashboardRefreshDropdown from '@/services/dashboards/modules/DashboardRef
 import DashboardVariablesSelector from '@/services/dashboards/modules/DashboardVariablesSelector.vue';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
+import WidgetViewModeModal from '@/services/dashboards/widgets/_components/WidgetViewModeModal.vue';
 
 const PUBLIC_ICON_COLOR = gray[500];
 

--- a/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
+++ b/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
@@ -46,6 +46,7 @@ export interface DashboardDetailInfoStoreState {
     dashboardWidgetInfoList: DashboardLayoutWidgetInfo[];
     loadingWidgets: boolean;
     widgetDataMap: WidgetDataMap;
+    widgetViewModeModalVisible: boolean,
     // validation
     isNameValid?: boolean;
     widgetValidMap: WidgetValidMap;
@@ -128,6 +129,7 @@ export const useDashboardDetailInfoStore = defineStore<string, DashboardDetailIn
         dashboardWidgetInfoList: [],
         loadingWidgets: false,
         widgetDataMap: {},
+        widgetViewModeModalVisible: false,
         // validation
         isNameValid: undefined,
         widgetValidMap: {},

--- a/apps/web/src/services/dashboards/store/widget-form.ts
+++ b/apps/web/src/services/dashboards/store/widget-form.ts
@@ -3,9 +3,16 @@ import { defineStore } from 'pinia';
 
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
 import type { DashboardLayoutWidgetInfo, InheritOptions, WidgetOptions } from '@/services/dashboards/widgets/_configs/config';
+import type { WidgetTheme } from '@/services/dashboards/widgets/_configs/view-config';
 import { getWidgetFilterDataKey } from '@/services/dashboards/widgets/_helpers/widget-filters-helper';
 import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
 
+/* Description
+    * This store is used to get/manage 'a' widget data.
+    * This store is used in
+    *   1) widget view modal (in dashboard detail page)
+    *   2) widget edit modal (in dashboard customize page)
+* */
 
 interface WidgetFormState {
     widgetConfigId?: string;
@@ -15,6 +22,9 @@ interface WidgetFormState {
     widgetOptions?: WidgetOptions;
     widgetInfo?: DashboardLayoutWidgetInfo;
     schemaProperties?: string[];
+    // view modal
+    widgetKey?: string;
+    theme?: WidgetTheme;
 }
 interface WidgetFormActions {
     setFormData: (formData: any) => void;

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -94,10 +94,6 @@
                                      :widget-key="props.widgetKey"
                                      @refresh="emit('refresh')"
         />
-        <widget-view-mode-modal :visible.sync="state.viewModeModalVisible"
-                                :widget-key="props.widgetKey"
-                                :theme="props.theme"
-        />
     </div>
 </template>
 
@@ -125,8 +121,8 @@ import { useI18nDayjs } from '@/common/composables/i18n-dayjs';
 
 import type { DateRange } from '@/services/dashboards/config';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
+import { useWidgetFormStore } from '@/services/dashboards/store/widget-form';
 import DashboardWidgetEditModal from '@/services/dashboards/widgets/_components/DashboardWidgetEditModal.vue';
-import WidgetViewModeModal from '@/services/dashboards/widgets/_components/WidgetViewModeModal.vue';
 import type { WidgetSize } from '@/services/dashboards/widgets/_configs/config';
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/_configs/config';
 import type { WidgetTheme } from '@/services/dashboards/widgets/_configs/view-config';
@@ -179,6 +175,7 @@ const props = withDefaults(defineProps<WidgetFrameProps>(), {
 const emit = defineEmits(['refresh']);
 
 const dashboardDetailStore = useDashboardDetailInfoStore();
+const widgetFormStore = useWidgetFormStore();
 const state = reactive({
     isFull: computed<boolean>(() => props.size === WIDGET_SIZE.full),
     dateLabel: computed<TranslateResult|undefined>(() => {
@@ -226,7 +223,6 @@ const state = reactive({
             },
         },
     ]),
-    viewModeModalVisible: false,
 });
 
 const setBasicDateFormat = (date) => (date ? dayjs.utc(date).format('YY-MM-DD') : undefined);
@@ -236,7 +232,13 @@ const handleDeleteModalConfirm = () => {
     state.visibleDeleteModal = false;
 };
 const handleClickViewModeButton = () => {
-    state.viewModeModalVisible = true;
+    widgetFormStore.$patch({
+        widgetKey: props.widgetKey,
+        theme: props.theme,
+    });
+    dashboardDetailStore.$patch({
+        widgetViewModeModalVisible: true,
+    });
 };
 </script>
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- There's no visible change.
  - Modal is moved from `WidgetFrame` to `DashboardDetailPage`
  - Modal uses **store data** instead of props.
