### PR TITLE
fix: clear authorization error visible state before each router changes

### DIFF
--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -83,6 +83,10 @@ export class SpaceRouter {
                 }
             }
 
+            // If top notification which indicates authorization error is visible, clear it before moving to next location
+            if (SpaceRouter.router.app?.$store.state.error.visibleAuthorizationError) {
+                SpaceRouter.router.app?.$store.commit('error/setVisibleAuthorizationError', false);
+            }
             next(nextLocation);
         });
 
@@ -93,7 +97,6 @@ export class SpaceRouter {
             const store = SpaceRouter.router.app?.$store;
             if (!store) return;
 
-            if (store.state.error.visibleAuthorizationError) { store.commit('error/setVisibleAuthorizationError', false); }
             const isDomainOwner = store.getters['user/isDomainOwner'];
             if (!isDomainOwner) {
                 const recent = getRecentConfig(to);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

There was a bug that clears top notification bar even there is 403 error on the page.
To fix this issue, move the initialization logic for authorization error visible state to the router.beforeEach hook.


### Things to Talk About
