### PR TITLE
fix: apply service accounts filter if exist and update appearance of service account dropdown

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/shared/collector-forms/AttachedServiceAccountForm.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-forms/AttachedServiceAccountForm.vue
@@ -32,8 +32,9 @@
                 <p-filterable-dropdown class="specific-service-account-dropdown"
                                        :selected="selectedAttachedServiceAccount"
                                        multi-selectable
+                                       show-select-marker
                                        :handler="serviceAccountHandler"
-                                       appearance-type="badge"
+                                       appearance-type="stack"
                                        :reset-selected-on-unmounted="false"
                                        @update:selected="handleSelectAttachedServiceAccount"
                 />


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

1. [fix: update appearance of service account dropdown](https://github.com/cloudforet-io/console/commit/9219fd600ce3283c211e476c0ec5ef0bfd503e99)
<img width="562" alt="image" src="https://github.com/cloudforet-io/console/assets/26986739/80477055-e3be-4c2c-9615-702de0229d83">

2. [fix: apply service accounts filter if exist](https://github.com/cloudforet-io/console/commit/0d9778793374f9c9563d41e14e368ef63ef05375)


### Things to Talk About
