### PR TITLE
fix(collector-version-form): fix autoUpgrade version initialization

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorVersionForm.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorVersionForm.vue
@@ -69,7 +69,7 @@ const initSelectedVersion = () => {
         const originVersion = collectorFormState.originCollector?.plugin_info?.version;
         collectorFormStore.$patch({
             version: originVersion ?? collectorFormState.versions[0] ?? '',
-            autoUpgrade: originAutoUpgrade ?? true,
+            autoUpgrade: props.getVersionsOnPluginIdChange ? true : (originAutoUpgrade ?? true),
         });
     }
 };

--- a/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorVersionForm.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorVersionForm.vue
@@ -64,12 +64,17 @@ const state = reactive({
 });
 
 const initSelectedVersion = () => {
-    if (!collectorFormState.version.length) {
+    if (!collectorFormState.version.length && collectorFormState.originCollector) {
         const originAutoUpgrade = collectorFormState.originCollector?.plugin_info?.upgrade_mode === 'AUTO';
         const originVersion = collectorFormState.originCollector?.plugin_info?.version;
         collectorFormStore.$patch({
             version: originVersion ?? collectorFormState.versions[0] ?? '',
-            autoUpgrade: props.getVersionsOnPluginIdChange ? true : (originAutoUpgrade ?? true),
+            autoUpgrade: originAutoUpgrade ?? true,
+        });
+    } else {
+        collectorFormStore.$patch({
+            version: collectorFormState.versions[0] ?? '',
+            autoUpgrade: true,
         });
     }
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
The purpose is to set autoUpgrade to true when creating a collector.


### Things to Talk About
