### PR TITLE
fix(p-json-schema-form): fix return value of refineValueByProperty

### DIFF
--- a/packages/mirinae/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue
@@ -143,7 +143,7 @@ interface FilterableDropdownProps {
     appearanceType?: FilterableDropdownAppearanceType;
     // eslint-disable-next-line vue/require-default-prop
     pageSize?: number;
-    resetSelectedOnUnmounted: boolean;
+    resetSelectedOnUnmounted?: boolean;
 }
 const props = withDefaults(defineProps<FilterableDropdownProps>(), {
     menu: () => [],

--- a/packages/mirinae/src/inputs/forms/json-schema-form/PJsonSchemaForm.stories.mdx
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/PJsonSchemaForm.stories.mdx
@@ -121,6 +121,7 @@ It internally uses [Ajv JSON schema validator](https://ajv.js.org/) and [ajv-for
 |menuItems|custom|[Filterable Dropdown](?path=/docs/inputs-dropdown-filterable-dropdown--basic)|supports `array` type only|
 |reference|custom|[Filterable Dropdown](?path=/docs/inputs-dropdown-filterable-dropdown--basic)|It represents reference information. supports `{ resource_type: string, reference_key?: string}` type only|
 |order|custom|-|order of properties. string[]|
+|disabled|custom|all|If the input event of the form is disabled, it will still be reflected in the formData if there is a default value.|
 
 
 

--- a/packages/mirinae/src/inputs/forms/json-schema-form/helper.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/helper.ts
@@ -59,7 +59,7 @@ const isStrictArraySelectMode = (schemaProperty: JsonSchema): boolean => {
 
 export const refineValueByProperty = (schema: JsonSchema, val?: any): any => {
     const { type, disabled } = schema;
-    if (disabled) return undefined;
+    if (disabled) return schema?.default ?? undefined;
     if (type === 'object') return val; // In case of object, child JsonSchemaForm refines the data.
     if (type === 'array') return refineArrayTypeValue(schema, val);
     if (NUMERIC_TYPES.includes(type)) return refineNumberTypeValue(val);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
If a disabled form has a default value, the default value will be stored in the `formData`.


### Things to Talk About
