### PR TITLE
feat(core-lib): add makeApiError function to make mock api error

### DIFF
--- a/packages/core-lib/src/space-connector/error.ts
+++ b/packages/core-lib/src/space-connector/error.ts
@@ -80,3 +80,15 @@ export const isInstanceOfBadRequestError = (e: unknown): e is BadRequestError =>
 export const isInstanceOfAuthenticationError = (e: unknown): e is AuthenticationError => e instanceof AuthenticationError;
 
 export const isInstanceOfAuthorizationError = (e: unknown): e is AuthorizationError => e instanceof AuthorizationError;
+
+export const makeAPIError = (message: string, status = 500, code = 'ERROR_UNKNOWN'): APIError => new APIError({
+    response: {
+        status,
+        data: {
+            error: {
+                message,
+                code,
+            },
+        },
+    },
+} as AxiosError);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [x] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

This PR adds `makeApiError` function.
It helps when we use `ErrorHandler.handleRequestError()` and there is no api binding.
(If the error is not an instance of `ApiError`, it doesn't work. So the error toast does not pop up.)
**This is only for testing when api is not ready.**

### Things to Talk About
