### PR TITLE
fix: don't delegate page requirements to ScheduleForm component

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep4.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep4.vue
@@ -1,6 +1,8 @@
 <template>
     <div class="collector-page-4">
-        <collector-schedule-form disable-first-loading />
+        <collector-schedule-form enable-hours-edit
+                                 disable-loading
+        />
         <div class="step-footer">
             <p-text-button icon-left="ic_chevron-left"
                            style-type="highlight"

--- a/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorScheduleForm.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorScheduleForm.vue
@@ -13,7 +13,7 @@
                          :disabled="props.disabled"
                          @change-toggle="handleChangeToggle"
         />
-        <div v-if="!props.enableHoursEdit && !props.disableFirstLoading"
+        <div v-if="!props.enableHoursEdit && collectorFormState.schedulePower"
              class="collect-data-desc"
         >
             <i18n v-if="state.timezoneAppliedHours.length > 0"
@@ -34,7 +34,7 @@
                 </p-button>
             </template>
         </div>
-        <p-field-group v-else
+        <p-field-group v-if="props.enableHoursEdit"
                        class="hourly-schedule-field-group"
                        :label="$t('INVENTORY.COLLECTOR.DETAIL.SCHEDULE_HOURLY')"
         >
@@ -86,7 +86,7 @@ import { useCollectorFormStore } from '@/services/asset-inventory/collector/shar
 
 const props = defineProps<{
     enableHoursEdit?: boolean;
-    disableFirstLoading?: boolean;
+    disableLoading?: boolean;
     disabled?: boolean;
     resetOnCollectorIdChange?: boolean;
     callApiOnPowerChange?: boolean;
@@ -112,7 +112,7 @@ const state = reactive({
     }),
     timezoneAppliedHoursDisplayText: computed(() => state.timezoneAppliedHours.map((hour) => `${hour}:00`).join(', ')),
     loading: computed<boolean>(() => {
-        if (props.disableFirstLoading) return false;
+        if (props.disableLoading) return false;
         return collectorFormState.originCollector === null;
     }),
 });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

1. show hours readonly UI only when the schedule power is on.
2. change the name of prop 'disableFirstLoading' to 'disableLoading' because the loading state always return false if this prop is true.
3. change the CreateCollectorStep4 component to bind prop in correct way.

### Things to Talk About
