### PR TITLE
feat(collector-landing-page): resolve loading of p-data-loader at landing page

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/CollectorPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/CollectorPage.vue
@@ -4,7 +4,7 @@
             use-total-count
             use-selected-count
             :title="$t('INVENTORY.COLLECTOR.MAIN.TITLE')"
-            :total-count="collectorPageState.listCount"
+            :total-count="collectorPageState.totalCount"
         >
             <template #extra>
                 <router-link
@@ -113,7 +113,7 @@ const initCollectorList = async () => {
     state.initLoading = true;
     try {
         await collectorPageStore.getCollectorList();
-        if (collectorPageState.listCount > 0) {
+        if (collectorPageState.totalCount > 0) {
             state.hasCollectorList = true;
         }
     } catch (e) {

--- a/apps/web/src/services/asset-inventory/collector/CollectorPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/CollectorPage.vue
@@ -142,6 +142,7 @@ const handleChangeToolbox = (options) => {
 /* Unmounted */
 onUnmounted(() => {
     collectorPageStore.$reset();
+    collectorPageStore.$dispose();
 });
 
 /* INIT */

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
@@ -1,65 +1,56 @@
 <template>
     <div class="collector-contents">
-        <provider-list
-            :provider-list="props.providerList"
-            :selected-provider="state.selectedProvider"
-            @change-provider="handleSelectedProvider"
-        />
-        <div class="collector-list-wrapper">
-            <p-toolbox
-                exportable
-                filters-visible
-                search-type="query"
-                :query-tags="props.searchTags"
-                :key-item-sets="props.keyItemSets"
-                :value-handler-map="state.valueHandlerMap"
-                :total-count="collectorPageState.totalCount"
-                @change="handleChange"
-                @refresh="handleChange"
-                @export="handleExport"
-            >
-                <template #left-area>
-                    <p-button
-                        icon-left="ic_plus_bold"
-                        class="create-button"
-                        @click="handleCreate"
-                    >
-                        {{ $t('INVENTORY.COLLECTOR.MAIN.CREATE') }}
-                    </p-button>
-                </template>
-            </p-toolbox>
-            <!-- FIXME: apply loading data -->
-            <p-data-loader
-                class="collector-lists-wrapper"
-                :data="collectorPageState.filteredList"
-                :loading="false"
-            >
-                <div class="collector-lists">
-                    <p-card
-                        v-for="item in collectorPageState.filteredList"
-                        :key="item.collector_id"
-                        :header="false"
-                        style-type="white"
-                    >
-                        <div class="collector-item-wrapper">
-                            <span class="collector-item-name">{{ item.name }}</span>
-                            <div class="collector-info-wrapper">
-                                <collector-item-info
-                                    v-for="info in state.infoItems"
-                                    :key="info.key"
-                                    :label="info.label"
-                                    :type="info.key"
-                                    :item="item"
-                                />
-                            </div>
+        <p-toolbox
+            exportable
+            filters-visible
+            search-type="query"
+            :key-item-sets="props.keyItemSets"
+            :query-tags="state.searchTags"
+            :value-handler-map="state.valueHandlerMap"
+            :total-count="collectorPageState.listCount"
+            @change="handleChangeToolbox"
+            @refresh="handleChangeToolbox"
+            @export="handleExport"
+        >
+            <template #left-area>
+                <p-button
+                    icon-left="ic_plus_bold"
+                    class="create-button"
+                    @click="handleCreate"
+                >
+                    {{ $t('INVENTORY.COLLECTOR.MAIN.CREATE') }}
+                </p-button>
+            </template>
+        </p-toolbox>
+        <p-data-loader :data="state.items"
+                       :loading="collectorPageState.loading"
+                       class="collector-list-wrapper"
+        >
+            <div class="collector-lists">
+                <p-card
+                    v-for="item in state.items"
+                    :key="item.collectorId"
+                    :header="false"
+                    style-type="white"
+                >
+                    <div class="collector-item-wrapper">
+                        <span class="collector-item-name">{{ item.name }}</span>
+                        <div class="collector-info-wrapper">
+                            <collector-item-info
+                                v-for="info in state.infoItems"
+                                :key="info.key"
+                                :label="info.label"
+                                :type="info.key"
+                                :item="item"
+                            />
                         </div>
-                    </p-card>
-                </div>
-                <template #no-data>
-                    <collector-list-no-data class="collector-no-data" />
-                </template>
-            </p-data-loader>
-        </div>
+                    </div>
+                </p-card>
+            </div>
+            <template #no-data>
+                <collector-list-no-data class="collector-no-data" />
+            </template>
+        </p-data-loader>
     </div>
 </template>
 
@@ -71,39 +62,38 @@ import {
 } from '@spaceone/design-system';
 
 import { makeDistinctValueHandler } from '@cloudforet/core-lib/component-util/query-search';
-import type { KeyItemSet, QueryTag, ValueHandlerMap } from '@cloudforet/core-lib/component-util/query-search/type';
+import type { KeyItemSet, ValueHandlerMap } from '@cloudforet/core-lib/component-util/query-search/type';
 import { QueryHelper } from '@cloudforet/core-lib/query';
 
 import { SpaceRouter } from '@/router';
+import { store } from '@/store';
 
-import type { ReferenceItem } from '@/store/modules/reference/type';
+import type { PluginReferenceMap } from '@/store/modules/reference/plugin/type';
 
 import { replaceUrlQuery } from '@/lib/router-query-string';
 
 import CollectorItemInfo from '@/services/asset-inventory/collector/modules/CollectorItemInfo.vue';
 import CollectorListNoData from '@/services/asset-inventory/collector/modules/CollectorListNoData.vue';
-import { COLLECTOR_ITEM_INFO_TYPE } from '@/services/asset-inventory/collector/type';
-import ProviderList from '@/services/asset-inventory/components/ProviderList.vue';
+import { COLLECTOR_ITEM_INFO_TYPE, COLLECTOR_QUERY_HELPER_SET } from '@/services/asset-inventory/collector/type';
 import { ASSET_INVENTORY_ROUTE } from '@/services/asset-inventory/route-config';
 import { useCollectorPageStore } from '@/services/asset-inventory/store/collector-page-store';
 
 interface Props {
     keyItemSets?: KeyItemSet[]
-    providerList?: ReferenceItem[]
-    searchTags?:QueryTag[]
 }
 
 const props = withDefaults(defineProps<Props>(), {
     keyItemSets: undefined,
-    providerList: undefined,
-    searchTags: undefined,
 });
 
 const collectorPageStore = useCollectorPageStore();
 const collectorPageState = collectorPageStore.$state;
 
+const storeState = reactive({
+    plugins: computed<PluginReferenceMap>(() => store.getters['reference/pluginItems']),
+});
+
 const state = reactive({
-    selectedProvider: computed(() => collectorPageState.selectedProvider),
     infoItems: [
         { key: COLLECTOR_ITEM_INFO_TYPE.PLUGIN, label: 'Plugin' },
         { key: COLLECTOR_ITEM_INFO_TYPE.STATUS, label: 'Current Status' },
@@ -128,60 +118,81 @@ const state = reactive({
         { key: 'plugin_info.version', name: 'Version' },
         { key: 'last_collected_at', name: 'Last Collected', type: 'datetime' },
     ],
+    searchTags: computed(() => searchQueryHelper.setFilters(collectorPageState.searchFilters).queryTags),
+    items: computed(() => {
+        const plugins = storeState.plugins;
+        return collectorPageState.collectors?.map((d) => ({
+            collectorId: d.collector_id,
+            name: d.name,
+            plugin: {
+                name: plugins[d.plugin_info.plugin_id]?.label,
+                icon: plugins[d.plugin_info.plugin_id]?.icon,
+                info: d.plugin_info,
+            },
+            detailLink: {
+                name: ASSET_INVENTORY_ROUTE.COLLECTOR.DETAIL._NAME,
+                param: { id: d.collector_id },
+                query: {
+                    filters: searchQueryHelper.setFilters([
+                        {
+                            k: COLLECTOR_QUERY_HELPER_SET.COLLECTOR_ID,
+                            v: d.collector_id,
+                            o: '=',
+                        },
+                    ]).rawQueryStrings,
+                },
+            },
+        }));
+    }),
 });
-
 
 const emit = defineEmits(['change-toolbox']);
 
-const searchQueryHelper = new QueryHelper();
+const searchQueryHelper = new QueryHelper().setKeyItemSets(props.keyItemSets ?? []);
 
 /* Components */
-const handleSelectedProvider = (providerName: string) => {
-    collectorPageStore.setSelectedProvider(providerName);
-};
 const handleCreate = () => {
     SpaceRouter.router.push({ name: ASSET_INVENTORY_ROUTE.COLLECTOR.CREATE._NAME });
 };
 const handleExport = async () => {};
-const handleChange = async (options) => {
+const handleChangeToolbox = async (options) => {
+    emit('change-toolbox');
     if (options.queryTags !== undefined) {
         searchQueryHelper.setFiltersAsQueryTag(options.queryTags);
         await collectorPageStore.setFilteredCollectorList(searchQueryHelper.filters);
         await replaceUrlQuery('filters', searchQueryHelper.rawQueryStrings);
     }
-    emit('change-toolbox', options);
 };
 </script>
 
 <style scoped lang="postcss">
 .collector-contents {
     @apply flex flex-col;
-    gap: 1.5rem;
+    gap: 0.5rem;
 
     .collector-list-wrapper {
         @apply flex flex-col;
         gap: 0.25rem;
+        min-height: 16.875rem;
 
         .create-button {
             padding-right: 0.75rem;
             padding-left: 0.75rem;
         }
 
-        .collector-lists-wrapper {
-            .collector-lists {
-                @apply grid grid-cols-2 gap-4;
+        .collector-lists {
+            @apply grid grid-cols-2 gap-4;
 
-                .collector-item-wrapper {
-                    @apply flex flex-col;
-                    gap: 1.25rem;
-                    padding: 0.5rem 0.625rem;
+            .collector-item-wrapper {
+                @apply flex flex-col;
+                gap: 1.25rem;
+                padding: 0.5rem 0.625rem;
 
-                    .collector-item-name {
-                        @apply text-label-xl font-bold;
-                    }
-                    .collector-info-wrapper {
-                        @apply grid grid-cols-2 gap-6;
-                    }
+                .collector-item-name {
+                    @apply text-label-xl font-bold;
+                }
+                .collector-info-wrapper {
+                    @apply grid grid-cols-2 gap-6;
                 }
             }
         }

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
@@ -156,12 +156,12 @@ const handleCreate = () => {
 };
 const handleExport = async () => {};
 const handleChangeToolbox = async (options) => {
-    emit('change-toolbox');
     if (options.queryTags !== undefined) {
         searchQueryHelper.setFiltersAsQueryTag(options.queryTags);
         await collectorPageStore.setFilteredCollectorList(searchQueryHelper.filters);
         await replaceUrlQuery('filters', searchQueryHelper.rawQueryStrings);
     }
+    emit('change-toolbox', options);
 };
 </script>
 

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
@@ -7,7 +7,7 @@
             :key-item-sets="props.keyItemSets"
             :query-tags="state.searchTags"
             :value-handler-map="state.valueHandlerMap"
-            :total-count="collectorPageState.listCount"
+            :total-count="collectorPageState.totalCount"
             @change="handleChangeToolbox"
             @refresh="handleChangeToolbox"
             @export="handleExport"

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
@@ -7,12 +7,12 @@
                 {{ props.label }}
             </p>
             <div class="plugin">
-                <p-lazy-img :src="props.item.pluginIcon"
+                <p-lazy-img :src="props.item.plugin.icon"
                             width="1.25rem"
                             height="1.25rem"
                 />
-                <span class="plugin-name">{{ props.item.pluginName }}</span>
-                <span class="plugin-version">v{{ props.item.pluginInfo.version }}</span>
+                <span class="plugin-name">{{ props.item.plugin.name }}</span>
+                <span class="plugin-version">v{{ props.item.plugin.info.version }}</span>
             </div>
         </div>
         <div
@@ -130,12 +130,12 @@ import {
     PButton, PI, PLazyImg, PToggleButton,
 } from '@spaceone/design-system';
 
-import type { CollectorModel } from '@/services/asset-inventory/collector/type';
+import type { CollectorItemInfo } from '@/services/asset-inventory/collector/type';
 import { COLLECTOR_ITEM_INFO_TYPE } from '@/services/asset-inventory/collector/type';
 
 interface Props {
     label: string;
-    item?: CollectorModel;
+    item?: CollectorItemInfo;
     type: string;
 }
 

--- a/apps/web/src/services/asset-inventory/collector/type.ts
+++ b/apps/web/src/services/asset-inventory/collector/type.ts
@@ -149,22 +149,22 @@ export type CollectorScheduleListResp = ListType<CollectorScheduleModel>;
 interface CollectorPlugin {
     name?: string;
     icon?: string;
-    info: CollectorPluginModel
+    info: CollectorPluginModel;
 }
 interface CollectorDetailLink {
     name: string;
-    param: CollectorDetailLinkParameter,
-    query: CollectorDetailLinkQuery
+    param: CollectorDetailLinkParameter;
+    query: CollectorDetailLinkQuery;
 }
 interface CollectorDetailLinkParameter {
-    id: string
+    id: string;
 }
 interface CollectorDetailLinkQuery {
-    filters: string[]
+    filters: string[];
 }
 export interface CollectorItemInfo {
-    collectorId: string,
-    name: string,
-    plugin: CollectorPlugin,
-    detailLink: CollectorDetailLink
+    collectorId: string;
+    name: string;
+    plugin: CollectorPlugin;
+    detailLink: CollectorDetailLink;
 }

--- a/apps/web/src/services/asset-inventory/collector/type.ts
+++ b/apps/web/src/services/asset-inventory/collector/type.ts
@@ -145,3 +145,26 @@ export interface ScheduleGetParameter {
 
 export type CollectorListResp = ListType<CollectorModel>;
 export type CollectorScheduleListResp = ListType<CollectorScheduleModel>;
+
+interface CollectorPlugin {
+    name?: string;
+    icon?: string;
+    info: CollectorPluginModel
+}
+interface CollectorDetailLink {
+    name: string;
+    param: CollectorDetailLinkParameter,
+    query: CollectorDetailLinkQuery
+}
+interface CollectorDetailLinkParameter {
+    id: string
+}
+interface CollectorDetailLinkQuery {
+    filters: string[]
+}
+export interface CollectorItemInfo {
+    collectorId: string,
+    name: string,
+    plugin: CollectorPlugin,
+    detailLink: CollectorDetailLink
+}

--- a/apps/web/src/services/asset-inventory/store/collector-page-store.ts
+++ b/apps/web/src/services/asset-inventory/store/collector-page-store.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+import type { Query } from '@cloudforet/core-lib/space-connector/type';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
@@ -10,15 +11,13 @@ import type { CollectorModel } from '@/services/asset-inventory/collector/type';
 export const useCollectorPageStore = defineStore('collector-page', {
     state: () => ({
         loading: true,
-        totalCount: 0,
         pageStart: 1,
         pageLimit: 15,
         sortBy: '',
         selectedProvider: 'all',
         collectors: [] as CollectorModel[],
         searchFilters: [] as ConsoleFilter[],
-        collectorList: undefined as CollectorModel[] | undefined,
-        filteredList: undefined as CollectorModel[] | undefined,
+        listCount: 0,
     }),
     getters: {
         allFilters: (state): ConsoleFilter[] => {
@@ -30,14 +29,14 @@ export const useCollectorPageStore = defineStore('collector-page', {
         },
     },
     actions: {
-        async getCollectorList(queryData) {
+        async getCollectorList(queryData?: Query) {
             this.loading = true;
             try {
                 const res = await SpaceConnector.client.inventory.collector.list({
                     query: queryData,
                 });
-                this.totalCount = res.total_count;
                 this.collectors = res.results;
+                this.listCount = res.total_count;
             } catch (e) {
                 ErrorHandler.handleError(e);
                 throw e;
@@ -47,10 +46,6 @@ export const useCollectorPageStore = defineStore('collector-page', {
         },
         async setSelectedProvider(provider) {
             this.selectedProvider = provider;
-        },
-        async setCollectorList(collectorList) {
-            this.collectorList = collectorList;
-            this.filteredList = collectorList;
         },
         async setFilteredCollectorList(filters) {
             this.searchFilters = filters;

--- a/apps/web/src/services/asset-inventory/store/collector-page-store.ts
+++ b/apps/web/src/services/asset-inventory/store/collector-page-store.ts
@@ -17,7 +17,7 @@ export const useCollectorPageStore = defineStore('collector-page', {
         selectedProvider: 'all',
         collectors: [] as CollectorModel[],
         searchFilters: [] as ConsoleFilter[],
-        listCount: 0,
+        totalCount: 0,
     }),
     getters: {
         allFilters: (state): ConsoleFilter[] => {
@@ -36,7 +36,7 @@ export const useCollectorPageStore = defineStore('collector-page', {
                     query: queryData,
                 });
                 this.collectors = res.results;
-                this.listCount = res.total_count;
+                this.totalCount = res.total_count;
             } catch (e) {
                 ErrorHandler.handleError(e);
                 throw e;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- Resolve loading of `p-data-loader` at collector landing page

**KEYPOINT**
When the page is rendered, we check the 'hasCollectorList' value through the collector list API to determine whether it has been filtered by the provider or not.

1. When there is no collector list data.
commit: b8e38dc
<img width="1543" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/d6aa75d2-5c5e-4457-a827-14f46313e5dc">

---

2. When there is no collector list based on the selected provider + apply contents loader.
commit: 0e3e1985203187b6a9056298ad8238a7c20bebb4
<img width="1550" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/4559c5ac-0108-49b2-aa9b-17769e8d15c8">

### Things to Talk About

🐱: The content and code I submitted in the previous PR are almost similar, but there have been some changes in the positioning and a few additions to apply the page's initial entry and content loader.
Please check changes by commit!