### PR TITLE
feat(collector): separate the CollectorPluginContents for reuse

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/create-collector/CreateCollectorPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/CreateCollectorPage.vue
@@ -31,7 +31,7 @@
         </div>
         <!--        song-lang-->
         <delete-modal :header-title="$t('Are you sure you want to quit?')"
-                      :visible.sync="state.isDeleteModalVisible"
+                      :visible.sync="state.deleteModalVisible"
                       :contents="$t('You cannot undo this action.')"
                       @confirm="handleClose"
         />
@@ -62,7 +62,7 @@ import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
 
 const state = reactive({
     step: 1,
-    isDeleteModalVisible: false,
+    deleteModalVisible: false,
     descriptionByStep: computed(() => ({
         // song-lang
         1: i18n.t('Select a plugin first.'),
@@ -73,7 +73,7 @@ const state = reactive({
 });
 
 const handleClickClose = () => {
-    state.isDeleteModalVisible = true;
+    state.deleteModalVisible = true;
 };
 
 const handleClose = () => {

--- a/apps/web/src/services/asset-inventory/collector/create-collector/CreateCollectorPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/CreateCollectorPage.vue
@@ -16,10 +16,18 @@
                     {{ state.descriptionByStep[state.step] }}
                 </p>
             </div>
-            <create-collector-step1 v-if="state.step===1" />
-            <create-collector-step2 v-if="state.step===2" />
-            <create-collector-step3 v-if="state.step===3" />
-            <create-collector-step4 v-if="state.step===4" />
+            <create-collector-step1 v-if="state.step===1"
+                                    @update:currentStep="handleChangeStep"
+            />
+            <create-collector-step2 v-if="state.step===2"
+                                    @update:currentStep="handleChangeStep"
+            />
+            <create-collector-step3 v-if="state.step===3"
+                                    @update:currentStep="handleChangeStep"
+            />
+            <create-collector-step4 v-if="state.step===4"
+                                    @update:currentStep="handleChangeStep"
+            />
         </div>
         <!--        song-lang-->
         <delete-modal :header-title="$t('Are you sure you want to quit?')"
@@ -70,6 +78,10 @@ const handleClickClose = () => {
 
 const handleClose = () => {
     SpaceRouter.router.push({ name: ASSET_INVENTORY_ROUTE.COLLECTOR._NAME });
+};
+
+const handleChangeStep = (step: number) => {
+    state.step = step;
 };
 
 (() => {

--- a/apps/web/src/services/asset-inventory/collector/create-collector/CreateCollectorPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/CreateCollectorPage.vue
@@ -3,7 +3,7 @@
         <p-icon-button name="ic_close"
                        color="inherit"
                        class="close-button"
-                       @click.stop="handleClose"
+                       @click="handleClickClose"
         />
         <div class="collector-creator-page">
             <div class="header">
@@ -21,6 +21,12 @@
             <create-collector-step3 v-if="state.step===3" />
             <create-collector-step4 v-if="state.step===4" />
         </div>
+        <!--        song-lang-->
+        <delete-modal :header-title="$t('Are you sure you want to quit?')"
+                      :visible.sync="state.isDeleteModalVisible"
+                      :contents="$t('You cannot undo this action.')"
+                      @confirm="handleClose"
+        />
     </fragment>
 </template>
 
@@ -29,9 +35,12 @@ import { computed, reactive } from 'vue';
 
 import { PHeading, PIconButton } from '@spaceone/design-system';
 
+
 import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { i18n } from '@/translations';
+
+import DeleteModal from '@/common/components/modals/DeleteModal.vue';
 
 import CreateCollectorStep1
     from '@/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue';
@@ -45,6 +54,7 @@ import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
 
 const state = reactive({
     step: 1,
+    isDeleteModalVisible: false,
     descriptionByStep: computed(() => ({
         // song-lang
         1: i18n.t('Select a plugin first.'),
@@ -53,6 +63,10 @@ const state = reactive({
         4: i18n.t('Set schedule for automate collecting jobs.'),
     })),
 });
+
+const handleClickClose = () => {
+    state.isDeleteModalVisible = true;
+};
 
 const handleClose = () => {
     SpaceRouter.router.push({ name: ASSET_INVENTORY_ROUTE.COLLECTOR._NAME });

--- a/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue
@@ -20,6 +20,7 @@
                                 <collect-plugin-contents :plugin="item" />
                                 <p-button style-type="secondary"
                                           class="select-button"
+                                          @click="handleClickNextStep(item)"
                                 >
                                     {{ $t('Select') }}
                                 </p-button>
@@ -61,6 +62,9 @@ import Step1SearchFilter from '@/services/asset-inventory/collector/create-colle
 import CollectPluginContents
     from '@/services/asset-inventory/collector/modules/CollectPluginContents.vue';
 
+const emit = defineEmits([
+    'update:currentStep',
+]);
 
 const state = reactive({
     searchValue: '',
@@ -104,6 +108,10 @@ const getPlugins = async () => {
 
 const handleSearch = (value) => {
     console.log('value', value);
+};
+const handleClickNextStep = (item) => {
+    emit('update:currentStep', 2);
+    console.log('item', item);
 };
 
 (() => {

--- a/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue
@@ -17,41 +17,19 @@
                     >
                         <template #content>
                             <div class="plugin-card-content">
-                                <div class="left-contents">
-                                    <p-lazy-img :src="item.icon"
-                                                class="plugin-icon"
-                                                width="2.5rem"
-                                                height="2.5rem"
-                                    />
-                                    <div class="contents">
-                                        <p class="plugin-name">
-                                            {{ item.name }} <span v-if="isBeta(item)"
-                                                                  class="beta"
-                                            >{{ $t('beta') }}</span>
-                                        </p>
-                                        <div class="plugin-description">
-                                            <span class="plugin-description-text">
-                                                {{ item.tags.description }}
-                                            </span><p-anchor size="sm"
-                                                             :highlight="true"
-                                            >
-                                                {{ $t('learn more') }}
-                                            </p-anchor>
-                                        </div>
-                                        <div v-if="item.labels">
-                                            <p-label v-for="(label, idx) in item.labels"
-                                                     :key="`${label}-${idx}`"
-                                                     class="mr-2 mb-2"
-                                                     :text="label"
-                                            />
-                                        </div>
-                                    </div>
-                                </div>
+                                <collect-plugin-contents :plugin="item" />
                                 <p-button style-type="secondary"
-                                          class="create-button"
+                                          class="select-button"
                                 >
                                     {{ $t('Select') }}
                                 </p-button>
+                                <p-i class="select-icon"
+                                     name="ic_chevron-right"
+                                     :color="gray[300]"
+                                     width="1.5rem"
+                                     height="1.5rem"
+                                     @click="handleClickNextStep(item)"
+                                />
                             </div>
                         </template>
                     </p-board-item>
@@ -65,9 +43,8 @@
 import { reactive } from 'vue';
 
 import {
-    PSearch, PDataLoader, PBoardItem, PLazyImg, PButton, PLabel, PAnchor,
+    PSearch, PDataLoader, PBoardItem, PButton, PI,
 } from '@spaceone/design-system';
-import { get } from 'lodash';
 
 import { getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
@@ -77,9 +54,13 @@ import { assetUrlConverter } from '@/lib/helper/asset-helper';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
+import { gray } from '@/styles/colors';
 import { BACKGROUND_COLOR } from '@/styles/colorsets';
 
 import Step1SearchFilter from '@/services/asset-inventory/collector/create-collector/modules/Step1SearchFilter.vue';
+import CollectPluginContents
+    from '@/services/asset-inventory/collector/modules/CollectPluginContents.vue';
+
 
 const state = reactive({
     searchValue: '',
@@ -120,7 +101,6 @@ const getPlugins = async () => {
         state.loading = false;
     }
 };
-const isBeta = (item) => get(item, 'tags.beta', '');
 
 const handleSearch = (value) => {
     console.log('value', value);
@@ -144,45 +124,28 @@ const handleSearch = (value) => {
         .right-area {
             overflow-y: auto;
             max-width: 44.375rem;
+
             .plugin-card-list {
                 @apply flex flex-col flex-wrap gap-2;
+                :deep(.p-board-item) {
+                    .content-area .content {
+                        flex-grow: unset;
+                        width: 100%;
+                    }
+                }
 
                 .plugin-card-item {
                     border-radius: 0.375rem;
                     width: 100%;
+
                     .plugin-card-content {
                         @apply flex justify-between;
                         width: 100%;
-                        .left-contents {
-                            @apply flex items-center;
-                            width: 100%;
-                            .plugin-icon {
-                                margin-right: 1.5rem;
-                            }
-                            .contents {
-                                @apply flex flex-col;
-                                width: 100%;
-
-                                .plugin-name {
-                                    @apply text-label-md text-gray-900 flex;
-                                    margin-bottom: 0.25rem;
-                                    .beta {
-                                        @apply text-label-xs text-coral-500 font-normal;
-                                    }
-                                }
-                                .plugin-description {
-                                    @apply inline-flex items-end gap-1;
-                                    width: 100%;
-                                    .plugin-description-text {
-                                        @apply text-label-sm text-gray-500 truncate;
-                                        max-width: 18.75rem;
-                                        flex-shrink: 0;
-                                    }
-                                }
-                            }
-                        }
-                        .create-button {
+                        .select-button {
                             flex-shrink: 0;
+                        }
+                        .select-icon {
+                            display: none;
                         }
                     }
                 }
@@ -203,13 +166,21 @@ const handleSearch = (value) => {
         min-width: 43rem;
         .contents-container {
             @apply flex-col;
-            .plugin-description {
-                @apply inline-flex items-end gap-1 flex-wrap;
-                width: 100%;
-                .plugin-description-text {
-                    @apply text-label-sm text-gray-500 truncate;
-                    max-width: 18.75rem;
-                    flex-shrink: 0;
+            .right-area {
+                .plugin-card-list {
+                    .plugin-card-item {
+                        .plugin-card-content {
+                            @apply flex items-center;
+                            .select-button {
+                                display: none;
+                            }
+                            .select-icon {
+                                flex-shrink: 0;
+                                display: inline-block;
+                                cursor: pointer;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectPluginContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectPluginContents.vue
@@ -1,0 +1,102 @@
+<template>
+    <div class="plugin-data-contents">
+        <p-lazy-img :src="props.plugin.icon"
+                    class="plugin-icon"
+                    width="2.5rem"
+                    height="2.5rem"
+        />
+        <div class="contents">
+            <p class="plugin-name">
+                {{ props.plugin.name }} <span v-if="isBeta(props.plugin)"
+                                              class="beta"
+                >{{ $t('beta') }}</span>
+            </p>
+            <div class="plugin-description">
+                <span class="plugin-description-text">
+                    {{ props.plugin.tags.description }}
+                </span><p-anchor size="sm"
+                                 :highlight="true"
+                >
+                    <!--                    // song-lang-->
+                    {{ $t('learn more') }}
+                </p-anchor>
+            </div>
+            <div v-if="props.plugin.labels"
+                 class="label-container"
+            >
+                <p-label v-for="(label, idx) in props.plugin.labels"
+                         :key="`${label}-${idx}`"
+                         class="mb-1"
+                         :text="label"
+                />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { defineProps } from 'vue';
+
+import {
+    PAnchor, PLazyImg, PLabel,
+} from '@spaceone/design-system';
+import { get } from 'lodash';
+
+// TODO: Add plugin data type
+interface Props {
+    plugin: any;
+}
+
+const props = defineProps<Props>();
+
+const isBeta = (item) => get(item, 'tags.beta', '');
+
+</script>
+
+<style lang="postcss" scoped>
+.plugin-data-contents {
+    @apply flex items-center;
+    width: 100%;
+    .plugin-icon {
+        flex-shrink: 0;
+        margin-right: 1.5rem;
+    }
+    .contents {
+        @apply flex flex-col;
+        width: 100%;
+
+        .plugin-name {
+            @apply text-label-md text-gray-900;
+            margin-bottom: 0.25rem;
+            .beta {
+                @apply text-label-xs text-coral-500 font-normal;
+            }
+        }
+        .plugin-description {
+            @apply inline-flex items-end gap-1;
+            flex-wrap: wrap;
+            .plugin-description-text {
+                @apply text-label-sm text-gray-500 truncate;
+                max-width: 18.75rem;
+                flex-shrink: 1;
+            }
+        }
+    }
+}
+
+@screen tablet {
+    .plugin-data-contents {
+        .contents {
+            .plugin-description {
+                .plugin-description-text {
+                    white-space: normal;
+                }
+            }
+            .label-container {
+                @apply flex flex-wrap;
+            }
+        }
+    }
+}
+
+</style>

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectPluginContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectPluginContents.vue
@@ -74,6 +74,7 @@ const isBeta = (item) => get(item, 'tags.beta', '');
         }
         .plugin-description {
             @apply inline-flex items-end gap-1;
+            margin-bottom: 0.5rem;
             flex-wrap: wrap;
             .plugin-description-text {
                 @apply text-label-sm text-gray-500 truncate;

--- a/apps/web/src/services/asset-inventory/store/collector-form-store.ts
+++ b/apps/web/src/services/asset-inventory/store/collector-form-store.ts
@@ -1,0 +1,6 @@
+import { defineStore } from 'pinia';
+
+export const useCollectorFormStore = defineStore('collector-form', {
+    state: () => ({}),
+    actions: {},
+});


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
- Separated CollectorPluginContents component
- Updated the plug-in list style additionally

before
![image](https://github.com/cloudforet-io/console/assets/50662170/a1f35bf4-c1e1-4b07-b90a-37809ee80658)

after
![image](https://github.com/cloudforet-io/console/assets/50662170/d7727516-cc3d-4172-b3f5-3a819a7c4fe3)
![image](https://github.com/cloudforet-io/console/assets/50662170/fbb7b72b-edeb-4a15-9c1e-c9f9433430c5)




### Things to Talk About
I was so confused because the css styling and mirinae component styles were mixed.. 😭 😭 