### PR TITLE
fix: hide widget option if there's no matched variable

### DIFF
--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/helpers/schema-helper.ts
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/helpers/schema-helper.ts
@@ -46,7 +46,7 @@ const refineOptionSchema = (propertyName: string, propertySchema: JsonSchema['pr
     if (propertyName.startsWith('filters.')) return refineFilterOptionSchema(propertyName, propertySchema, referenceStoreState);
     return propertySchema;
 };
-const refineOptionSchemaByVariablesSchema = (propertySchema: JsonSchema['properties'], variablesSchema: DashboardVariablesSchema) => {
+const refineOptionSchemaByVariablesSchema = (propertySchema: JsonSchema['properties'], variablesSchema: DashboardVariablesSchema): JsonSchema['properties'] => {
     const availableVariables = Object.entries(variablesSchema.properties)
         .filter(([, d]) => {
             if (!d.use) return false;
@@ -72,25 +72,24 @@ export const getWidgetOptionSchema = (
     referenceStoreState: ReferenceStoreState,
     isInherit: boolean,
     projectId?: string,
-) => {
-    let refinedPropertySchema;
+): JsonSchema['properties'] | undefined => {
     const _referenceType = propertyName.replace('filters.', '');
     const _isProjectDashboard = projectId && _referenceType === REFERENCE_TYPE_INFO.project.type;
-    if (isInherit || _isProjectDashboard) {
-        // inherit case
-        refinedPropertySchema = refineOptionSchemaByVariablesSchema(propertySchema, variablesSchema);
+    if (isInherit) { // inherit case
+        const refinedPropertySchema = refineOptionSchemaByVariablesSchema(propertySchema, variablesSchema);
         if (_isProjectDashboard) {
-            refinedPropertySchema = {
+            return {
                 ...refinedPropertySchema,
                 disabled: true,
                 default: REFERENCE_TYPE_INFO.project.type,
             };
+        } if (variablesSchema.properties[_referenceType]?.use) {
+            return refineOptionSchemaByVariablesSchema(propertySchema, variablesSchema);
         }
-    } else {
-        // non inherit case
-        refinedPropertySchema = refineOptionSchema(propertyName, propertySchema, referenceStoreState);
+    } else { // non inherit case
+        return refineOptionSchema(propertyName, propertySchema, referenceStoreState);
     }
-    return refinedPropertySchema;
+    return undefined;
 };
 export const getRefinedWidgetOptionsSchema = (
     referenceStoreState: ReferenceStoreState,
@@ -115,7 +114,8 @@ export const getRefinedWidgetOptionsSchema = (
         // set properties declared in schemaProperties only
         if (!schemaProperties.includes(propertyName as WidgetOptionsSchemaProperty)) return;
         const isInherit = !!inheritOptions[propertyName]?.enabled;
-        refinedJsonSchema.properties[propertyName] = getWidgetOptionSchema(propertyName, propertySchema, variablesSchema, referenceStoreState, isInherit, projectId);
+        const refinedWidgetOptionsSchema = getWidgetOptionSchema(propertyName, propertySchema, variablesSchema, referenceStoreState, isInherit, projectId);
+        if (refinedWidgetOptionsSchema) refinedJsonSchema.properties[propertyName] = refinedWidgetOptionsSchema;
     });
 
     return refinedJsonSchema;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
Hide widget options if there's **no matched dashboard variables**.

![스크린샷 2023-07-07 오후 1 05 34](https://github.com/cloudforet-io/console/assets/18563857/3e582f41-1d57-42c4-95b5-bb24ae0223d7)

Before
![스크린샷 2023-07-07 오후 1 17 58](https://github.com/cloudforet-io/console/assets/18563857/7a3fbb3f-3dbd-445c-a981-abd8f8d9cafe)

After
![스크린샷 2023-07-07 오후 1 05 47](https://github.com/cloudforet-io/console/assets/18563857/ebf07c1f-f052-4452-9068-bd00f4fb0509)
