### PR TITLE
fix: do not use 'YY-MM-DD' format string for dayjs argument

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,7 @@
     "cashify": "^2.5.0",
     "color": "^3.1.2",
     "currency.js": "^2.0.4",
-    "dayjs": "^1.10.7",
+    "dayjs": "^1.11.7",
     "diff-match-patch": "^1.0.5",
     "ejs": "^3.1.9",
     "hashids": "^2.2.1",

--- a/apps/web/src/lib/site-initializer/dayjs.ts
+++ b/apps/web/src/lib/site-initializer/dayjs.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -8,16 +9,20 @@ import utc from 'dayjs/plugin/utc';
 export const initDayjs = () => {
     dayjs.extend(utc);
     dayjs.extend(tz);
+    dayjs.extend(duration);
     dayjs.extend(relativeTime, {
         thresholds: [
-            { l: 'd', r: 1, d: 'day' },
+            { l: 's', r: 1 },
+            { l: 'm', r: 1 },
+            { l: 'mm', r: 59, d: 'minute' },
+            { l: 'd', r: 1 },
             { l: 'dd', r: 29, d: 'day' },
-            { l: 'M', r: 1, d: 'month' },
+            { l: 'M', r: 1 },
             { l: 'MM', r: 11, d: 'month' },
-            { l: 'y', d: 'year' },
+            { l: 'y' },
             { l: 'yy', d: 'year' },
         ],
-        rounding: Math.ceil, // Any time before midnight is considered as the previous date.
+        // rounding: Math.ceil, // Any time before midnight is considered as the previous date.
     });
     dayjs.extend(isSameOrBefore);
     dayjs.extend(isSameOrAfter);

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -165,16 +165,17 @@ const dashboardDetailStore = useDashboardDetailInfoStore();
 const state = reactive({
     isFull: computed<boolean>(() => props.size === WIDGET_SIZE.full),
     dateLabel: computed<TranslateResult|undefined>(() => {
-        const start = setBasicDateFormat(props.dateRange?.start);
+        const start = props.dateRange?.start;
         const endDayjs = props.dateRange?.end ? dayjs.utc(props.dateRange.end) : undefined;
         if (start && endDayjs) {
             let endText;
             const isCurrentMonth = endDayjs.isSame(dayjs.utc(), 'month');
             if (isCurrentMonth) endText = dayjs.utc().format('YY-MM-DD');
             else endText = endDayjs.endOf('month').format('YY-MM-DD');
-            return `${start} ~ ${endText}`;
+            const startText = dayjs.utc(start).format('YY-MM-DD');
+            return `${startText} ~ ${endText}`;
         }
-        if (start && !endDayjs) {
+        if (start && endDayjs) {
             const today = dayjs();
             const diff = today.diff(start, 'day', true);
             if (diff < 1) return i18n.t('DASHBOARDS.WIDGET.DATE_TODAY');
@@ -211,7 +212,6 @@ const state = reactive({
     ]),
 });
 
-const setBasicDateFormat = (date) => (date ? dayjs.utc(date).format('YY-MM-DD') : undefined);
 const handleEditButtonClick = () => { state.visibleEditModal = true; };
 const handleDeleteModalConfirm = () => {
     dashboardDetailStore.deleteWidget(props.widgetKey);

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -175,7 +175,7 @@ const state = reactive({
             const startText = dayjs.utc(start).format('YY-MM-DD');
             return `${startText} ~ ${endText}`;
         }
-        if (start && endDayjs) {
+        if (start && !endDayjs) {
             const today = dayjs();
             const diff = today.diff(start, 'day', true);
             if (diff < 1) return i18n.t('DASHBOARDS.WIDGET.DATE_TODAY');

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "cashify": "^2.5.0",
         "color": "^3.1.2",
         "currency.js": "^2.0.4",
-        "dayjs": "^1.10.7",
+        "dayjs": "^1.11.7",
         "diff-match-patch": "^1.0.5",
         "ejs": "^3.1.9",
         "hashids": "^2.2.1",
@@ -13307,9 +13307,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -45339,9 +45339,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -61345,7 +61345,7 @@
         "cashify": "^2.5.0",
         "color": "^3.1.2",
         "currency.js": "^2.0.4",
-        "dayjs": "^1.10.7",
+        "dayjs": "^1.11.7",
         "diff-match-patch": "^1.0.5",
         "dotenv": "^16.0.3",
         "ejs": "^3.1.9",


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

There was a bug in `WidgetFrame` component since `dayjs` can not parse the string whose format is 'YY-MM-DD'.


### Things to Talk About
