### PR TITLE
fix: fixed notification-email & user-update bug

### DIFF
--- a/apps/web/src/services/administration/iam/user/modules/UserManagementTable.vue
+++ b/apps/web/src/services/administration/iam/user/modules/UserManagementTable.vue
@@ -113,7 +113,7 @@ import { store } from '@/store';
 import { i18n } from '@/translations';
 
 import { FILE_NAME_PREFIX } from '@/lib/excel-export';
-import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
+import { showErrorMessage, showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 import { replaceUrlQuery } from '@/lib/router-query-string';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
@@ -352,8 +352,13 @@ export default {
                     userFormState.roleOfSelectedUser = roleId;
                 }
                 showSuccessMessage(i18n.t('IDENTITY.USER.MAIN.ALT_S_UPDATE_USER'), '');
-            } catch (e) {
-                ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.MAIN.ALT_E_UPDATE_USER'));
+            } catch (e: any) {
+                const errorDetail = e.axiosError.response.data.detail;
+                if (errorDetail.code === 'ERROR_UNABLE_TO_RESET_PASSWORD_IN_EXTERNAL_AUTH') {
+                    showErrorMessage(errorDetail.message, '');
+                } else {
+                    ErrorHandler.handleRequestError(e, i18n.t('IDENTITY.USER.MAIN.ALT_E_UPDATE_USER'));
+                }
             } finally {
                 await userPageStore.listUsers(userListApiQuery);
                 userPageStore.$patch({ selectedIndices: [] });

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
@@ -207,7 +207,7 @@ export default {
             if (userPageState.visibleCreateModal) {
                 data.backend = formState.activeTab === 'local' ? 'LOCAL' : 'EXTERNAL';
             }
-            if (formState.activeTab === 'local') {
+            if (formState.activeTab === 'local' || userPageState.visibleUpdateModal) {
                 data.reset_password = formState.passwordType === PASSWORD_TYPE.RESET;
             }
 

--- a/apps/web/src/store/modules/user/actions.ts
+++ b/apps/web/src/store/modules/user/actions.ts
@@ -145,7 +145,7 @@ export const setUser = async ({ commit, state }, userRequest: UpdateUserRequest)
         email: userRequest.email || state.email,
         language: userRequest.language || state.language,
         timezone: userRequest.timezone || state.timezone,
-        emailVerified: userRequest.email_verified || state.emailVerified,
+        emailVerified: userRequest.email_verified !== undefined ? userRequest.email_verified : state.emailVerified,
     });
 
     commit('setUser', { ...state, ...convertRequestType() });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- fixed the bug where the reset-password email is not being sent during user update
- even if the 'email-verified' value is false, modify it so that the 'email-verified' value is assigned

### Things to Talk About
