### PR TITLE
feat(collector-landing): apply schedule data at the current status

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/CollectorPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/CollectorPage.vue
@@ -33,6 +33,7 @@
                 <collector-contents
                     :key-item-sets="handlerState.keyItemSets"
                     @change-toolbox="handleChangeToolbox"
+                    @export-excel="handleExportExcel"
                 />
             </div>
             <template #no-data>
@@ -54,6 +55,8 @@ import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 import { store } from '@/store';
 
 import type { ProviderReferenceMap } from '@/store/modules/reference/provider/type';
+
+import { FILE_NAME_PREFIX } from '@/lib/excel-export';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
@@ -109,6 +112,24 @@ const collectorApiQueryHelper = new ApiQueryHelper()
     .setSort(collectorPageState.sortBy, true);
 
 /* Components */
+const handleSelectedProvider = (providerName: string) => {
+    collectorPageStore.setSelectedProvider(providerName);
+    refreshCollectorList();
+};
+const handleChangeToolbox = (options) => {
+    setApiQueryWithToolboxOptions(collectorApiQueryHelper, options);
+    refreshCollectorList();
+};
+const handleExportExcel = async (excelFields) => {
+    await store.dispatch('file/downloadExcel', {
+        url: '/inventory/collector/list',
+        param: { query: collectorApiQueryHelper.data },
+        fields: excelFields,
+        file_name_prefix: FILE_NAME_PREFIX.collector,
+    });
+};
+
+/* API */
 const initCollectorList = async () => {
     state.initLoading = true;
     try {
@@ -129,14 +150,6 @@ const refreshCollectorList = async () => {
     } catch (e) {
         ErrorHandler.handleError(e);
     }
-};
-const handleSelectedProvider = (providerName: string) => {
-    collectorPageStore.setSelectedProvider(providerName);
-    refreshCollectorList();
-};
-const handleChangeToolbox = (options) => {
-    setApiQueryWithToolboxOptions(collectorApiQueryHelper, options);
-    refreshCollectorList();
 };
 
 /* Unmounted */

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
@@ -10,7 +10,7 @@
             :total-count="collectorPageState.totalCount"
             @change="handleChangeToolbox"
             @refresh="handleChangeToolbox"
-            @export="handleExport"
+            @export="handleExportExcel"
         >
             <template #left-area>
                 <p-button
@@ -146,7 +146,7 @@ const state = reactive({
     }),
 });
 
-const emit = defineEmits(['change-toolbox']);
+const emit = defineEmits(['change-toolbox', 'export-excel']);
 
 const searchQueryHelper = new QueryHelper().setKeyItemSets(props.keyItemSets ?? []);
 
@@ -154,7 +154,9 @@ const searchQueryHelper = new QueryHelper().setKeyItemSets(props.keyItemSets ?? 
 const handleCreate = () => {
     SpaceRouter.router.push({ name: ASSET_INVENTORY_ROUTE.COLLECTOR.CREATE._NAME });
 };
-const handleExport = async () => {};
+const handleExportExcel = async () => {
+    emit('export-excel', state.excelFields);
+};
 const handleChangeToolbox = async (options) => {
     if (options.queryTags !== undefined) {
         searchQueryHelper.setFiltersAsQueryTag(options.queryTags);

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
@@ -55,7 +55,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, watch } from 'vue';
+import { computed, reactive } from 'vue';
 
 import {
     PToolbox, PButton, PCard, PDataLoader,
@@ -166,14 +166,14 @@ const handleChangeToolbox = async (options) => {
     emit('change-toolbox', options);
 };
 
+// TODO: will be checked after API is ready
 /* Watcher */
-watch(() => state.items, async (value) => {
-    const ids = value?.map((item) => item.collectorId);
-    if (ids.length > 0) {
-        const promises = ids.map(collectorPageStore.getCollectorSchedule);
-        await Promise.all(promises);
-    }
-});
+// watch(() => state.items, async (value) => {
+//     const ids = value?.map((item) => item.collectorId);
+//     if (ids.length > 0) {
+//         await collectorPageStore.getCollectorSchedule(ids);
+//     }
+// });
 </script>
 
 <style scoped lang="postcss">

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
@@ -55,7 +55,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from 'vue';
+import { computed, reactive, watch } from 'vue';
 
 import {
     PToolbox, PButton, PCard, PDataLoader,
@@ -163,6 +163,15 @@ const handleChangeToolbox = async (options) => {
     }
     emit('change-toolbox', options);
 };
+
+/* Watcher */
+watch(() => state.items, async (value) => {
+    const ids = value?.map((item) => item.collectorId);
+    if (ids.length > 0) {
+        const promises = ids.map(collectorPageStore.getCollectorSchedule);
+        await Promise.all(promises);
+    }
+});
 </script>
 
 <style scoped lang="postcss">

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorContents.vue
@@ -171,7 +171,8 @@ const handleChangeToolbox = async (options) => {
 // watch(() => state.items, async (value) => {
 //     const ids = value?.map((item) => item.collectorId);
 //     if (ids.length > 0) {
-//         await collectorPageStore.getCollectorSchedule(ids);
+//         const promises = ids.map(collectorPageStore.getCollectorSchedule);
+//         await Promise.all(promises);
 //     }
 // });
 </script>

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
@@ -199,13 +199,14 @@ const state = reactive({
         return undefined;
     }),
     diffSchedule: computed(() => {
+        const today = dayjs();
         let dueDate: Dayjs;
 
         if (state.nextSchedule >= 24) {
-            dueDate = dayjs().add(1, 'd');
+            dueDate = today.add(1, 'd');
         }
-        dueDate = dayjs().set('h', state.nextSchedule).set('m', 0);
-        const timeDiff = dueDate.diff(dayjs(), 'm');
+        dueDate = today.set('h', state.nextSchedule).set('m', 0);
+        const timeDiff = dueDate.diff(today, 'm');
         return { diffHour: Math.floor(timeDiff / 60), diffMin: timeDiff % 60 };
     }),
 });

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
@@ -184,7 +184,7 @@ const state = reactive({
     toggleStatus: computed(() => (state.collectorState === COLLECTOR_STATE.ENABLED ? 'ON' : 'OFF')),
     nextSchedule: computed(() => {
         if (state.schedule) {
-            const numbersArray = state.schedule.schedule.hours;
+            const numbersArray = state.schedule.schedule?.hours ?? [];
             const hour = dayjs().hour();
             const hasNextSchedule = numbersArray.find((num) => num > hour);
 

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
@@ -80,13 +80,15 @@
                 </span>
             </div>
             <div class="to-history-detail">
-                <span>{{ $t('INVENTORY.COLLECTOR.MAIN.VIEW_HISTORY_DETAIL') }}</span>
-                <p-i
-                    name="ic_chevron-right"
-                    width="0.75rem"
-                    height="0.75rem"
-                    color="inherit transparent"
-                />
+                <router-link :to="props.item.detailLink">
+                    <span>{{ $t('INVENTORY.COLLECTOR.MAIN.VIEW_HISTORY_DETAIL') }}</span>
+                    <p-i
+                        name="ic_chevron-right"
+                        width="0.75rem"
+                        height="0.75rem"
+                        color="inherit transparent"
+                    />
+                </router-link>
             </div>
         </div>
         <div

--- a/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
+++ b/apps/web/src/services/asset-inventory/collector/modules/CollectorItemInfo.vue
@@ -156,6 +156,8 @@ import { computed, reactive } from 'vue';
 import {
     PButton, PI, PLazyImg, PToggleButton,
 } from '@spaceone/design-system';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 
 import type { CollectorItemInfo } from '@/services/asset-inventory/collector/type';
 import { COLLECTOR_ITEM_INFO_TYPE, COLLECTOR_STATE } from '@/services/asset-inventory/collector/type';
@@ -183,42 +185,28 @@ const state = reactive({
     nextSchedule: computed(() => {
         if (state.schedule) {
             const numbersArray = state.schedule.schedule.hours;
-            const hour = new Date().getHours();
+            const hour = dayjs().hour();
             const hasNextSchedule = numbersArray.find((num) => num > hour);
 
             let closestValue = 0;
-
             if (hasNextSchedule) {
                 closestValue = hasNextSchedule as number;
             } else {
                 closestValue = 24 - Math.min(...numbersArray);
             }
-
             return closestValue;
         }
         return undefined;
     }),
     diffSchedule: computed(() => {
-        const today = new Date();
-        const year = today.getFullYear();
-        const month = today.getMonth() + 1;
-        const day = today.getDate();
-        let formatDate = '';
+        let dueDate: Dayjs;
 
         if (state.nextSchedule >= 24) {
-            formatDate = `${year}-${month}-${day + 1}`;
-        } else {
-            formatDate = `${year}-${month}-${day}`;
+            dueDate = dayjs().add(1, 'd');
         }
-
-        const dueDate = new Date(`${formatDate} ${state.nextSchedule}:00:00`);
-
-        const timeDiff = Math.abs(dueDate.getTime() - today.getTime());
-
-        const diffHour = Math.floor((timeDiff / (1000 * 60 * 60)) % 24);
-        const diffMin = Math.floor((timeDiff / (1000 * 60)) % 60);
-
-        return { diffHour, diffMin };
+        dueDate = dayjs().set('h', state.nextSchedule).set('m', 0);
+        const timeDiff = dueDate.diff(dayjs(), 'm');
+        return { diffHour: Math.floor(timeDiff / 60), diffMin: timeDiff % 60 };
     }),
 });
 

--- a/apps/web/src/services/asset-inventory/store/collector-page-store.ts
+++ b/apps/web/src/services/asset-inventory/store/collector-page-store.ts
@@ -54,7 +54,7 @@ export const useCollectorPageStore = defineStore('collector-page', {
         },
         async getCollectorSchedule(id) {
             try {
-                const res = await SpaceConnector.client.inventory.collector.schedule.list({
+                const res = await SpaceConnector.client.inventory.collector.listSchedules({
                     collector_id: id,
                 });
                 this.schedules.push(...res.results);

--- a/apps/web/src/services/asset-inventory/store/collector-page-store.ts
+++ b/apps/web/src/services/asset-inventory/store/collector-page-store.ts
@@ -54,7 +54,7 @@ export const useCollectorPageStore = defineStore('collector-page', {
         },
         async getCollectorSchedule(id) {
             try {
-                const res = await SpaceConnector.client.inventory.collector.listSchedules({
+                const res = await SpaceConnector.client.inventory.collector.schedule.list({
                     collector_id: id,
                 });
                 this.schedules.push(...res.results);

--- a/apps/web/src/services/asset-inventory/store/collector-page-store.ts
+++ b/apps/web/src/services/asset-inventory/store/collector-page-store.ts
@@ -6,7 +6,7 @@ import type { Query } from '@cloudforet/core-lib/space-connector/type';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
-import type { CollectorModel } from '@/services/asset-inventory/collector/type';
+import type { CollectorModel, CollectorScheduleModel } from '@/services/asset-inventory/collector/type';
 
 export const useCollectorPageStore = defineStore('collector-page', {
     state: () => ({
@@ -18,6 +18,8 @@ export const useCollectorPageStore = defineStore('collector-page', {
         collectors: [] as CollectorModel[],
         searchFilters: [] as ConsoleFilter[],
         totalCount: 0,
+        schedules: [] as CollectorScheduleModel[],
+
     }),
     getters: {
         allFilters: (state): ConsoleFilter[] => {
@@ -49,6 +51,17 @@ export const useCollectorPageStore = defineStore('collector-page', {
         },
         async setFilteredCollectorList(filters) {
             this.searchFilters = filters;
+        },
+        async getCollectorSchedule(id) {
+            try {
+                const res = await SpaceConnector.client.inventory.collector.schedule.list({
+                    collector_id: id,
+                });
+                this.schedules.push(...res.results);
+            } catch (e) {
+                ErrorHandler.handleError(e);
+                throw e;
+            }
         },
     },
 });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- Apply the remaining time of the fastest collector schedule.
`the fastest collector schedule - current time`
<img width="1161" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/f81cc577-13c0-42c7-b89e-401921b842c8">

- Linking each collector to its history detail page.

- Apply the export function to Excel.

### Things to Talk About
