### PR TITLE
feat: apply hidden filters to cloud service usage overview

### DIFF
--- a/apps/web/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-usage-overview/CloudServiceUsageOverview.vue
+++ b/apps/web/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-usage-overview/CloudServiceUsageOverview.vue
@@ -16,6 +16,7 @@
                                                   :data-list="summaryDataList"
                                                   :widget-schema-list="summaryWidgetSchemaList"
                                                   :cloud-service-type-id="cloudServiceTypeId"
+                                                  :filters="hiddenFilters"
             />
         </div>
         <cloud-service-usage-overview-detail-modal v-model="usageOverviewDetailModalVisible"
@@ -42,6 +43,7 @@ import {
 import type {
     DynamicWidgetSchema,
 } from '@spaceone/design-system/types/data-display/dynamic/dynamic-widget/type';
+import type { KeyItemSet } from '@spaceone/design-system/types/inputs/search/query-search/type';
 import type { CancelTokenSource } from 'axios';
 import axios from 'axios';
 import dayjs from 'dayjs';
@@ -67,6 +69,8 @@ interface Props {
     cloudServiceTypeInfo: CloudServiceTypeInfo;
     filters?: ConsoleFilter[];
     period?: Period;
+    hiddenFilters?: ConsoleFilter[];
+    keyItemSets: KeyItemSet[];
 }
 
 interface Data {
@@ -94,6 +98,14 @@ export default defineComponent<Props>({
             type: Object as () => Period|undefined,
             default: undefined,
         },
+        hiddenFilters: {
+            type: Array as () => ConsoleFilter[]|undefined,
+            default: undefined,
+        },
+        keyItemSets: {
+            type: Array as () => KeyItemSet[],
+            default: () => [],
+        },
     },
     setup(props) {
         const queryHelper = new QueryHelper();
@@ -107,12 +119,16 @@ export default defineComponent<Props>({
             summaryDataList: [] as Data[],
             dataLoading: false,
             cloudServiceTypeId: computed<string>(() => props.cloudServiceTypeInfo.cloud_service_type_id ?? ''),
-            apiQuery: computed<{filter?: ApiFilter[]; keyword?: string}>(() => {
+            apiQuery: computed<{filter: ApiFilter[]; keyword: string}>(() => {
+                queryHelper.setFilters([]);
                 if (props.filters) {
-                    const { filter, keyword } = queryHelper.setFilters(props.filters).apiQuery;
-                    return { filter, keyword };
+                    queryHelper.addFilter(...props.filters);
                 }
-                return {};
+                if (props.hiddenFilters) {
+                    queryHelper.addFilter(...props.hiddenFilters);
+                }
+                const { filter, keyword } = queryHelper.apiQuery;
+                return { filter, keyword };
             }),
             dateRange: computed<Period|undefined>(() => {
                 if (isEmpty(props.period)) return undefined;
@@ -199,7 +215,7 @@ export default defineComponent<Props>({
         };
 
         /* Watchers */
-        watch([() => props.filters, () => state.dateRange], () => {
+        watch([() => state.apiQuery, () => state.dateRange], () => {
             if (state.cloudServiceTypeId) {
                 getDataListWithSchema();
             }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

CloudServiceUsageOverview component operated like below:
1. takes `filters` prop. it is shown as query tags.
2. call get-schema api. given schema has `default_filter`.
3. call get data api with `default_filter` and `filters`.

It changed to as below:
1. takes `filters` and `hiddenFilter` props. only `filters` will be shown as query tags.
2. call get-schema api. given schema has `default_filter`.
3. call get data api with `default_filter`, `filters` and `hiddenFilter`.



### Things to Talk About
