### PR TITLE
fix(query-search-tags): correct values for boolean converter

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -34,7 +34,7 @@ module.exports = {
         'no-mixed-operators': 0,
         'no-promise-executor-return': 1,
         'no-multiple-empty-lines': 0,
-        'prefer-regex-literals': 1,
+        'prefer-regex-literals': ['off'],
         'prefer-const': 1,
 
         indent: ['error', 4],

--- a/packages/mirinae/.eslintrc.cjs
+++ b/packages/mirinae/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-    root: true,
+    root: false,
     extends: ["custom"],
 
     rules: {

--- a/packages/mirinae/src/inputs/search/query-search-tags/helper.ts
+++ b/packages/mirinae/src/inputs/search/query-search-tags/helper.ts
@@ -15,8 +15,8 @@ const booleanConverter = (query: QueryItem): QueryTag => {
     const res: QueryTag = { ...query };
     const str = String(res.value.name) || '';
 
-    if (trueRegex.test(str)) res.value = { ...res.value, name: false, label: 'TRUE' };
-    else if (falseRegex.test(str)) res.value = { ...res.value, name: true, label: 'FALSE' };
+    if (trueRegex.test(str)) res.value = { ...res.value, name: true, label: 'TRUE' };
+    else if (falseRegex.test(str)) res.value = { ...res.value, name: false, label: 'FALSE' };
     else {
         res.invalid = true;
         res.description = 'This is not suitable for boolean format.';

--- a/packages/mirinae/src/inputs/search/query-search/config.ts
+++ b/packages/mirinae/src/inputs/search/query-search/config.ts
@@ -62,7 +62,8 @@ const datetimeItems: ValueItem[] = [
 ];
 
 export const defaultHandlerMap: Partial<Record<KeyDataType, ValueHandler>> = {
-    boolean: (inputText: string) => {
+    boolean: (inputText: string|number) => {
+        if (typeof inputText === 'number') return { results: booleanItems };
         const regex = RegExp(inputText || '', 'i');
         return {
             results: booleanItems.reduce((res, d) => {
@@ -71,7 +72,8 @@ export const defaultHandlerMap: Partial<Record<KeyDataType, ValueHandler>> = {
             }, [] as ValueItem[]),
         };
     },
-    datetime: (inputText: string) => {
+    datetime: (inputText: string|number) => {
+        if (typeof inputText === 'number') return { results: datetimeItems };
         const regex = RegExp(inputText || '', 'i');
         return {
             results: datetimeItems.filter((d) => regex.test(d.name)) as ValueItem[],

--- a/packages/mirinae/src/navigation/toolbox/PToolbox.vue
+++ b/packages/mirinae/src/navigation/toolbox/PToolbox.vue
@@ -76,7 +76,7 @@
             </div>
             <div class="filters-wrapper">
                 <p-query-search-tags v-show="searchable && filtersVisible && searchType === SEARCH_TYPES.query"
-                                     :tags.sync="proxyState.queryTags"
+                                     :tags="proxyState.queryTags"
                                      :timezone="timezone"
                                      :converter="queryTagConverter"
                                      @change="onQueryTagsChange"


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [x] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

- There was critical bug that causes infinity loop. In `QuerySearchTags` component, the tag converter for boolean data type worked wrong. So this PR fixes this bug.
- Fixed eslint configs

### Things to Talk About
