### PR TITLE
feat: add sections in collector detail page (just markups)

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
@@ -1,17 +1,58 @@
 <template>
     <div class="collector-detail-page">
-        collector-detail-page - {{ props.collectorId }}
+        <p-heading :title="collectorName">
+            <p-skeleton v-if="!collectorName"
+                        width="20rem"
+                        height="1.5rem"
+            />
+            <template #extra>
+                <router-link :to="{name: ASSET_INVENTORY_ROUTE.COLLECTOR.HISTORY._NAME }">
+                    <p-button v-if="props.collectorId"
+                              style-type="tertiary"
+                    >
+                        {{ i18n.t('INVENTORY.COLLECTOR.DETAIL.COLLECTOR_HISTORY') }}
+                    </p-button>
+                </router-link>
+            </template>
+        </p-heading>
+
+        <collector-base-info-section class="section" />
+        <collector-schedule-section class="section" />
+        <collector-options-section class="section" />
+        <collector-service-accounts-section class="section" />
     </div>
 </template>
 
 <script lang="ts" setup>
 import { defineProps } from 'vue';
 
-const props = defineProps({
-    collectorId: {
-        type: String,
-        required: true,
-    },
-});
+import { PHeading, PSkeleton, PButton } from '@spaceone/design-system';
+
+import { i18n } from '@/translations';
+
+import CollectorBaseInfoSection from '@/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue';
+import CollectorOptionsSection
+    from '@/services/asset-inventory/collector/collector-detail/modules/CollectorOptionsSection.vue';
+import CollectorScheduleSection from '@/services/asset-inventory/collector/collector-detail/modules/CollectorScheduleSection.vue';
+import CollectorServiceAccountsSection
+    from '@/services/asset-inventory/collector/collector-detail/modules/CollectorServiceAccountsSection.vue';
+import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
+
+const props = defineProps<{
+    collectorId: string;
+}>();
+
+const collectorName = 'Collector';
+
+
 
 </script>
+
+<style lang="postcss" scoped>
+.section {
+    margin-bottom: 1rem;
+}
+
+</style>
+
+

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
@@ -1,0 +1,28 @@
+<template>
+    <p-pane-layout>
+        <p-heading :title="i18n.t('INVENTORY.COLLECTOR.DETAIL.BASE_INFO')"
+                   heading-type="sub"
+        >
+            <template #extra>
+                <p-button size="md"
+                          icon-left="ic_edit"
+                          style-type="secondary"
+                >
+                    {{ i18n.t('INVENTORY.COLLECTOR.DETAIL.EDIT') }}
+                </p-button>
+            </template>
+        </p-heading>
+    </p-pane-layout>
+</template>
+
+<script lang="ts" setup>
+import { defineProps } from 'vue';
+
+import { PHeading, PButton, PPaneLayout } from '@spaceone/design-system';
+
+import { i18n } from '@/translations';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/ban-types
+const props = defineProps<{}>();
+
+</script>

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorOptionsSection.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorOptionsSection.vue
@@ -1,0 +1,28 @@
+<template>
+    <p-pane-layout>
+        <p-heading :title="i18n.t('INVENTORY.COLLECTOR.DETAIL.COLLECTOR_OPTIONS')"
+                   heading-type="sub"
+        >
+            <template #extra>
+                <p-button size="md"
+                          icon-left="ic_edit"
+                          style-type="secondary"
+                >
+                    {{ i18n.t('INVENTORY.COLLECTOR.DETAIL.EDIT') }}
+                </p-button>
+            </template>
+        </p-heading>
+    </p-pane-layout>
+</template>
+
+<script lang="ts" setup>
+import { defineProps } from 'vue';
+
+import { PHeading, PButton, PPaneLayout } from '@spaceone/design-system';
+
+import { i18n } from '@/translations';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/ban-types
+const props = defineProps<{}>();
+
+</script>

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorScheduleSection.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorScheduleSection.vue
@@ -1,0 +1,28 @@
+<template>
+    <p-pane-layout>
+        <p-heading :title="i18n.t('INVENTORY.COLLECTOR.DETAIL.SCHEDULE')"
+                   heading-type="sub"
+        >
+            <template #extra>
+                <p-button size="md"
+                          icon-left="ic_edit"
+                          style-type="secondary"
+                >
+                    {{ i18n.t('INVENTORY.COLLECTOR.DETAIL.EDIT') }}
+                </p-button>
+            </template>
+        </p-heading>
+    </p-pane-layout>
+</template>
+
+<script lang="ts" setup>
+import { defineProps } from 'vue';
+
+import { PHeading, PButton, PPaneLayout } from '@spaceone/design-system';
+
+import { i18n } from '@/translations';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/ban-types
+const props = defineProps<{}>();
+
+</script>

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorServiceAccountsSection.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorServiceAccountsSection.vue
@@ -1,0 +1,28 @@
+<template>
+    <p-pane-layout>
+        <p-heading :title="i18n.t('INVENTORY.COLLECTOR.DETAIL.ATTACHED_SERVICE_ACCOUNTS')"
+                   heading-type="sub"
+        >
+            <template #extra>
+                <p-button size="md"
+                          icon-left="ic_edit"
+                          style-type="secondary"
+                >
+                    {{ i18n.t('INVENTORY.COLLECTOR.DETAIL.EDIT') }}
+                </p-button>
+            </template>
+        </p-heading>
+    </p-pane-layout>
+</template>
+
+<script lang="ts" setup>
+import { defineProps } from 'vue';
+
+import { PHeading, PButton, PPaneLayout } from '@spaceone/design-system';
+
+import { i18n } from '@/translations';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/ban-types
+const props = defineProps<{}>();
+
+</script>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description

- Added markups to collector detail page
- Splitted page secions into several section components

<img width="986" alt="image" src="https://github.com/cloudforet-io/console/assets/26986739/93416c33-1ca1-4529-a413-03f739305ace">


### Things to Talk About
