### PR TITLE
build(svg-icon): create svg icons object builder cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5851,6 +5851,15 @@
       "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
       "dev": true
     },
+    "node_modules/@storybook/core-server/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@storybook/core-server/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -11476,12 +11485,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true,
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "engines": {
-        "node": ">= 6"
+        "node": ">=14"
       }
     },
     "node_modules/commondir": {
@@ -19889,15 +19897,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/lint-staged/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/lint-staged/node_modules/execa": {
@@ -35027,6 +35026,7 @@
         "bytes": "^3.1.2",
         "codemirror": "^5.65.6",
         "color": "^3.1.2",
+        "commander": "^10.0.1",
         "core-js": "^3.29.1",
         "dayjs": "^1.10.7",
         "dompurify": "^2.3.3",
@@ -38267,6 +38267,7 @@
         "bytes": "^3.1.2",
         "codemirror": "^5.65.6",
         "color": "^3.1.2",
+        "commander": "^10.0.1",
         "concurrently": "^7.6.0",
         "core-js": "^3.29.1",
         "dayjs": "^1.10.7",
@@ -39428,6 +39429,12 @@
           "version": "14.18.43",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
           "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+          "dev": true
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
         },
         "fs-extra": {
@@ -43900,10 +43907,9 @@
       "dev": true
     },
     "commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -50337,12 +50343,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
           "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-          "dev": true
-        },
-        "commander": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
           "dev": true
         },
         "execa": {

--- a/packages/mirinae/cli/build.js
+++ b/packages/mirinae/cli/build.js
@@ -10,7 +10,10 @@ const Svgo = require('svgo');
 const defaultSvgoConfig = require('./svgo');
 
 /**
- * build svg icon
+ * build
+ * - build svg icons
+ * - register svg icons to svgicon
+ * - this must be replaced to generate function in Vue 3 with @yzfe/svgicon
  */
 async function build(options) {
     const { sourcePath, targetPath } = options;

--- a/packages/mirinae/cli/build.js
+++ b/packages/mirinae/cli/build.js
@@ -1,0 +1,150 @@
+/* eslint-disable */
+
+const path = require('path');
+
+const colors = require('colors');
+const fs = require('fs-plus');
+const glob = require('glob');
+const Svgo = require('svgo');
+
+const defaultSvgoConfig = require('./svgo');
+
+/**
+ * build svg icon
+ */
+async function build(options) {
+    const { sourcePath, targetPath } = options;
+
+
+    return new Promise((resolve, reject) => {
+        // delete previous icons
+        fs.removeSync(targetPath);
+
+        // the template file which to generate icon files
+        const tplPath = path.join(
+            __dirname,
+            './icon.tpl.txt',
+        );
+        const tpl = fs.readFileSync(tplPath, 'utf8');
+        const svgo = new Svgo(defaultSvgoConfig);
+
+        glob(path.join(sourcePath, '**/*.svg'), (
+            err,
+            files,
+        ) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            const normalizedFilePaths = files.map((f) => path.normalize(f));
+
+            normalizedFilePaths.forEach(async (filename, ix) => {
+                const name = path.basename(filename).split('.')[0];
+                const svgContent = fs.readFileSync(filename, 'utf-8');
+                const result = (await svgo.optimize(
+                    svgContent,
+                ));
+                let data = result.data
+                    .replace(/<svg[^>]+>/gi, '')
+                    .replace(/<\/svg>/gi, '');
+
+                // get view box
+                const viewBox = getViewBox(result);
+
+                // add pid attr, for css
+                data = addPid(data);
+
+                // rename fill and stroke. (It can restroe in vue-svgicon)
+                data = renameStyle(data);
+
+                // escape single quotes
+                data = data.replace(/'/g, "\\'");
+
+                const content = compile(tpl, {
+                    name,
+                    width: parseFloat(result.info.width) || 16,
+                    height: parseFloat(result.info.height) || 16,
+                    viewBox: `'${viewBox}'`,
+                    data,
+                });
+
+                try {
+                    fs.writeFileSync(
+                        path.join(
+                            targetPath,
+                            `${name}.js`,
+                        ),
+                        content,
+                        'utf-8',
+                    );
+                    console.log(colors.yellow(`Generated icon: ${name}`));
+
+                    if (ix === normalizedFilePaths.length - 1) {
+                        generateIndex(options, normalizedFilePaths);
+                        resolve();
+                    }
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        });
+    });
+}
+
+// simple template compile
+function compile(content, data) {
+    return content.replace(/\${(\w+)}/gi, (match, name) => (data[name] ? data[name] : ''));
+}
+
+// generate index.js, which import all icons
+function generateIndex(opts, files) {
+    let content = '';
+    content += '/* eslint-disable */\n';
+
+    files.forEach((file) => {
+        const name = path.basename(file).split('.')[0];
+        content += `import './${name}'\n`;
+    });
+
+    fs.writeFileSync(
+        path.join(opts.targetPath, 'index.js'),
+        content,
+        'utf-8',
+    );
+    console.log(colors.green('Generated index.js'));
+}
+
+// get svg viewbox
+function getViewBox(svgoResult) {
+    const viewBoxMatch = svgoResult.data.match(
+        /viewBox="([-\d.]+\s[-\d.]+\s[-\d.]+\s[-\d.]+)"/,
+    );
+    let viewBox = '0 0 200 200';
+
+    if (viewBoxMatch && viewBoxMatch.length > 1) {
+        viewBox = viewBoxMatch[1];
+    } else if (svgoResult.info.height && svgoResult.info.width) {
+        viewBox = `0 0 ${svgoResult.info.width} ${svgoResult.info.height}`;
+    }
+
+    return viewBox;
+}
+
+// add pid attr, for css
+function addPid(content) {
+    const shapeReg = /<(path|rect|circle|polygon|line|polyline|ellipse)\s/gi;
+    let id = 0;
+    return content.replace(shapeReg, (match) => `${match}pid="${id++}" `);
+}
+
+// rename fill and stroke. (It can restroe in vue-svgicon)
+function renameStyle(content) {
+    const styleShaeReg = /<(path|rect|circle|polygon|line|polyline|g|ellipse).+>/gi;
+    const styleReg = /fill="|stroke="/gi;
+    return content.replace(styleShaeReg, (shape) => shape.replace(styleReg, (styleName) => `_${styleName}`));
+}
+
+module.exports = {
+    build,
+};

--- a/packages/mirinae/cli/generate.js
+++ b/packages/mirinae/cli/generate.js
@@ -1,0 +1,40 @@
+/* eslint-disable */
+
+const path = require('path');
+const util = require('util');
+
+const fs = require('fs-plus');
+
+const readdirAsync = util.promisify(fs.readdir);
+const writeFileAsync = util.promisify(fs.writeFile);
+
+async function generate(options) {
+    const {
+        sourcePath, targetPath,
+    } = options;
+
+    fs.removeSync(targetPath);
+    const targetFile = path.join(targetPath, 'icons.js');
+
+    try {
+        const files = await readdirAsync(sourcePath);
+        const svgFiles = files.filter((file) => path.extname(file).toLowerCase() === '.svg');
+
+        const fileNames = svgFiles.map((file) => path.basename(file, '.svg'));
+        const fileImportContent = fileNames.map((key) => `import ${snakeToCamel(key)} from '${path.relative(targetPath, sourcePath)}/${key}.svg';\n`).join('');
+        const iconContent = `\n\nexport default {\n${fileNames.map((key) => `    '${key}': ${snakeToCamel(key)},\n`).join('')}};\n`;
+
+        await writeFileAsync(targetFile, fileImportContent + iconContent);
+        console.log('file write success');
+    } catch (err) {
+        console.log('file write error:', err);
+    }
+}
+
+function snakeToCamel(str) {
+    return str.replace(/([-]\w)/g, (match) => match[1].toUpperCase());
+}
+
+module.exports = {
+    generate,
+};

--- a/packages/mirinae/cli/generate.js
+++ b/packages/mirinae/cli/generate.js
@@ -8,6 +8,11 @@ const fs = require('fs-plus');
 const readdirAsync = util.promisify(fs.readdir);
 const writeFileAsync = util.promisify(fs.writeFile);
 
+/**
+ * generate
+ * - generate svg icons object
+ * - this will be used after Vue3 migration with @yzfe/vue3-svgicon
+ */
 async function generate(options) {
     const {
         sourcePath, targetPath,

--- a/packages/mirinae/cli/icon.tpl.txt
+++ b/packages/mirinae/cli/icon.tpl.txt
@@ -1,0 +1,13 @@
+
+/* eslint-disable */
+/* tslint:disable */
+// @ts-ignore
+import icon from 'vue-svgicon'
+icon.register({
+  '${name}': {
+    width: ${width},
+    height: ${height},
+    viewBox: ${viewBox},
+    data: '${data}'
+  }
+})

--- a/packages/mirinae/cli/svg-gen.js
+++ b/packages/mirinae/cli/svg-gen.js
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 /**
- * generate svg icons object
+ * generate svg icons contents
  * @since 2023-05-12
  */
 
@@ -34,6 +34,7 @@ const targetPath = path.isAbsolute(program.opts().targetPath)
 // auto run
 (async () => {
     try {
+        /* TODO: replace to generate function in Vue 3 with @yzfe/svgicon */
         await build({
             sourcePath,
             targetPath,

--- a/packages/mirinae/cli/svg-gen.js
+++ b/packages/mirinae/cli/svg-gen.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/* eslint-disable */
+
+/**
+ * generate svg icons object
+ * @since 2023-05-12
+ */
+
+const path = require('path');
+
+const { Command } = require('commander');
+
+const { build } = require('./build');
+
+const program = new Command();
+program
+    .option('-s, --svgSourcePath <path>', 'Svg source path')
+    .option('-t, --targetPath <path>', 'Generate icon path')
+    .option('-e, --ext <ext>', "Generated file's extension", 'js')
+    .option('--svgo <svgo>', 'Svgo config file', 'svgo')
+    .parse(process.argv);
+
+// svg file path
+const sourcePath = path.isAbsolute(program.opts().svgSourcePath)
+    ? program.opts().svgSourcePath
+    : path.join(process.cwd(), program.opts().svgSourcePath);
+
+// generated icon path
+const targetPath = path.isAbsolute(program.opts().targetPath)
+    ? program.opts().targetPath
+    : path.join(process.cwd(), program.opts().targetPath);
+
+// auto run
+(async () => {
+    try {
+        await build({
+            sourcePath,
+            targetPath,
+        });
+    } catch (err) {
+        console.log(err);
+    }
+})();

--- a/packages/mirinae/cli/svgo.js
+++ b/packages/mirinae/cli/svgo.js
@@ -1,0 +1,39 @@
+module.exports = {
+    plugins: [
+        {
+            removeAttrs: {},
+        },
+        {
+            removeTitle: true,
+        },
+        {
+            inlineStyles: {
+                onlyMatchedOnce: false,
+            },
+        },
+        {
+            convertStyleToAttrs: true,
+        },
+        {
+            removeStyleElement: true,
+        },
+        {
+            removeComments: true,
+        },
+        {
+            removeDesc: true,
+        },
+        {
+            removeUselessDefs: true,
+        },
+        {
+            cleanupIDs: {
+                remove: true,
+                prefix: 'svgicon',
+            },
+        },
+        {
+            convertShapeToPath: true,
+        },
+    ],
+};

--- a/packages/mirinae/package.json
+++ b/packages/mirinae/package.json
@@ -43,14 +43,14 @@
     "tsc-alias": "tsc-alias -p tsconfig.build.json",
     "build:storybook": "NODE_OPTIONS=--max_old_space_size=4096 build-storybook -o .out -s public",
     "storybook": "start-storybook -p 6006 -s public",
-    "icon": "vsvg -s ./src/foundation/icons/icon-assets -t src/foundation/icons/p-icons --es6",
     "css": "node scripts/css.js",
     "eslint": "eslint --quiet --ext .js,.vue,.ts ./src/",
     "stylelint": "stylelint \"src/**/*.{css,vue,pcss,scss}\"",
     "lint": "npm run eslint && npm run stylelint",
     "test": "vitest run",
     "test:watch": "vitest watch --ui",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "icon": "node ./cli/svg-gen.js -s ./src/foundation/icons/icon-assets -t src/foundation/icons/p-icons"
   },
   "dependencies": {
     "@amcharts/amcharts4": "^4.10.32",
@@ -66,6 +66,7 @@
     "bytes": "^3.1.2",
     "codemirror": "^5.65.6",
     "color": "^3.1.2",
+    "commander": "^10.0.1",
     "core-js": "^3.29.1",
     "dayjs": "^1.10.7",
     "dompurify": "^2.3.3",
@@ -99,7 +100,6 @@
   },
   "devDependencies": {
     "@cloudforet/stylelint-config-custom": "*",
-    "postcss-config-custom": "*",
     "@originjs/vite-plugin-commonjs": "^1.0.3",
     "@types/bytes": "^3.1.1",
     "@types/codemirror": "0.0.109",
@@ -115,6 +115,7 @@
     "@vue/test-utils": "^1.3.3",
     "concurrently": "^7.6.0",
     "eslint-config-custom": "*",
+    "postcss-config-custom": "*",
     "resolve-url-loader": "^3.1.5",
     "rollup-plugin-copy": "^3.4.0",
     "ts-loader": "^8.4.0",


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [ ] `Error / Warning / Lint / Type`

### Description
SSIA

- Now, we use `svg-gen`-`build` instead of `vsvg`.
- After vue 3 migration, `build` will be replaced to `generate`.

### Things to Talk About
