### PR TITLE
feat(collector-create-page): apply keep-alive to steps

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-create/CollectorCreatePage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-create/CollectorCreatePage.vue
@@ -18,15 +18,19 @@
             <create-collector-step1 v-if="state.step===1"
                                     @update:currentStep="handleChangeStep"
             />
-            <create-collector-step2 v-if="state.step===2"
-                                    @update:currentStep="handleChangeStep"
-            />
-            <create-collector-step3 v-if="state.step===3"
-                                    @update:currentStep="handleChangeStep"
-            />
-            <create-collector-step4 v-if="state.step===4"
-                                    @update:currentStep="handleChangeStep"
-            />
+            <div v-if="state.step !== 1">
+                <keep-alive>
+                    <create-collector-step2 v-if="state.step===2"
+                                            @update:currentStep="handleChangeStep"
+                    />
+                    <create-collector-step3 v-if="state.step===3"
+                                            @update:currentStep="handleChangeStep"
+                    />
+                    <create-collector-step4 v-if="state.step===4"
+                                            @update:currentStep="handleChangeStep"
+                    />
+                </keep-alive>
+            </div>
         </div>
         <delete-modal :header-title="$t('INVENTORY.COLLECTOR.CREATE.CREATE_EXIT_MODAL_TITLE')"
                       :visible.sync="state.deleteModalVisible"

--- a/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep1.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep1.vue
@@ -142,6 +142,7 @@ watch([() => collectorFormState.provider, () => state.selectedRepository], async
 }, { immediate: true });
 
 onMounted(() => {
+    collectorFormStore.resetForm();
     useInfiniteScroll(pluginCardListRef, () => {
         loadMorePlugin();
     });

--- a/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep2.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep2.vue
@@ -93,6 +93,7 @@ const handleClickNextButton = () => {
 };
 const handleClose = () => {
     emit('update:currentStep', 1);
+    state.deleteModalVisible = false;
 };
 
 const handleUpdateIsValid = (isValid: boolean) => {

--- a/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep4.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep4.vue
@@ -132,6 +132,7 @@ const handleClickOtherPluginButton = () => {
 
 const handleClose = () => {
     emit('update:currentStep', 1);
+    state.deleteModalVisible = false;
 };
 
 const handleConfirmCreateCollector = () => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
The values in the input forms from step 2 to step 4 will be retained. 
If you go back to step 1 and reselect the plugin, the form will be reset.


https://github.com/cloudforet-io/console/assets/50662170/df4e5036-1d34-4f09-a6af-a42bfb81d94e




### Things to Talk About
