### PR TITLE
feat(mirinae): add uniformWidth prop to JsonSchemaForm and update DashboardWidgetInputForm

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -27,12 +27,13 @@
                                 :custom-error-map="inheritOptionsErrorMap"
                                 :validation-mode="widgetKey ? 'all' : 'input'"
                                 use-fixed-menu-style
+                                uniform-width
                                 :reference-handler="referenceHandler"
                                 class="widget-options-form"
                                 @validate="handleFormValidate"
             >
                 <template #label-extra="{ propertyName }">
-                    <div class="inherit-toggle-button">
+                    <div class="inherit-toggle-button-wrapper">
                         <span class="text"
                               :class="{inherit: inheritableProperties.includes(propertyName)}"
                         >{{ $t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.INHERIT') }}</span>
@@ -52,8 +53,10 @@
                     />
                 </template>
                 <template #dropdown-extra="{ propertyName, selectedItem }">
-                    <div v-if="isSelected(selectedItem) && inheritableProperties.includes(propertyName)">
-                        <span>{{ selectedItem.label }}</span>
+                    <div v-if="isSelected(selectedItem) && inheritableProperties.includes(propertyName)"
+                         class="dropdown-inner"
+                    >
+                        <span class="item-label">{{ selectedItem.label }}</span>
                         <span class="suffix-text">{{ $t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.FROM_DASHBOARD') }}</span>
                     </div>
                 </template>
@@ -451,27 +454,54 @@ export default defineComponent<Props>({
         }
     }
 
-    /* custom design-system component - p-field-group */
+    .widget-options-form {
+        width: 100%;
+    }
+
+    /* custom design-system component - p-json-schema-form */
     :deep(.widget-options-form) {
-        .field-title-box {
-            pointer-events: none;
+        /* custom design-system component - p-field-group */
+        .p-field-group {
+            .form-label {
+                width: 100%;
+                > .title {
+                    display: flex;
+                    width: 100%;
+                    justify-content: space-between;
+                    align-items: center;
+                }
+            }
+
+            /* HACK: remove this when p-select-dropdown is fixed */
+            .input-wrapper {
+                width: calc(100% - 2.5rem);
+            }
         }
-        .form-label {
-            display: -webkit-box;
-            width: 100%;
-            justify-content: space-between;
-            align-content: center;
-        }
-        .input-form {
-            width: 100%;
+
+        /*
+        custom design-system component - p-select-dropdown
+        HACK: remove this when p-select-dropdown is fixed
+         */
+        .p-select-dropdown .dropdown-button {
+            > .text {
+                @apply truncate;
+                max-width: calc(100% - 1.5rem);
+            }
         }
     }
-    .suffix-text {
-        @apply text-gray-500;
-        padding-left: 0.25rem;
+    .dropdown-inner {
+        display: flex;
+        .item-label {
+            @apply truncate;
+            flex-shrink: 0;
+        }
+        .suffix-text {
+            @apply truncate text-gray-500;
+            padding-left: 0.25rem;
+        }
     }
-    .inherit-toggle-button {
-        @apply flex bg-gray-100 rounded;
+    .inherit-toggle-button-wrapper {
+        @apply inline-flex bg-gray-100 rounded;
         line-height: 1.25;
         padding: 0.25rem 0.5rem;
         pointer-events: initial;

--- a/packages/mirinae/src/inputs/buttons/toggle-button/PToggleButton.vue
+++ b/packages/mirinae/src/inputs/buttons/toggle-button/PToggleButton.vue
@@ -48,7 +48,7 @@ const handleChangeToggle = () => {
 
 <style lang="postcss">
 .p-toggle-button {
-    @apply inline-block flex items-center cursor-pointer;
+    @apply inline-flex items-center cursor-pointer;
     .slider {
         @apply relative bg-gray-300 cursor-pointer appearance-none;
         width: 2rem;

--- a/packages/mirinae/src/inputs/forms/json-schema-form/PJsonSchemaForm.stories.mdx
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/PJsonSchemaForm.stories.mdx
@@ -43,6 +43,8 @@ export const Template = (args, { argTypes }) => ({
             :reset-on-schema-change="resetOnSchemaChange"
             :custom-error-map="customErrorMap"
             :reference-handler="simpleHandler"
+            :use-fixed-menu-style="useFixedMenuStyle"
+            :uniform-width="uniformWidth"
         />
     `,
     setup(props) {
@@ -375,6 +377,44 @@ It internally uses [Ajv JSON schema validator](https://ajv.js.org/) and [ajv-for
 <br/>
 <br/>
 
+
+## Uniform Width
+
+<Canvas>
+    <Story name="Uniform Width" >
+        {{
+            components: { PJsonSchemaForm, PTextEditor, PHeading },
+            i18n: I18nConnector.i18n,
+            template: `
+<div class="grid gap-4 grid-cols-12">
+    <div class="col-span-6 bg-blue-100 p-4">
+        <p-heading>Json Schema Form</p-heading>
+        <p-json-schema-form :schema="schema"
+                            :form-data.sync="formData"
+                            :language="$i18n.locale"
+                            :reference-handler="handler"
+                            uniform-width
+                            style="width: 100%"
+        />
+    </div>
+</div>
+`,
+            setup(props) {
+                const state = reactive({
+                    schema: getDefaultSchema(),
+                    formData: {},
+                    handler: getReferenceHandler()
+                })
+                return {
+                    ...toRefs(state),
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
 
 ## Playground
 

--- a/packages/mirinae/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
@@ -1,5 +1,6 @@
 <template>
     <form class="p-json-schema-form"
+          :class="{'uniform-width': uniformWidth}"
           @submit.prevent
     >
         <p-field-group v-if="isJsonInputMode"
@@ -60,6 +61,7 @@
                                                 :value="rawFormData[schemaProperty.propertyName]"
                                                 :disabled="schemaProperty.disabled"
                                                 :invalid="invalid"
+                                                :full-width="uniformWidth"
                                                 class="input-form"
                                                 @update:value="handleUpdateFormValue(schemaProperty, propertyIdx, ...arguments)"
                             />
@@ -76,6 +78,7 @@
                                                :items="schemaProperty.menuItems"
                                                :disabled="schemaProperty.disabled"
                                                :use-fixed-menu-style="useFixedMenuStyle"
+                                               :button-text-ellipsis="uniformWidth"
                                                class="input-form"
                                                @update:selected="handleUpdateFormValue(schemaProperty, propertyIdx, ...arguments)"
                             >
@@ -236,6 +239,10 @@ export default defineComponent<JsonSchemaFormProps>({
             default: undefined,
         },
         useFixedMenuStyle: {
+            type: Boolean,
+            default: false,
+        },
+        uniformWidth: {
             type: Boolean,
             default: false,
         },
@@ -407,7 +414,7 @@ export default defineComponent<JsonSchemaFormProps>({
     }
     .field-group-default-wrapper {
         display: flex;
-        .input-wrapper {
+        > .input-wrapper {
             flex-grow: 1;
         }
     }
@@ -416,6 +423,11 @@ export default defineComponent<JsonSchemaFormProps>({
         margin-bottom: 0.25rem;
         &:last-of-type {
             margin-bottom: 0;
+        }
+    }
+    &.uniform-width {
+        .field-group-default-wrapper > .input-wrapper > .input-form {
+            width: 100%;
         }
     }
 }

--- a/packages/mirinae/src/inputs/forms/json-schema-form/components/GenerateIdFormat.vue
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/components/GenerateIdFormat.vue
@@ -9,6 +9,7 @@
         </p-button>
         <p-text-input :value="value"
                       :invalid="invalid"
+                      :style="{ width: fullWidth ? '100%' : undefined }"
                       @update:value="handleUpdateValue"
         >
             <template #right-edge>
@@ -52,6 +53,10 @@ export default defineComponent<Props>({
             default: false,
         },
         invalid: {
+            type: Boolean,
+            default: false,
+        },
+        fullWidth: {
             type: Boolean,
             default: false,
         },

--- a/packages/mirinae/src/inputs/forms/json-schema-form/mock.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/mock.ts
@@ -53,12 +53,13 @@ export const getDefaultSchema = () => ({
             title: 'Provider',
             minLength: 1,
             type: 'string',
-            default: 'aws',
-            enum: ['aws', 'google_cloud', 'azure'],
+            default: 'long',
+            enum: ['aws', 'google_cloud', 'azure', 'long'],
             menuItems: [
                 { name: 'aws', label: 'AWS' },
                 { name: 'google_cloud', label: 'Google Cloud' },
                 { name: 'azure', label: 'Azure' },
+                { name: 'long', label: 'this is very long long long long long long long long long long provider name' },
             ],
         },
         age: {

--- a/packages/mirinae/src/inputs/forms/json-schema-form/story-helper.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/story-helper.ts
@@ -149,6 +149,24 @@ export const getJsonSchemaFormArgTypes = (): ArgTypes => ({
             type: 'boolean',
         },
     },
+    uniformWidth: {
+        name: 'uniformWidth',
+        type: { name: 'boolean' },
+        description: 'It ensures that all input forms have the same width, creating a consistent and visually appealing layout.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'false',
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
     // slots
     labelExtraSlot: {
         name: 'label-extra',


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

- Added `uniformWidth` prop to `JsonSchemaForm` to reduce codes that makes all the input form's width the same.

![image](https://github.com/cloudforet-io/console/assets/26986739/c2ef13b4-e1d4-4207-83f9-4d68ea7d487e)
![image](https://github.com/cloudforet-io/console/assets/26986739/2e7d1c20-0c59-4a1a-9a44-2de34306af66)


- Updated `DashboardWidgetInputForm` to use `uniformWidth` of `JsonSchemaForm`

![image](https://github.com/cloudforet-io/console/assets/26986739/eef80b61-b358-4e56-a9e0-4ebc67a09cff)

- Also, fixed a style bug in `DashboardWidgetInputForm` that is related to `PToggleButton` component.

- Also, changed from 'flex' to 'inline-flex' in 'PToggleButton' and remove double declaration for display css property.
  - Toggle buttons are often used right next to other elements. Therefore, it is much more advantageous in terms of usability to make `inline-flex` rather than `flex`.

### Things to Talk About

There are some bugs in `PSelectDropdown` component.
In this PR, additional css are added to  `DashboardWidgetInputForm` in order to temporarily fix those bugs.
