### PR TITLE
refactor: update store's plugin reference item spec, update collector and plugin types

### DIFF
--- a/apps/web/src/common/modules/monitoring/Monitoring.vue
+++ b/apps/web/src/common/modules/monitoring/Monitoring.vue
@@ -128,12 +128,13 @@ import { referenceRouter } from '@/lib/reference/referenceRouter';
 
 import MetricChart from '@/common/components/charts/metric-chart/MetricChart.vue';
 import ErrorHandler from '@/common/composables/error/errorHandler';
+import type { StatisticsType } from '@/common/modules/monitoring/config';
 import {
     COLORS, MONITORING_TYPE, STATISTICS_TYPE, TIME_RANGE,
 } from '@/common/modules/monitoring/config';
 import type {
     AvailableResource,
-    Metric, MetricChartData, StatisticsType, StatItem,
+    Metric, MetricChartData, StatItem,
 } from '@/common/modules/monitoring/type';
 
 interface DataToolType {

--- a/apps/web/src/common/modules/monitoring/config.ts
+++ b/apps/web/src/common/modules/monitoring/config.ts
@@ -2,16 +2,18 @@ import {
     blue, coral, green, indigo, peacock, violet, yellow,
 } from '@/styles/colors';
 
-export const MONITORING_TYPE = Object.freeze({
+export const MONITORING_TYPE = {
     METRIC: 'METRIC',
     LOG: 'LOG',
-});
+} as const;
+export type MonitoringType = typeof MONITORING_TYPE[keyof typeof MONITORING_TYPE];
 
-export const STATISTICS_TYPE = Object.freeze({
+export const STATISTICS_TYPE = {
     AVERAGE: 'AVERAGE',
     MAXIMUM: 'MAXIMUM',
     MINIMUM: 'MINIMUM',
-});
+} as const;
+export type StatisticsType = typeof STATISTICS_TYPE[keyof typeof STATISTICS_TYPE];
 
 export const COLORS = [
     coral[500], blue[500], violet[500], yellow[500], green[400], coral[400], peacock[500], coral[600],

--- a/apps/web/src/common/modules/monitoring/type.ts
+++ b/apps/web/src/common/modules/monitoring/type.ts
@@ -1,6 +1,3 @@
-/* eslint-disable camelcase */
-import type { STATISTICS_TYPE } from '@/common/modules/monitoring/config';
-
 export interface Metric {
     key: string;
     name: string;
@@ -25,7 +22,6 @@ export interface MonitoringProps {
     responsive?: boolean;
 }
 
-export type StatisticsType = typeof STATISTICS_TYPE[keyof typeof STATISTICS_TYPE];
 
 export interface MetricChartData {
     loading: boolean;

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
@@ -75,16 +75,15 @@ const getCollector = async (): Promise<CollectorModel> => {
                 provider: 'aws',
                 capability: {
                     supported_providers: ['aws'],
-                    supported_schema: ['aws_access_key', 'aws_access_key_pair'],
-                    supported_mode: ['FULL', 'DIFF'],
-                    supported_schedule: ['* * * * *'],
+                    supported_schemas: ['aws_access_key', 'aws_access_key_pair'],
+                    monitoring_type: 'METRIC',
+                    use_resource_secret: true,
                 },
                 schedule: {
-                    hours: ['3'],
+                    hours: [3],
                 },
                 plugin_info: {
                     plugin_id: 'plugin-aws-phd-inven-collector',
-                    name: 'AWS Service Health Dashboard Collector Plugin',
                     version: '1.4.3',
                     upgrade_mode: 'AUTO',
                     options: {

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
@@ -86,13 +86,11 @@ const getCollector = async (): Promise<CollectorModel> => {
                     plugin_id: 'plugin-aws-phd-inven-collector',
                     version: '1.4.3',
                     upgrade_mode: 'AUTO',
+                    metadata: {},
+                    secret_filter: {},
                     options: {
                         supported_resource_type: ['inventory.Server'],
                         filter_format: [],
-                    },
-                    tags: {
-                        description: 'AWS Personal Health Dashboard collector',
-                        icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/aws/AWS-Personal-Health-Dashboard.svg',
                     },
                 },
                 tags: {

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
@@ -111,7 +111,7 @@ const fields = computed<DefinitionField[]>(() => [
 ]);
 
 const state = reactive({
-    plugin: computed<CollectorPluginModel|null>(() => collectorFormState.pluginInfo),
+    plugin: computed<CollectorPluginModel|null>(() => collectorFormState.originCollector?.plugin_info ?? null),
     pluginName: computed<string>(() => state.plugin?.name ?? ''),
     pluginIcon: computed<string>(() => state.plugin?.tags.icon ?? ''),
     isEditMode: false,

--- a/apps/web/src/services/asset-inventory/collector/collector-history/collect-job/modules/JobBasicInformation.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-history/collect-job/modules/JobBasicInformation.vue
@@ -108,7 +108,7 @@ export default {
                 const id = state.job.collector_info?.plugin_info?.plugin_id || '';
                 return {
                     id,
-                    label: state.plugins[id]?.name || id,
+                    label: state.plugins[id]?.label || id,
                     icon: state.plugins[id]?.icon,
                 };
             }),

--- a/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep1.vue
@@ -68,7 +68,7 @@ import Step1SearchFilter from '@/services/asset-inventory/collector/create-colle
 import { useCollectorFormStore } from '@/services/asset-inventory/collector/shared/collector-forms/collector-form-store';
 import CollectPluginContents
     from '@/services/asset-inventory/collector/shared/CollectorPluginContents.vue';
-import type { CollectorPluginModel } from '@/services/asset-inventory/collector/type';
+import type { RepositoryPluginModel } from '@/services/asset-inventory/collector/type';
 
 const emit = defineEmits([
     'update:currentStep',
@@ -82,7 +82,7 @@ const collectorPageState = collectorPageStore.$state;
 
 const state = reactive({
     searchValue: '',
-    pluginList: [] as CollectorPluginModel[],
+    pluginList: [] as RepositoryPluginModel[],
     loading: false,
     selectedRepository: '',
     currentPage: 1,
@@ -92,7 +92,7 @@ const pluginCardListRef = ref<HTMLElement | null>(null);
 
 
 const pluginApiQuery = new ApiQueryHelper();
-const getPlugins = async (): Promise<CollectorPluginModel[]> => {
+const getPlugins = async (): Promise<RepositoryPluginModel[]> => {
     state.loading = true;
     try {
         pluginApiQuery.setPage(getPageStart(state.currentPage, 10), 10).setSort('name', false)
@@ -134,9 +134,9 @@ const handleSearch = async (value) => {
     state.searchValue = value;
     state.pluginList = await getPlugins();
 };
-const handleClickNextStep = (item: CollectorPluginModel) => {
+const handleClickNextStep = (item: RepositoryPluginModel) => {
     emit('update:currentStep', 2);
-    collectorFormStore.setPluginInfo(item);
+    collectorFormStore.setRepositoryPlugin(item);
 };
 const handleChangeRepository = (value:string) => {
     state.selectedRepository = value;

--- a/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep2.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep2.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="collector-page-2">
-        <collect-plugin-contents :plugin="collectorFormState.pluginInfo" />
+        <collect-plugin-contents :plugin="collectorFormState.repositoryPlugin" />
         <div class="input-form">
             <p-field-group :label="$t('INVENTORY.COLLECTOR.CREATE.NAME')"
                            :invalid-text="invalidTexts.name"
@@ -92,7 +92,7 @@ const state = reactive({
     isVersionValid: false,
     deleteModalVisible: false,
     isAllFormValid: computed(() => isAllValid.value && state.isVersionValid && state.isTagsValid),
-    pluginName: computed(() => collectorFormState.pluginInfo?.name),
+    pluginName: computed(() => collectorFormState.repositoryPlugin?.name),
 });
 
 const {

--- a/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep3.vue
+++ b/apps/web/src/services/asset-inventory/collector/create-collector/modules/CreateCollectorStep3.vue
@@ -60,7 +60,7 @@ const collectorFormState = collectorFormStore.$state;
 
 const state = reactive({
     loading: true,
-    pluginId: computed<string|undefined>(() => collectorFormState.pluginInfo?.plugin_id),
+    pluginId: computed<string|undefined>(() => collectorFormState.repositoryPlugin?.plugin_id),
     deleteModalVisible: false,
     isAttachedServiceAccountValid: false,
 });

--- a/apps/web/src/services/asset-inventory/collector/shared/CollectorPluginContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/CollectorPluginContents.vue
@@ -41,23 +41,37 @@ import {
     PAnchor, PLazyImg, PLabel,
 } from '@spaceone/design-system';
 
-import type { CollectorPluginModel } from '@/services/asset-inventory/collector/type';
+import { store } from '@/store';
+
+import type { PluginReferenceItem, PluginReferenceMap } from '@/store/modules/reference/plugin/type';
+
+import type { CollectorPluginModel, RepositoryPluginModel } from '@/services/asset-inventory/collector/type';
 
 // TODO: Add plugin data type
 interface Props {
-    plugin?: CollectorPluginModel|null;
+    plugin?: CollectorPluginModel|RepositoryPluginModel|null;
 }
 
 const props = defineProps<Props>();
 
 const state = reactive({
-    icon: computed(() => props.plugin?.tags.icon ?? ''),
-    name: computed(() => props.plugin?.name ?? ''),
-    description: computed(() => props.plugin?.tags.description ?? ''),
-    labels: computed<string[]>(() => props.plugin?.labels ?? []),
-    isBeta: computed(() => !!props.plugin?.tags.beta ?? false),
-    pluginDetailLink: computed<CollectorPluginModel['tags']['link']>(() => props.plugin?.tags?.link ?? ''),
+    icon: computed<string>(() => state.pluginItem?.tags.icon ?? ''),
+    name: computed<string>(() => state.pluginItem?.name ?? state.pluginItem?.key ?? ''),
+    description: computed<string>(() => state.pluginItem?.description ?? ''),
+    labels: computed<string[]>(() => (props.plugin as RepositoryPluginModel)?.labels ?? []), // it is empty with collector plugin
+    isBeta: computed<boolean>(() => !!(props.plugin as RepositoryPluginModel)?.tags?.beta ?? false), // it is empty with collector plugin
+    pluginDetailLink: computed<string>(() => state.pluginItem?.link ?? ''),
+    plugins: computed<PluginReferenceMap>(() => store.getters['reference/pluginItems']),
+    pluginItem: computed<PluginReferenceItem|undefined>(() => {
+        if (!props.plugin) return undefined;
+        return state.plugins[props.plugin.plugin_id];
+    }),
 });
+
+// init reference data
+(async () => {
+    await store.dispatch('reference/plugin/load');
+})();
 
 
 </script>

--- a/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorVersionForm.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorVersionForm.vue
@@ -41,7 +41,6 @@ import { useFormValidator } from '@/common/composables/form-validator';
 import { useCollectorFormStore } from '@/services/asset-inventory/collector/shared/collector-forms/collector-form-store';
 
 const collectorFormStore = useCollectorFormStore();
-const collectorFormState = collectorFormStore.$state;
 
 const emit = defineEmits<{(event: 'update:isVersionValid', value: boolean): void;
 }>();
@@ -66,7 +65,7 @@ const {
 });
 
 const state = reactive({
-    pluginId: computed<string|undefined>(() => collectorFormState.pluginInfo?.plugin_id),
+    pluginId: computed<string|undefined>(() => collectorFormStore.pluginId),
     isAutoUpgrade: false,
     versions: [] as any[], // FIXME: type
 });

--- a/apps/web/src/services/asset-inventory/collector/type.ts
+++ b/apps/web/src/services/asset-inventory/collector/type.ts
@@ -1,5 +1,8 @@
-/* eslint-disable camelcase */
+import type { JsonSchema } from '@spaceone/design-system/types/inputs/forms/json-schema-form/type';
+
 import type { ListType, Tags, TimeStamp } from '@/models';
+
+import type { MonitoringType } from '@/common/modules/monitoring/config';
 
 export enum COLLECT_MODE {
     all = 'ALL',
@@ -52,23 +55,45 @@ export interface PluginOptions {
 
 export interface CollectorPluginModel {
     plugin_id: string;
-    name: string;
     version: string;
     options: PluginOptions;
-    secret_id?: string;
-    secret_group_id?: string;
-    provider?: string;
+    metadata: object;
     upgrade_mode: UpgradeMode;
-    labels?: string[];
+    secret_filter: object;
+}
+
+export interface RepositoryPluginModel {
+    plugin_id: string;
+    name: string;
+    state: CollectorState;
+    image: string;
+    registry_type: 'DOCKER_HUB'|'AWS_PUBLIC_ECR'|'HARBOR';
+    registry_url: string;
+    registry_config: object;
+    service_type: string;
+    provider?: string;
+    capability: Capability;
+    template: {
+        options: {
+            schema: JsonSchema;
+        }
+    };
+    repository_info: object;
+    project_id: string;
+    labels: string[];
+    version: string;
     tags: {
         icon?: string;
         description?: string;
         link?: string;
         beta?: string;
-    } & Record<string, any>;
+    } & Tags;
 }
 
 interface Capability {
+    supported_schemas: string[];
+    use_resource_secret: boolean;
+    monitoring_type: MonitoringType;
     supported_providers?: string[];
     [key: string]: any;
 }
@@ -86,11 +111,12 @@ export interface CollectorModel {
     tags: Tags;
 }
 
-export interface CollectorUpdateParameter extends Tags {
+export interface CollectorUpdateParameter {
     collector_id: string;
     name?: string;
     plugin_info?: CollectorPluginModel;
     priority?: number;
+    tags: Tags;
 }
 
 export interface CollectorCollectParameter {
@@ -102,19 +128,22 @@ export interface CollectorCollectParameter {
     secret_group_id?: string;
 }
 
-export interface CollectorCreateParameter extends Tags {
+export interface CollectorCreateParameter {
     name: string;
+    tags: Tags;
 }
 
 export interface Schedule {
-    hours?: string[];
+    cron?: string;
+    interval?: number;
+    minutes?: number[];
+    hours?: number[];
 }
 
 export interface ScheduleAddParameter {
     collector_id: string;
     name?: string;
     schedule: Schedule;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     filter?: any;
     collect_mode?: COLLECT_MODE;
 }
@@ -122,12 +151,10 @@ export interface ScheduleAddParameter {
 export interface CollectorScheduleModel {
     schedule_id: string;
     name: string;
-    state: CollectorState;
-    collector_info: CollectorModel;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    filter: any;
-    collect_mode: COLLECT_MODE;
+    collector_id: string;
     schedule: Schedule;
+    filters: object;
+    collect_mode: COLLECT_MODE;
     created_at: TimeStamp;
     last_schedule_at: TimeStamp;
 }

--- a/apps/web/src/services/project/project-detail/project-alert/project-webhook/modules/WebhookAddFormModal.vue
+++ b/apps/web/src/services/project/project-detail/project-alert/project-webhook/modules/WebhookAddFormModal.vue
@@ -59,10 +59,7 @@ import {
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 
-import { store } from '@/store';
 import { i18n } from '@/translations';
-
-import type { PluginReferenceMap } from '@/store/modules/reference/plugin/type';
 
 import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 
@@ -96,7 +93,6 @@ export default {
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
-            plugins: computed<PluginReferenceMap>(() => store.getters['reference/pluginItems']),
             proxyVisible: useProxyValue('visible', props, emit),
             loading: false,
             webhookName: '',
@@ -190,10 +186,6 @@ export default {
             getListWebhookType();
         }, { immediate: true });
 
-        // LOAD REFERENCE STORE
-        (async () => {
-            await store.dispatch('reference/plugin/load');
-        })();
 
         return {
             ...toRefs(state),

--- a/apps/web/src/store/modules/reference/plugin/actions.ts
+++ b/apps/web/src/store/modules/reference/plugin/actions.ts
@@ -10,6 +10,8 @@ import { assetUrlConverter } from '@/lib/helper/asset-helper';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
+import type { RepositoryPluginModel } from '@/services/asset-inventory/collector/type';
+
 let lastLoadedTime = 0;
 
 export const load: Action<PluginReferenceState, any> = async ({ state, commit }, options: ReferenceLoadOptions): Promise<void|Error> => {
@@ -38,12 +40,14 @@ export const load: Action<PluginReferenceState, any> = async ({ state, commit },
                 repository_id: repoInfo.repository_id,
             }, { timeout: 3000 });
 
-            pluginResponse.results.forEach((pluginInfo: any): void => {
+            pluginResponse.results.forEach((pluginInfo: RepositoryPluginModel): void => {
                 plugins[pluginInfo.plugin_id] = {
                     key: pluginInfo.plugin_id,
-                    label: pluginInfo.tags.description || pluginInfo.name,
+                    label: pluginInfo.name,
                     name: pluginInfo.name,
-                    icon: assetUrlConverter(pluginInfo.tags.icon),
+                    icon: pluginInfo.tags.icon ? assetUrlConverter(pluginInfo.tags.icon) : '',
+                    description: pluginInfo.tags.description ?? '',
+                    link: pluginInfo.tags.link ?? '',
                 };
             });
         });

--- a/apps/web/src/store/modules/reference/plugin/type.ts
+++ b/apps/web/src/store/modules/reference/plugin/type.ts
@@ -1,6 +1,6 @@
 import type { ReferenceItem, ReferenceMap } from '@/store/modules/reference/type';
 
-export type PluginReferenceItem = Required<Pick<ReferenceItem<undefined>, 'key'|'label'|'name'|'icon'>>;
+export type PluginReferenceItem = Required<Pick<ReferenceItem<undefined>, 'key'|'label'|'name'|'icon'|'description'|'link'>>;
 
 export type PluginReferenceMap = ReferenceMap<PluginReferenceItem>;
 

--- a/apps/web/src/store/modules/reference/type.ts
+++ b/apps/web/src/store/modules/reference/type.ts
@@ -14,6 +14,8 @@ export interface ReferenceItem<Data = Record<string, any>> {
     latitude?: string;
     longitude?: string;
     data?: Data;
+    description?: string;
+    link?: string;
 }
 
 export type ReferenceMap<Item extends ReferenceItem = ReferenceItem> = Record<string, Item>;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

- Updated reference store > plugin item spec.
```javascript
// As Is
{
 key: pluginInfo.plugin_id,
 label: pluginInfo.tags.description || pluginInfo.name,
 name: pluginInfo.name,
 icon: assetUrlConverter(pluginInfo.tags.icon),
}

// To Be
{
 key: pluginInfo.plugin_id,
 label: pluginInfo.name,
 name: pluginInfo.name,
 icon: assetUrlConverter(pluginInfo.tags.icon),
 link: pluginInfo.tags.link,
 description: pluginInfo.tags.description,
}
```
- Separate `PluginModel` interface into `CollectorPluginModel` and `RepositoryPluginModel`. Refer to backend api spec.
  - [repository plugin model](https://github.com/cloudforet-io/repository/blob/master/src/spaceone/repository/model/plugin_model.py)
  - [inventory collector plugin model](https://github.com/cloudforet-io/inventory/blob/master/src/spaceone/inventory/model/collector_model.py)

### Things to Talk About
