### PR TITLE
feat(collector-landing-page): code separation

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/CollectorPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/CollectorPage.vue
@@ -4,7 +4,7 @@
             use-total-count
             use-selected-count
             :title="$t('INVENTORY.COLLECTOR.MAIN.TITLE')"
-            :total-count="collectorPageState.totalCount"
+            :total-count="collectorPageState.listCount"
         >
             <template #extra>
                 <router-link
@@ -18,19 +18,23 @@
                 </router-link>
             </template>
         </p-heading>
-        <!-- FIXME: loading must be fixed after basic function. -->
         <p-data-loader
-            :data="collectorPageState.collectorList"
-            :loading="collectorPageState.loading && !collectorPageState.collectorList"
+            :data="collectorPageState.hasCollectorList"
+            :loading="state.loading"
             loader-backdrop-color="gray.100"
-            class="collector-contents-wrapper"
+            class="collector-loader-wrapper"
         >
-            <collector-contents
-                :key-item-sets="handlerState.keyItemSets"
-                :provider-list="state.providerList"
-                :search-tags="state.searchTags"
-                @change-toolbox="handleChangeToolbox"
-            />
+            <div class="collector-contents-wrapper">
+                <provider-list
+                    :provider-list="state.providerList"
+                    :selected-provider="state.selectedProvider"
+                    @change-provider="handleSelectedProvider"
+                />
+                <!-- TODO: will be apply data-->
+                <collector-contents
+                    :key-item-sets="handlerState.keyItemSets"
+                />
+            </div>
             <template #no-data>
                 <collector-no-data />
             </template>
@@ -39,27 +43,19 @@
 </template>
 
 <script lang="ts" setup>
-import {
-    computed, onUnmounted, reactive, watch,
-} from 'vue';
+import { computed, onUnmounted, reactive } from 'vue';
 
-import { PButton, PDataLoader, PHeading } from '@spaceone/design-system';
+import { PButton, PHeading, PDataLoader } from '@spaceone/design-system';
 
 import type { KeyItemSet } from '@cloudforet/core-lib/component-util/query-search/type';
-import { setApiQueryWithToolboxOptions } from '@cloudforet/core-lib/component-util/toolbox';
-import { QueryHelper } from '@cloudforet/core-lib/query';
-import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 
 import { store } from '@/store';
 
-import type { PluginReferenceMap } from '@/store/modules/reference/plugin/type';
 import type { ProviderReferenceMap } from '@/store/modules/reference/provider/type';
-
-import ErrorHandler from '@/common/composables/error/errorHandler';
 
 import CollectorContents from '@/services/asset-inventory/collector/modules/CollectorContents.vue';
 import CollectorNoData from '@/services/asset-inventory/collector/modules/CollectorNoData.vue';
-import { COLLECTOR_QUERY_HELPER_SET } from '@/services/asset-inventory/collector/type';
+import ProviderList from '@/services/asset-inventory/components/ProviderList.vue';
 import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
 import { useCollectorPageStore } from '@/services/asset-inventory/store/collector-page-store';
 
@@ -68,7 +64,6 @@ const collectorPageState = collectorPageStore.$state;
 
 const storeState = reactive({
     providers: computed<ProviderReferenceMap>(() => store.getters['reference/providerItems']),
-    plugins: computed<PluginReferenceMap>(() => store.getters['reference/pluginItems']),
 });
 
 const handlerState = reactive({
@@ -88,72 +83,27 @@ const handlerState = reactive({
     }]),
 });
 
-const searchQueryHelper = new QueryHelper().setKeyItemSets(handlerState.keyItemSets ?? []);
-
 const state = reactive({
+    loading: true,
+    selectedProvider: computed(() => collectorPageState.selectedProvider),
     providerList: computed(() => ([{ key: 'all', name: 'All Providers' }, ...Object.values(storeState.providers)])),
-    searchTags: computed(() => searchQueryHelper.setFilters(collectorPageState.searchFilters).queryTags),
-    items: computed(() => {
-        const plugins = storeState.plugins;
-        return collectorPageState.collectors?.map((d) => ({
-            collectorId: d.collector_id,
-            name: d.name,
-            pluginName: plugins[d.plugin_info.plugin_id]?.label,
-            pluginIcon: plugins[d.plugin_info.plugin_id]?.icon,
-            pluginInfo: d.plugin_info,
-            detailLink: {
-                name: ASSET_INVENTORY_ROUTE.COLLECTOR.DETAIL._NAME,
-                param: { id: d.collector_id },
-                query: {
-                    filters: searchQueryHelper.setFilters([
-                        {
-                            k: COLLECTOR_QUERY_HELPER_SET.COLLECTOR_ID,
-                            v: d.collector_id,
-                            o: '=',
-                        },
-                    ]).rawQueryStrings,
-                },
-            },
-        }));
-    }),
 });
-
-/* Query Helper */
-const collectorApiQueryHelper = new ApiQueryHelper()
-    .setOnly(
-        COLLECTOR_QUERY_HELPER_SET.COLLECTOR_ID,
-        COLLECTOR_QUERY_HELPER_SET.NAME,
-        COLLECTOR_QUERY_HELPER_SET.LAST_COLLECTED_AT,
-        COLLECTOR_QUERY_HELPER_SET.PROVIDER,
-        COLLECTOR_QUERY_HELPER_SET.TAGS,
-        COLLECTOR_QUERY_HELPER_SET.PLUGIN_INFO,
-        COLLECTOR_QUERY_HELPER_SET.STATE,
-    )
-    .setPage(collectorPageState.pageStart, collectorPageState.pageLimit)
-    .setSort(collectorPageState.sortBy, true);
 
 /* Components */
 const initCollectorList = async () => {
-    collectorApiQueryHelper.setFilters(collectorPageStore.allFilters);
+    state.loading = true;
     try {
-        await collectorPageStore.getCollectorList(collectorApiQueryHelper.data);
-        if (Object.keys(state.items).length > 0) {
-            await collectorPageStore.setCollectorList(state.items);
-        }
+        await collectorPageStore.getInitCollectorList();
     } catch (e) {
-        ErrorHandler.handleError(e);
         await collectorPageStore.$reset();
+    } finally {
+        state.loading = false;
     }
 };
-const handleChangeToolbox = async (options) => {
-    setApiQueryWithToolboxOptions(collectorApiQueryHelper, options);
-    await initCollectorList();
+const handleSelectedProvider = (providerName: string) => {
+    collectorPageStore.setSelectedProvider(providerName);
+    // getCollectorList();
 };
-
-/* Watcher */
-watch(() => collectorPageState.selectedProvider, async () => {
-    await initCollectorList();
-});
 
 /* Unmounted */
 onUnmounted(() => {
@@ -196,7 +146,12 @@ onUnmounted(() => {
     }
 }
 
-.collector-contents-wrapper {
+.collector-loader-wrapper {
     min-height: 16.875rem;
+
+    .collector-contents-wrapper {
+        @apply flex flex-col;
+        gap: 1.5rem;
+    }
 }
 </style>

--- a/apps/web/src/services/asset-inventory/store/collector-page-store.ts
+++ b/apps/web/src/services/asset-inventory/store/collector-page-store.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+import type { Query } from '@cloudforet/core-lib/space-connector/type';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
@@ -10,15 +11,15 @@ import type { CollectorModel } from '@/services/asset-inventory/collector/type';
 export const useCollectorPageStore = defineStore('collector-page', {
     state: () => ({
         loading: true,
-        totalCount: 0,
+        hasCollectorList: false,
         pageStart: 1,
         pageLimit: 15,
         sortBy: '',
         selectedProvider: 'all',
         collectors: [] as CollectorModel[],
         searchFilters: [] as ConsoleFilter[],
-        collectorList: undefined as CollectorModel[] | undefined,
-        filteredList: undefined as CollectorModel[] | undefined,
+        collectorList: null as CollectorModel[] | null,
+        listCount: 0,
     }),
     getters: {
         allFilters: (state): ConsoleFilter[] => {
@@ -30,13 +31,25 @@ export const useCollectorPageStore = defineStore('collector-page', {
         },
     },
     actions: {
-        async getCollectorList(queryData) {
+        async getInitCollectorList() {
+            try {
+                const res = await SpaceConnector.client.inventory.collector.list();
+                this.collectors = res.results;
+                if (res.total_count > 0) {
+                    this.hasCollectorList = true;
+                    this.listCount = res.total_count;
+                }
+            } catch (e) {
+                ErrorHandler.handleError(e);
+                throw e;
+            }
+        },
+        async getCollectorList(queryData?: Query) {
             this.loading = true;
             try {
                 const res = await SpaceConnector.client.inventory.collector.list({
                     query: queryData,
                 });
-                this.totalCount = res.total_count;
                 this.collectors = res.results;
             } catch (e) {
                 ErrorHandler.handleError(e);
@@ -50,7 +63,6 @@ export const useCollectorPageStore = defineStore('collector-page', {
         },
         async setCollectorList(collectorList) {
             this.collectorList = collectorList;
-            this.filteredList = collectorList;
         },
         async setFilteredCollectorList(filters) {
             this.searchFilters = filters;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- code separation for solving the `FIXME` of `p-data-loader`
  - I have modified to display the contents of `p-data-loader` based on the total number of collector lists during page initialization.

  - The collector total count is undefined
  <img width="1486" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/00ea415e-e479-4655-b819-dda1dde74e3e">

  - The collector total count is 0
  <img width="1486" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/e6b6b995-4885-4955-ba85-930d9a5ebeef">

### Things to Talk About
🤔 Question
I created `getInitCollectorList` in pinia to check the presence of collector lists during the initial page entry.
However, it is similar to `getCollectorList`, so I'm worried about to keep this function.
For now, I applied it this way to avoid complicating the internal code based on the presence of queryData.

🐱 P.S
I haven't committed the `collector-contents` section yet in order to split it into separate pull requests.