### PR TITLE
build(mirinae): fix to transpile import alias to relative path

### DIFF
--- a/packages/mirinae/package.json
+++ b/packages/mirinae/package.json
@@ -35,12 +35,12 @@
     "access": "public"
   },
   "scripts": {
-    "build": "NODE_OPTIONS=--max_old_space_size=8192 vite build && npm run css && npm run vue-tsc || true",
+    "build": "NODE_OPTIONS=--max_old_space_size=8192 vite build && npm run css && npm run vue-tsc || true && npm run tsc-alias",
     "dev": "concurrently \"npm run build:watch\" \"npm run tsc:watch\"",
     "build:watch": "NODE_OPTIONS=--max_old_space_size=8192 vite build --watch",
-    "tsc:watch": "tsc-watch --compiler vue-tsc/bin/vue-tsc.js -p tsconfig.build.json --silent --onCompilationComplete \"tsc-alias -w -p tsconfig.build.json\"",
+    "tsc:watch": "tsc-watch --compiler vue-tsc/bin/vue-tsc.js -p tsconfig.build.json --silent --onCompilationComplete \"tsc-alias -w -p tsconfig.alias.json\"",
     "vue-tsc": "vue-tsc -p tsconfig.build.json",
-    "tsc-alias": "tsc-alias -p tsconfig.build.json",
+    "tsc-alias": "tsc-alias -p tsconfig.alias.json",
     "build:storybook": "NODE_OPTIONS=--max_old_space_size=4096 build-storybook -o .out -s public",
     "storybook": "start-storybook -p 6006 -s public",
     "css": "node scripts/css.js",

--- a/packages/mirinae/tsconfig.alias.json
+++ b/packages/mirinae/tsconfig.alias.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["types/**/*.ts"]
+}


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [x] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

There was a critical issue that alias '@' is not resolved.
This PR fix this issue.

### Things to Talk About
