### PR TITLE
fix: plugin and collector is different

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue
@@ -62,6 +62,7 @@ import { BACKGROUND_COLOR } from '@/styles/colorsets';
 import Step1SearchFilter from '@/services/asset-inventory/collector/create-collector/modules/Step1SearchFilter.vue';
 import CollectPluginContents
     from '@/services/asset-inventory/collector/modules/CollectorPluginContents.vue';
+import type { CollectorPluginModel } from '@/services/asset-inventory/collector/type';
 import { useCollectorFormStore } from '@/services/asset-inventory/store/collector-form-store';
 
 const emit = defineEmits([
@@ -73,7 +74,7 @@ const collectorFormStore = useCollectorFormStore();
 
 const state = reactive({
     searchValue: '',
-    pluginList: [] as any[],
+    pluginList: [] as CollectorPluginModel[],
     loading: false,
 });
 
@@ -114,9 +115,9 @@ const getPlugins = async () => {
 const handleSearch = (value) => {
     console.log('value', value);
 };
-const handleClickNextStep = (item) => {
+const handleClickNextStep = (item: CollectorPluginModel) => {
     emit('update:currentStep', 2);
-    collectorFormStore.setOriginCollector(item);
+    collectorFormStore.setPluginInfo(item);
 };
 
 (() => {

--- a/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep2.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep2.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="collector-page-2">
-        <collect-plugin-contents :plugin="collectorFormState.originCollector" />
+        <collect-plugin-contents :plugin="collectorFormState.pluginInfo" />
         <div class="input-form">
             <p-field-group :label="$t('PLUGIN.COLLECTOR.CREATE.NAME_LABEL')"
                            :invalid-text="invalidTexts.name"

--- a/apps/web/src/services/asset-inventory/store/collector-form-store.ts
+++ b/apps/web/src/services/asset-inventory/store/collector-form-store.ts
@@ -1,9 +1,12 @@
 import { defineStore } from 'pinia';
 
+import type { CollectorModel, CollectorPluginModel } from '@/services/asset-inventory/collector/type';
+
 type AttachedServiceAccount = string[]|null; // TODO: need to check type
 
 interface CollectorFormState {
-    originCollector: any; // TODO: CollectorPlugin Model
+    originCollector: CollectorModel|null;
+    pluginInfo: CollectorPluginModel|null;
     attachedServiceAccount: AttachedServiceAccount;
 }
 
@@ -13,11 +16,15 @@ type CollectorFormAction = any;
 export const useCollectorFormStore = defineStore<string, CollectorFormState, CollectorFormGetter, CollectorFormAction>('collector-form', {
     state: () => ({
         originCollector: null,
+        pluginInfo: null,
         attachedServiceAccount: null,
     }),
     actions: {
-        setOriginCollector(collector: any) {
+        setOriginCollector(collector: CollectorModel) {
             this.originCollector = collector;
+        },
+        setPluginInfo(pluginInfo: CollectorPluginModel) {
+            this.pluginInfo = pluginInfo;
         },
         setAttachedServiceAccount(serviceAccount: AttachedServiceAccount) {
             if (!serviceAccount?.length) this.attachedServiceAccount = null;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

There was wrong concept between collector and plugin in CreateCollectorStep1, 2 and collector-form-store.
plugin is not the collector. collector includes plugin. 
`collector.plugin_info === plugin`

So I changed several things.

- add `pluginInfo` state to the form store.
- change to set pluginInfo, not originCollector in create step 1.
- change to pass plugin as `CollectorPluginContents` component's `plugin` prop, not the collector in create step 2.


### Things to Talk About

I guess, we all missed this since there wasn't any type declaration of `CollectorModel` or `CollectorPluginModel` in previous PRs.
Let's use typescript more tightly!! :)