### PR TITLE
feat: split a widget into 2 widgets(pass and fail & fail)

### DIFF
--- a/apps/web/src/services/dashboards/widgets/_base/base-count-of-findings/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/_base/base-count-of-findings/widget-config.ts
@@ -1,0 +1,24 @@
+import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
+import { ASSET_GROUP_BY, GRANULARITY } from '@/services/dashboards/widgets/_configs/config';
+
+const baseCountOfFindingsWidgetConfig: WidgetConfig = {
+    widget_config_id: 'baseCountOfFindings',
+    widget_component: () => ({
+        component: import('@/services/dashboards/widgets/_base/base-count-of-findings/BaseCountOfFindingsWidget.vue'),
+    }),
+    scopes: ['WORKSPACE'],
+    theme: {
+        inherit: false,
+    },
+    sizes: ['lg', 'full'],
+    options: {
+        granularity: GRANULARITY.ACCUMULATED,
+        asset_group_by: ASSET_GROUP_BY.REGION,
+        pagination_options: {
+            enabled: true,
+            page_size: 8,
+        },
+    },
+};
+
+export default baseCountOfFindingsWidgetConfig;

--- a/apps/web/src/services/dashboards/widgets/count-of-fail-findings/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/count-of-fail-findings/widget-config.ts
@@ -4,14 +4,15 @@ import {
     getWidgetFilterOptionsSchema, getWidgetFilterSchemaPropertyNames, getWidgetOptionsSchema,
 } from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
-const countOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
-    widget_config_id: 'countOfPassAndFailFindings',
+const countOfFailFindingsWidgetConfig: WidgetConfig = {
+    widget_config_id: 'countOfFailFindings',
     base_configs: [{ config_id: 'baseCountOfFindings' }],
-    title: 'Count of Pass and Fail Findings',
+    title: 'Count of Fail Findings',
     labels: ['Asset'],
     description: {
-        // translation_id: 'DASHBOARDS.WIDGET.MONTHLY_COST.DESC', // TODO: To be added
-        preview_image: 'widget-img_countOfPassAndFailFindings--thumbnail.png',
+        // TODO: To be added
+        // translation_id: 'DASHBOARDS.WIDGET.MONTHLY_COST.DESC',
+        preview_image: 'widget-img_countOfFailFindings--thumbnail.png',
     },
     scopes: ['WORKSPACE'],
     theme: {
@@ -20,7 +21,7 @@ const countOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
     sizes: ['lg', 'full'],
     options: {
         granularity: GRANULARITY.ACCUMULATED,
-        asset_group_by: ASSET_GROUP_BY.REGION,
+        asset_group_by: ASSET_GROUP_BY.SERVICE,
         pagination_options: {
             enabled: true,
             page_size: 8,
@@ -54,4 +55,4 @@ const countOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
     },
 };
 
-export default countOfPassAndFailFindingsWidgetConfig;
+export default countOfFailFindingsWidgetConfig;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Checklist
- [x] `Error / Warning / Lint / Type`

### Description
**Before**
- `CountOfPassAndFailFindings`
![스크린샷 2023-05-26 오전 10 52 59](https://github.com/cloudforet-io/console/assets/18563857/c33272de-d1cd-49e7-92c8-75a9bffc1aa8)


**After**
- `BaseCountOfFindingsWidget`
  - `CountOfPassAndFailFindings`
    ![스크린샷 2023-05-26 오전 10 52 59](https://github.com/cloudforet-io/console/assets/18563857/4aa0ac45-589d-4165-a1b5-8e17158c224e)
  - `CountOfFailFindings`
    ![스크린샷 2023-05-26 오전 10 52 56](https://github.com/cloudforet-io/console/assets/18563857/911652bc-7d35-4527-8ed6-c3c7324150d4)
