### PR TITLE
refactor: set cancelToken to all widgets

### DIFF
--- a/apps/web/src/services/asset-inventory/cloud-service/CloudServicePage.vue
+++ b/apps/web/src/services/asset-inventory/cloud-service/CloudServicePage.vue
@@ -217,7 +217,7 @@ export default {
                             end: dayjs.utc(cloudServicePageState.period.end).add(1, 'day').format('YYYY-MM-DD'),
                         },
                     }),
-                });
+                }, { cancelToken: listCloudServiceRequest.token });
                 state.items = res.results;
                 state.totalCount = res.total_count || 0;
                 state.loading = false;

--- a/apps/web/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-usage-overview/CloudServiceUsageOverview.vue
+++ b/apps/web/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/cloud-service-usage-overview/CloudServiceUsageOverview.vue
@@ -172,7 +172,7 @@ export default defineComponent<Props>({
                     ...state.apiQuery,
                     default_query: schema.query,
                     date_range: state.dateRange,
-                });
+                }, { cancelToken: fetchDataTokenList[idx]?.token });
                 fetchDataTokenList[idx] = undefined;
                 return results[0] ?? {};
             } catch (e: any) {

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChart.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChart.vue
@@ -136,7 +136,7 @@ export default {
                     end: dayjs.utc(costAnalysisPageState.period.end).format(dateFormat),
                     limit: 15,
                     ...costQueryHelper.apiQuery,
-                });
+                }, { cancelToken: listCostAnalysisRequest.token });
                 listCostAnalysisRequest = undefined;
                 return results;
             } catch (e) {

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisDataTable.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisDataTable.vue
@@ -355,7 +355,7 @@ export default {
                     start: dayjs.utc(period.start).format(dateFormat),
                     end: dayjs.utc(period.end).format(dateFormat),
                     ...query,
-                });
+                }, { cancelToken: listCostAnalysisRequest.token });
                 let items = results;
                 if (granularity !== GRANULARITY.ACCUMULATED && stack) items = _getStackedTableData(results, granularity, period);
                 tableState.items = items;

--- a/apps/web/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
@@ -54,6 +54,8 @@ import type { Location } from 'vue-router/types/router';
 
 import type { XYChart } from '@amcharts/amcharts5/xy';
 import { PDataLoader } from '@spaceone/design-system';
+import type { CancelTokenSource } from 'axios';
+import axios from 'axios';
 import dayjs from 'dayjs';
 import { cloneDeep } from 'lodash';
 
@@ -155,7 +157,13 @@ const state = reactive({
 const widgetFrameProps:ComputedRef = useWidgetFrameProps(props, state);
 
 /* Api */
+let analyzeRequest: CancelTokenSource | undefined;
 const fetchData = async (): Promise<FullData> => {
+    if (analyzeRequest) {
+        analyzeRequest.cancel('Next request has been called.');
+        analyzeRequest = undefined;
+    }
+    analyzeRequest = axios.CancelToken.source();
     try {
         const apiQueryHelper = new ApiQueryHelper();
         apiQueryHelper.setFilters(state.consoleFilters);
@@ -176,7 +184,8 @@ const fetchData = async (): Promise<FullData> => {
                 field_group: ['date'],
                 ...apiQueryHelper.data,
             },
-        });
+        }, { cancelToken: analyzeRequest.token });
+        analyzeRequest = undefined;
         return { results: sortTableData(getRefinedDateTableData(results, state.dateRange)), more };
     } catch (e) {
         ErrorHandler.handleError(e);

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/total-failure-and-severity/TotalFailureAndSeverityWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/total-failure-and-severity/TotalFailureAndSeverityWidget.vue
@@ -99,6 +99,8 @@ import type { TranslateResult } from 'vue-i18n';
 import {
     PI, PDivider, PDataLoader,
 } from '@spaceone/design-system';
+import type { CancelTokenSource } from 'axios';
+import axios from 'axios';
 import dayjs from 'dayjs';
 import { cloneDeep, sum } from 'lodash';
 
@@ -229,7 +231,14 @@ const widgetFrameProps:ComputedRef = useWidgetFrameProps(props, state);
 
 /* API */
 const apiQueryHelper = new ApiQueryHelper();
+let trendAnalyzeRequest: CancelTokenSource | undefined;
+let realtimeAnalyzeRequest: CancelTokenSource | undefined;
 const fetchTrendData = async (): Promise<Data[]> => {
+    if (trendAnalyzeRequest) {
+        trendAnalyzeRequest.cancel('Next request has been called.');
+        trendAnalyzeRequest = undefined;
+    }
+    trendAnalyzeRequest = axios.CancelToken.source();
     try {
         apiQueryHelper
             .setFilters(state.cloudServiceStatsConsoleFilters)
@@ -253,7 +262,8 @@ const fetchTrendData = async (): Promise<Data[]> => {
                 }],
                 ...apiQueryHelper.data,
             },
-        });
+        }, { cancelToken: trendAnalyzeRequest.token });
+        trendAnalyzeRequest = undefined;
         return results;
     } catch (e) {
         ErrorHandler.handleError(e);
@@ -261,6 +271,11 @@ const fetchTrendData = async (): Promise<Data[]> => {
     }
 };
 const fetchRealtimeData = async (): Promise<Data[]> => {
+    if (realtimeAnalyzeRequest) {
+        realtimeAnalyzeRequest.cancel('Next request has been called.');
+        realtimeAnalyzeRequest = undefined;
+    }
+    realtimeAnalyzeRequest = axios.CancelToken.source();
     try {
         apiQueryHelper
             .setFilters(state.cloudServiceStatsConsoleFilters)
@@ -281,7 +296,8 @@ const fetchRealtimeData = async (): Promise<Data[]> => {
                 },
                 ...apiQueryHelper.data,
             },
-        });
+        }, { cancelToken: realtimeAnalyzeRequest.token });
+        realtimeAnalyzeRequest = undefined;
         return results;
     } catch (e) {
         ErrorHandler.handleError(e);

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/cost-by-region/CostByRegionWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/cost-by-region/CostByRegionWidget.vue
@@ -49,6 +49,8 @@ import {
 import type { Location } from 'vue-router/types/router';
 
 import { PDataLoader } from '@spaceone/design-system';
+import type { CancelTokenSource } from 'axios';
+import axios from 'axios';
 import {
     groupBy, isEqual, sum, uniqWith,
 } from 'lodash';
@@ -202,7 +204,13 @@ const getRefinedMapChartData = (results?: Data): MapChartData[] => {
 };
 
 /* Api */
+let analyzeRequest: CancelTokenSource | undefined;
 const fetchData = async (): Promise<FullData> => {
+    if (analyzeRequest) {
+        analyzeRequest.cancel('Next request has been called.');
+        analyzeRequest = undefined;
+    }
+    analyzeRequest = axios.CancelToken.source();
     try {
         const apiQueryHelper = new ApiQueryHelper();
         apiQueryHelper.setFilters(state.consoleFilters);
@@ -222,7 +230,8 @@ const fetchData = async (): Promise<FullData> => {
                 sort: [{ key: 'usd_cost_sum', desc: true }],
                 ...apiQueryHelper.data,
             },
-        });
+        }, { cancelToken: analyzeRequest.token });
+        analyzeRequest = undefined;
         return { results, more };
     } catch (e) {
         ErrorHandler.handleError(e);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
Whenever the Dashboard Variable at the top is modified, the widget reloads the API. However, if the variable is continuously modified, API requests accumulate, causing issues with the proper display of the dashboard. Therefore, cancelToken is applied to all widgets.

상단의 Dashboard Variable이 수정될 때마다 위젯에서 api를 다시 불러오는데, variable을 계속 수정할 경우 **api request가 쌓여 대시보드가 제대로 보이지 않는 현상 발생**. 고로 모든 위젯에 cancelToken을 적용함

![스크린샷 2023-06-20 오전 8 55 15](https://github.com/cloudforet-io/console/assets/18563857/2f2060bc-1cc9-4589-8f93-4d445392e9ca)
