### PR TITLE
feat: add useGoBack composable

### DIFF
--- a/apps/web/src/common/composables/go-back/index.ts
+++ b/apps/web/src/common/composables/go-back/index.ts
@@ -1,0 +1,22 @@
+import type { RawLocation } from 'vue-router';
+
+import { SpaceRouter } from '@/router';
+
+export const useGoBack = (mainRoute: RawLocation) => { // RawLocation
+    let pathFrom;
+    const setPathFrom = (path: any) => {
+        pathFrom = path;
+    };
+
+    const handleClickBackButton = () => {
+        if (pathFrom?.name) SpaceRouter.router.replace(pathFrom);
+        else {
+            SpaceRouter.router.replace(mainRoute);
+        }
+    };
+
+    return {
+        setPathFrom,
+        handleClickBackButton,
+    };
+};

--- a/apps/web/src/common/composables/go-back/index.ts
+++ b/apps/web/src/common/composables/go-back/index.ts
@@ -1,17 +1,20 @@
-import type { RawLocation } from 'vue-router';
+import type { Location } from 'vue-router';
 
 import { SpaceRouter } from '@/router';
 
-export const useGoBack = (mainRoute: RawLocation) => { // RawLocation
+export const useGoBack = (mainRoute: Location) => {
     let pathFrom;
-    const setPathFrom = (path: any) => {
+    const setPathFrom = (path: Location) => {
         pathFrom = path;
     };
 
     const handleClickBackButton = () => {
-        if (pathFrom?.name) SpaceRouter.router.replace(pathFrom);
-        else {
-            SpaceRouter.router.replace(mainRoute);
+        if (!pathFrom?.name) { // in case of direct access from the other site, go to the main page
+            SpaceRouter.router.push(mainRoute);
+        } else if (pathFrom.name === mainRoute.name) { // in case of access from the service main page in the same site, go to the previous page
+            SpaceRouter.router.push(pathFrom);
+        } else { // in case of access from the other page in the same site, go to the main page
+            SpaceRouter.router.push(mainRoute);
         }
     };
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

There are two cases that users can come to pages:
1. They came from the other site.
2. They came from the other page in the app.

The browser back always go back to the previous url in all cases.
**But the back button inside the application must works differently for each case:**
1. Must go to the main page of the service.
2. Must go to the previous page.

To fulfill those requirements, this PR adds the useGoBack composable.


### Things to Talk About
