### PR TITLE
refactor(centered-page-layout): use mirinae layout component

### DIFF
--- a/apps/web/src/common/modules/page-layouts/CenteredPageLayout.vue
+++ b/apps/web/src/common/modules/page-layouts/CenteredPageLayout.vue
@@ -1,16 +1,21 @@
 <template>
-    <div class="centered-page-layout">
-        <g-n-b-logo v-if="!props.hasNavBar"
-                    class="gnb-logo"
-                    :to="{ name: ROOT_ROUTE._NAME }"
-        />
-        <div class="layout-contents">
+    <p-centered-layout class="centered-page-layout">
+        <template v-if="!props.hasNavBar"
+                  #top-contents
+        >
+            <g-n-b-logo class="gnb-logo"
+                        :to="{ name: ROOT_ROUTE._NAME }"
+            />
+        </template>
+        <template #default>
             <slot />
-        </div>
-    </div>
+        </template>
+    </p-centered-layout>
 </template>
 
 <script setup lang="ts">
+
+import { PCenteredLayout } from '@spaceone/design-system';
 
 import { ROOT_ROUTE } from '@/router/service-routes';
 
@@ -23,32 +28,3 @@ const props = withDefaults(defineProps<Props>(), {
     hasNavBar: false,
 });
 </script>
-
-<style lang="postcss" scoped>
-.centered-page-layout {
-    &::before {
-        @apply absolute;
-        content: "";
-        background-image: url('@/assets/images/landing/img_landing_cost-explorer_background.png');
-        background-size: cover;
-        opacity: 0.3;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-    }
-    .gnb-logo {
-        @apply absolute z-10;
-        top: 1rem;
-        left: 1.25rem;
-    }
-    .layout-contents {
-        @apply absolute flex items-center justify-center;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        overflow-y: auto;
-    }
-}
-</style>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

I checked every pages this page layout component used and all were fine.

![스크린샷 2023-07-12 오전 10 54 09](https://github.com/cloudforet-io/console/assets/26986739/8856b325-d2de-461e-b1b6-3b46ec16fc4c)
![스크린샷 2023-07-12 오전 10 53 40](https://github.com/cloudforet-io/console/assets/26986739/6de2a3da-93c6-476b-8e30-b9d0aa762d62)
![스크린샷 2023-07-12 오전 10 53 27](https://github.com/cloudforet-io/console/assets/26986739/cd3eef99-0c50-475e-b10d-311e35b177a8)


### Things to Talk About
