### PR TITLE
fix: check if plugin_info is empty in CollectorBaseInfoSection

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
@@ -126,7 +126,7 @@ const state = reactive({
     pluginInfo: computed<CollectorPluginModel|null>(() => collectorFormState.originCollector?.plugin_info ?? null),
     pluginName: computed<string>(() => state.pluginItem?.label ?? ''),
     pluginIcon: computed<string>(() => state.pluginItem?.icon ?? ''),
-    isCollectorAutoUpgrade: computed<boolean>(() => collectorFormState.originCollector?.plugin_info.upgrade_mode === UPGRADE_MODE.AUTO),
+    isCollectorAutoUpgrade: computed<boolean>(() => collectorFormState.originCollector?.plugin_info?.upgrade_mode === UPGRADE_MODE.AUTO),
     isLatestVersion: computed<boolean>(() => {
         const version = state.pluginInfo?.version;
         if (!version) return false;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

SSIA

### Things to Talk About
