### PR TITLE
feat: disable 'service_account' in asset widgets & fix dashboard clone bug

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-detail/modules/dashboard-widget-container/DashboardWidgetContainer.vue
+++ b/apps/web/src/services/dashboards/dashboard-detail/modules/dashboard-widget-container/DashboardWidgetContainer.vue
@@ -143,6 +143,7 @@ export default defineComponent<Props>({
         /* refresh widgets */
         let dashboardChangedTime;
         watch(() => dashboardDetailState.dashboardId, () => {
+            state.initiatedWidgetMap = {};
             dashboardChangedTime = new Date().getTime();
         });
         watch(() => dashboardDetailState.settings, (dashboardSettings, prevSettings) => {

--- a/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
+++ b/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
@@ -12,6 +12,7 @@ import { CURRENCY } from '@/store/modules/display/config';
 
 import { ASSET_REFERENCE_TYPE_INFO } from '@/lib/reference/asset-reference-config';
 import { COST_REFERENCE_TYPE_INFO } from '@/lib/reference/cost-reference-config';
+import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
 
 import type {
     DashboardViewer, DashboardSettings, DashboardVariables, DashboardVariablesSchema,
@@ -93,6 +94,8 @@ const refineVariablesSchema = (variablesSchemaInfo?: DashboardVariablesSchema, l
                     _managedDashboardVariablesSchema.properties[key] = { ...value, use: true };
                 }
             });
+            // HACK: remove below code after backend is ready
+            _managedDashboardVariablesSchema.properties[REFERENCE_TYPE_INFO.service_account.type].use = false;
         } else if (labels?.includes('Cost')) {
             managedVariablesPropertiesMap.forEach((value, key) => {
                 if (Object.keys(COST_REFERENCE_TYPE_INFO).includes(key)) {

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/compliance-check-status/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/compliance-check-status/widget-config.ts
@@ -24,13 +24,13 @@ const complianceCheckStatusWidgetConfig: WidgetConfig = {
         granularity: GRANULARITY.ACCUMULATED,
     },
     options_schema: {
-        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project', 'region', 'service_account', 'asset_compliance_type', 'asset_account'),
+        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project', 'region', 'asset_compliance_type', 'asset_account'),
         schema: {
             type: 'object',
             properties: {
                 ...getWidgetFilterOptionsSchema(
                     'project',
-                    'service_account',
+                    // 'service_account', HACK: Re-enable it after backend is ready
                     'provider',
                     'region',
                     'asset_compliance_type',
@@ -39,7 +39,7 @@ const complianceCheckStatusWidgetConfig: WidgetConfig = {
             },
             order: getWidgetFilterSchemaPropertyNames(
                 'project',
-                'service_account',
+                // 'service_account',
                 'provider',
                 'region',
                 'asset_compliance_type',

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/count-of-fail-findings/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/count-of-fail-findings/widget-config.ts
@@ -27,7 +27,7 @@ const countOfFailFindingsWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'region', 'service_account', 'asset_compliance_type', 'asset_account')],
+        default_properties: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'region', 'asset_compliance_type', 'asset_account')],
         fixed_properties: ['asset_group_by'],
         schema: {
             type: 'object',
@@ -35,7 +35,7 @@ const countOfFailFindingsWidgetConfig: WidgetConfig = {
                 ...getWidgetOptionsSchema('asset_group_by'),
                 ...getWidgetFilterOptionsSchema(
                     'project',
-                    'service_account',
+                    // 'service_account', HACK: Re-enable it after backend is ready
                     'provider',
                     'region',
                     'asset_compliance_type',
@@ -44,7 +44,7 @@ const countOfFailFindingsWidgetConfig: WidgetConfig = {
             },
             order: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames(
                 'project',
-                'service_account',
+                // 'service_account',
                 'provider',
                 'region',
                 'asset_compliance_type',

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/count-of-pass-and-fail-findings/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/count-of-pass-and-fail-findings/widget-config.ts
@@ -27,7 +27,7 @@ const countOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'region', 'service_account', 'asset_compliance_type', 'asset_account')],
+        default_properties: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames('provider', 'project', 'region', 'asset_compliance_type', 'asset_account')],
         fixed_properties: ['asset_group_by'],
         schema: {
             type: 'object',
@@ -35,7 +35,7 @@ const countOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
                 ...getWidgetOptionsSchema('asset_group_by'),
                 ...getWidgetFilterOptionsSchema(
                     'project',
-                    'service_account',
+                    // 'service_account', HACK: Re-enable it after backend is ready
                     'provider',
                     'region',
                     'asset_compliance_type',
@@ -44,7 +44,7 @@ const countOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
             },
             order: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames(
                 'project',
-                'service_account',
+                // 'service_account',
                 'provider',
                 'region',
                 'asset_compliance_type',

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/severity-status-by-service/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/severity-status-by-service/widget-config.ts
@@ -29,13 +29,13 @@ const severityStatusByServiceWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: getWidgetFilterSchemaPropertyNames('project', 'service_account', 'provider', 'region', 'asset_compliance_type', 'asset_account'),
+        default_properties: getWidgetFilterSchemaPropertyNames('project', 'provider', 'region', 'asset_compliance_type', 'asset_account'),
         schema: {
             type: 'object',
             properties: {
                 ...getWidgetFilterOptionsSchema(
                     'project',
-                    'service_account',
+                    // 'service_account', HACK: Re-enable it after backend is ready
                     'provider',
                     'region',
                     'asset_compliance_type',
@@ -44,7 +44,7 @@ const severityStatusByServiceWidgetConfig: WidgetConfig = {
             },
             order: getWidgetFilterSchemaPropertyNames(
                 'project',
-                'service_account',
+                // 'service_account',
                 'provider',
                 'region',
                 'asset_compliance_type',

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/total-failure-and-severity/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/total-failure-and-severity/widget-config.ts
@@ -26,13 +26,13 @@ const totalFailureAndSeverityWidgetConfig: WidgetConfig = {
         granularity: GRANULARITY.MONTHLY,
     },
     options_schema: {
-        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project', 'service_account', 'region', 'asset_compliance_type', 'asset_account'),
+        default_properties: getWidgetFilterSchemaPropertyNames('provider', 'project', 'region', 'asset_compliance_type', 'asset_account'),
         schema: {
             type: 'object',
             properties: {
                 ...getWidgetFilterOptionsSchema(
                     'project',
-                    'service_account',
+                    // 'service_account', HACK: Re-enable it after backend is ready
                     'provider',
                     'region',
                     'asset_compliance_type',
@@ -41,7 +41,7 @@ const totalFailureAndSeverityWidgetConfig: WidgetConfig = {
             },
             order: getWidgetFilterSchemaPropertyNames(
                 'project',
-                'service_account',
+                // 'service_account',
                 'provider',
                 'region',
                 'asset_compliance_type',

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/trend-of-pass-and-fail-findings/widget-config.ts
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/trend-of-pass-and-fail-findings/widget-config.ts
@@ -29,7 +29,7 @@ const trendOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
         },
     },
     options_schema: {
-        default_properties: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames('project', 'service_account', 'provider', 'asset_compliance_type', 'region', 'asset_account')],
+        default_properties: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames('project', 'provider', 'asset_compliance_type', 'region', 'asset_account')],
         fixed_properties: ['asset_group_by'],
         schema: {
             type: 'object',
@@ -37,7 +37,7 @@ const trendOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
                 ...getWidgetOptionsSchema('asset_group_by'),
                 ...getWidgetFilterOptionsSchema(
                     'project',
-                    'service_account',
+                    // 'service_account', HACK: Re-enable it after backend is ready
                     'provider',
                     'asset_compliance_type',
                     'region',
@@ -46,7 +46,7 @@ const trendOfPassAndFailFindingsWidgetConfig: WidgetConfig = {
             },
             order: ['asset_group_by', ...getWidgetFilterSchemaPropertyNames(
                 'project',
-                'service_account',
+                // 'service_account',
                 'provider',
                 'asset_compliance_type',
                 'region',


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- disable 'service account' in asset dashboard & asset widgets (**backend is not ready!!!**)
- fix dashboard clone bug
