### PR TITLE
fix: fix bugs in asset dashboard

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -322,6 +322,11 @@ export default defineComponent<Props>({
             });
             if (!props.widgetKey) {
                 let _inheritOptions = widgetFormState.inheritOptions;
+                // set default value to fixed properties
+                widgetFormState.schemaProperties?.filter((d) => state.fixedProperties.includes(d)).forEach((propertyName) => {
+                    state.schemaFormData[propertyName] = state.widgetConfig?.options?.[propertyName];
+                });
+                // set default value to default properties
                 widgetFormState.schemaProperties?.filter((d) => !state.fixedProperties.includes(d)).forEach((propertyName) => {
                     state.schemaFormData[propertyName] = propertyName.replace('filters.', '');
                     _inheritOptions = {

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -207,6 +207,8 @@ export default defineComponent<Props>({
         const handleDeleteProperty = (property: string) => {
             const _properties = widgetFormState.schemaProperties?.filter((d) => d !== property) ?? [];
             handleUpdateSchemaProperties(_properties);
+            state.schemaFormData[property] = undefined;
+            state.schemaFormData = { ...state.schemaFormData };
         };
 
         /* utils */

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/compliance-check-status/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/compliance-check-status/widget-config.ts
@@ -24,7 +24,7 @@ const complianceCheckStatusWidgetConfig: WidgetConfig = {
         granularity: GRANULARITY.ACCUMULATED,
     },
     options_schema: {
-        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account', 'asset_compliance_type', 'asset_account'),
+        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project', 'region', 'service_account', 'asset_compliance_type', 'asset_account'),
         schema: {
             type: 'object',
             properties: {
@@ -32,6 +32,7 @@ const complianceCheckStatusWidgetConfig: WidgetConfig = {
                     'project',
                     'service_account',
                     'provider',
+                    'region',
                     'asset_compliance_type',
                     'asset_account',
                 ),
@@ -40,6 +41,7 @@ const complianceCheckStatusWidgetConfig: WidgetConfig = {
                 'project',
                 'service_account',
                 'provider',
+                'region',
                 'asset_compliance_type',
                 'asset_account',
             ),


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
1. feat: set default value to fixedProperties of widget
  [QA-528 대시보드 생성 > 대시보드 커스터마이즈 > 위젯 추가 모달 > 일부 위젯에서 default값이 지정되지 않음](https://pyengine.atlassian.net/browse/QA-528)

2. fix: update json form data when delete widget options
  [QA-511 대시보드 생성 > 대시보드 커스터마이즈 > 위젯 추가 모달 > 다른 위젯으로 변경 시, validation rule이 초기화 되지 않음](https://pyengine.atlassian.net/browse/QA-511)

3. fix: add 'region' property to compliance check widget
  [QA-522 대시보드 > Compliance Check Status 위젯에 Region 옵션 없음 ](https://pyengine.atlassian.net/browse/QA-522)
