### PR TITLE
fix(toast-message): fixing 'vue-notification-group' css issue

### DIFF
--- a/packages/mirinae/src/feedbacks/alert/toast-alert/PToastAlert.vue
+++ b/packages/mirinae/src/feedbacks/alert/toast-alert/PToastAlert.vue
@@ -86,7 +86,8 @@ const state = reactive({
 </script>
 
 <style lang="postcss">
-/* Applying 'important' to resolve the issue where CSS is not being applied due to a change in the timing of the loading of 'vue-notification-group' during build. */
+/* CAUTION: Do not remove 'important'.
+ * This resolves the issue where CSS is not being applied due to a change in the timing of the loading of original 'vue-notification-group' libarary's css on the application at running time. */
 .vue-notification-group {
     overflow: unset !important;
     z-index: 10000 !important;

--- a/packages/mirinae/src/feedbacks/alert/toast-alert/PToastAlert.vue
+++ b/packages/mirinae/src/feedbacks/alert/toast-alert/PToastAlert.vue
@@ -103,6 +103,7 @@ const state = reactive({
     margin-left: 0;
     margin-right: 0;
     overflow-y: hidden;
+    z-index: 10000;
 
     .alert-contents {
         @apply bg-gray-900 rounded-lg;

--- a/packages/mirinae/src/feedbacks/alert/toast-alert/PToastAlert.vue
+++ b/packages/mirinae/src/feedbacks/alert/toast-alert/PToastAlert.vue
@@ -89,7 +89,7 @@ const state = reactive({
 <style lang="postcss">
 .vue-notification-group {
     overflow: unset;
-    z-index: 10000;
+    z-index: 10000 !important;
 }
 .vue-notification-wrapper {
     margin: 1rem 0;
@@ -103,7 +103,6 @@ const state = reactive({
     margin-left: 0;
     margin-right: 0;
     overflow-y: hidden;
-    z-index: 10000;
 
     .alert-contents {
         @apply bg-gray-900 rounded-lg;

--- a/packages/mirinae/src/feedbacks/alert/toast-alert/PToastAlert.vue
+++ b/packages/mirinae/src/feedbacks/alert/toast-alert/PToastAlert.vue
@@ -12,15 +12,12 @@
                  @click="close"
             >
                 <div class="icon-wrapper">
-                    <span class="text-safe">
-                        <p-i v-if="item.type === 'success'"
-                             name="ic_check"
-                             class="item-type-icon"
-                             width="1.5rem"
-                             height="1.5rem"
-                             color="inherit"
-                        />
-                    </span>
+                    <p-i name="ic_check"
+                         class="item-type-icon"
+                         width="1.5rem"
+                         height="1.5rem"
+                         :color="safe"
+                    />
                     <p-i v-if="item.type === 'warning'"
                          name="ic_warning-filled"
                          class="item-type-icon"
@@ -70,6 +67,8 @@ import {
 import PSpinner from '@/feedbacks/loading/spinner/PSpinner.vue';
 import PI from '@/foundation/icons/PI.vue';
 
+import { safe } from '@/styles/colors.cjs';
+
 /**
  * Used library: vue-notification
  * https://www.npmjs.com/package/vue-notification
@@ -87,17 +86,16 @@ const state = reactive({
 </script>
 
 <style lang="postcss">
+/* Applying 'important' to resolve the issue where CSS is not being applied due to a change in the timing of the loading of 'vue-notification-group' during build. */
 .vue-notification-group {
-    overflow: unset;
+    overflow: unset !important;
     z-index: 10000 !important;
 }
 .vue-notification-wrapper {
-    margin: 1rem 0;
-    overflow: visible;
+    margin: 1rem 0 !important;
+    overflow: visible !important;
 }
-</style>
 
-<style lang="postcss">
 .p-toast-alert {
     margin-top: 4.5rem;
     margin-left: 0;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- Applying 'important' to resolve the issue where CSS is not being applied due to a change in the timing of the loading of 'vue-notification-group' during build.
- Fixing the issue where the success icon is not being displayed. 

### Things to Talk About
