### PR TITLE
refactor(dashboard-customize): separate it from page to reuse

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -1,37 +1,15 @@
 <template>
     <div class="dashboard-customize-page">
-        <dashboard-customize-page-name :name.sync="state.name"
-                                       :dashboard-id="props.dashboardId"
-                                       @update:name="handleUpdateDashboardName"
-        />
-        <div class="filters-box">
-            <dashboard-labels editable />
-            <dashboard-toolset />
-        </div>
-        <p-divider />
-        <div class="dashboard-selectors">
-            <dashboard-variables-select-dropdown class="variable-selector-wrapper"
-                                                 is-manageable
-            />
-            <dashboard-refresh-dropdown :dashboard-id="props.dashboardId"
-                                        refresh-disabled
-            />
-        </div>
-        <dashboard-widget-container edit-mode
-                                    reuse-previous-data
-        />
-        <dashboard-customize-sidebar :loading="state.loading"
-                                     @save="handleSave"
+        <dashboard-customize :dashboard-id="props.dashboardId"
+                             :loading="state.loading"
+                             @go-back="handleClickBackButton"
+                             @save="updateDashboardData"
         />
     </div>
 </template>
 
 <script setup lang="ts">
-import {
-    computed, onBeforeUnmount, onMounted, reactive, watch,
-} from 'vue';
-
-import { PDivider } from '@spaceone/design-system';
+import { reactive, defineProps } from 'vue';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
@@ -39,66 +17,54 @@ import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
-
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
-import type {
-    DashboardConfig,
-} from '@/services/dashboards/config';
-import DashboardCustomizePageName
-    from '@/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue';
-import DashboardCustomizeSidebar from '@/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue';
+import DashboardCustomize from '@/services/dashboards/dashboard-customize/modules/DashboardCustomize.vue';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
-import DashboardToolset from '@/services/dashboards/shared/dashboard-toolset/DashboardToolset.vue';
-import DashboardVariablesSelectDropdown from '@/services/dashboards/shared/dashboard-variables/DashboardVariablesSelectDropdown.vue';
-import DashboardWidgetContainer from '@/services/dashboards/shared/dashboard-widget-container/DashboardWidgetContainer.vue';
-import DashboardLabels from '@/services/dashboards/shared/DashboardLabels.vue';
-import DashboardRefreshDropdown from '@/services/dashboards/shared/DashboardRefreshDropdown.vue';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
+
 
 interface Props {
     dashboardId?: string;
 }
 
 const props = defineProps<Props>();
+
 const dashboardDetailStore = useDashboardDetailInfoStore();
 const dashboardDetailState = dashboardDetailStore.$state;
 
 const state = reactive({
-    name: dashboardDetailState.name,
-    apiParam: computed<Partial<DashboardConfig>>(() => ({
-        name: dashboardDetailState.name,
-        labels: dashboardDetailState.labels,
-        settings: dashboardDetailState.settings,
-        layouts: [dashboardDetailState.dashboardWidgetInfoList],
-        variables: dashboardDetailState.variables,
-        variables_schema: dashboardDetailState.variablesSchema,
-        tags: { created_by: store.state.user.userId },
-    })),
     loading: false,
 });
 
-/* Api */
-const getDashboardData = async () => {
-    try {
-        await dashboardDetailStore.getDashboardInfo(props.dashboardId);
-    } catch (e) {
-        ErrorHandler.handleError(e);
-        await SpaceRouter.router.push({ name: DASHBOARDS_ROUTE.ALL._NAME });
-    }
+const handleClickBackButton = () => {
+    SpaceRouter.router.back();
 };
+
 const updateDashboardData = async () => {
     try {
+        state.loading = true;
+
         if (dashboardDetailStore.isProjectDashboard) {
             await SpaceConnector.clientV2.dashboard.projectDashboard.update({
-                ...state.apiParam,
-                name: state.name,
+                name: dashboardDetailState.name,
+                labels: dashboardDetailState.labels,
+                settings: dashboardDetailState.settings,
+                layouts: [dashboardDetailState.dashboardWidgetInfoList],
+                variables: dashboardDetailState.variables,
+                variables_schema: dashboardDetailState.variablesSchema,
+                tags: { created_by: store.state.user.userId },
                 project_dashboard_id: props.dashboardId,
             });
         } else {
             await SpaceConnector.clientV2.dashboard.domainDashboard.update({
-                ...state.apiParam,
-                name: state.name,
+                name: dashboardDetailState.name,
+                labels: dashboardDetailState.labels,
+                settings: dashboardDetailState.settings,
+                layouts: [dashboardDetailState.dashboardWidgetInfoList],
+                variables: dashboardDetailState.variables,
+                variables_schema: dashboardDetailState.variablesSchema,
+                tags: { created_by: store.state.user.userId },
                 domain_dashboard_id: props.dashboardId,
             });
         }
@@ -111,85 +77,8 @@ const updateDashboardData = async () => {
         });
     } catch (e) {
         ErrorHandler.handleRequestError(e, i18n.t('DASHBOARDS.CUSTOMIZE.ALT_E_UPDATE_DASHBOARD'));
+    } finally {
+        state.loading = false;
     }
 };
-const createDashboard = async () => {
-    try {
-        if (dashboardDetailStore.isProjectDashboard) {
-            const result = await SpaceConnector.clientV2.dashboard.projectDashboard.create({
-                ...state.apiParam,
-                name: state.name,
-                viewers: dashboardDetailStore.dashboardViewer,
-                project_id: dashboardDetailState.projectId,
-            });
-            dashboardDetailStore.$patch({ dashboardId: result.project_dashboard_id });
-        } else {
-            const result = await SpaceConnector.clientV2.dashboard.domainDashboard.create({
-                ...state.apiParam,
-                name: state.name,
-                viewers: dashboardDetailStore.dashboardViewer,
-            });
-            dashboardDetailStore.$patch({ dashboardId: result.domain_dashboard_id });
-        }
-        const routeName = dashboardDetailStore.isProjectDashboard ? DASHBOARDS_ROUTE.PROJECT.DETAIL._NAME : DASHBOARDS_ROUTE.WORKSPACE.DETAIL._NAME;
-        await SpaceRouter.router.push({
-            name: routeName,
-            params: {
-                dashboardId: dashboardDetailState.dashboardId as string,
-            },
-        });
-    } catch (e) {
-        ErrorHandler.handleRequestError(e, i18n.t('DASHBOARDS.CUSTOMIZE.ALT_E_UPDATE_DASHBOARD'));
-    }
-};
-
-/* Event */
-const handleUpdateDashboardName = (name: string) => {
-    state.name = name;
-};
-const handleSave = async () => {
-    state.loading = true;
-    if (dashboardDetailState.dashboardId) await updateDashboardData();
-    if (dashboardDetailState.dashboardId === undefined) await createDashboard();
-    state.loading = false;
-};
-
-// for preventing refresh
-const handleUnload = (event) => {
-    event.preventDefault(); event.returnValue = '';
-};
-
-watch(() => dashboardDetailState.name, (name: string) => {
-    state.name = name;
-});
-
-onMounted(() => {
-    getDashboardData();
-    window.addEventListener('beforeunload', handleUnload);
-});
-
-onBeforeUnmount(() => {
-    window.removeEventListener('beforeunload', handleUnload);
-});
 </script>
-
-<style lang="postcss" scoped>
-.dashboard-customize-page {
-    @apply relative;
-    .filters-box {
-        @apply flex justify-between items-start;
-        margin-bottom: 1.3125rem;
-    }
-
-    .dashboard-selectors {
-        @apply relative flex justify-between items-start z-10;
-        padding: 1.5rem 0 1.25rem;
-
-        .variable-selector-wrapper {
-            @apply relative flex items-center flex-wrap;
-            gap: 0.5rem;
-            padding-right: 1rem;
-        }
-    }
-}
-</style>

--- a/apps/web/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/DashboardCustomizePage.vue
@@ -45,26 +45,23 @@ const updateDashboardData = async () => {
     try {
         state.loading = true;
 
+        const apiParam = {
+            name: dashboardDetailState.name,
+            labels: dashboardDetailState.labels,
+            settings: dashboardDetailState.settings,
+            layouts: [dashboardDetailState.dashboardWidgetInfoList],
+            variables: dashboardDetailState.variables,
+            variables_schema: dashboardDetailState.variablesSchema,
+            tags: { created_by: store.state.user.userId },
+        };
         if (dashboardDetailStore.isProjectDashboard) {
             await SpaceConnector.clientV2.dashboard.projectDashboard.update({
-                name: dashboardDetailState.name,
-                labels: dashboardDetailState.labels,
-                settings: dashboardDetailState.settings,
-                layouts: [dashboardDetailState.dashboardWidgetInfoList],
-                variables: dashboardDetailState.variables,
-                variables_schema: dashboardDetailState.variablesSchema,
-                tags: { created_by: store.state.user.userId },
+                ...apiParam,
                 project_dashboard_id: props.dashboardId,
             });
         } else {
             await SpaceConnector.clientV2.dashboard.domainDashboard.update({
-                name: dashboardDetailState.name,
-                labels: dashboardDetailState.labels,
-                settings: dashboardDetailState.settings,
-                layouts: [dashboardDetailState.dashboardWidgetInfoList],
-                variables: dashboardDetailState.variables,
-                variables_schema: dashboardDetailState.variablesSchema,
-                tags: { created_by: store.state.user.userId },
+                ...apiParam,
                 domain_dashboard_id: props.dashboardId,
             });
         }

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/DashboardCustomize.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/DashboardCustomize.vue
@@ -1,0 +1,149 @@
+<template>
+    <div class="dashboard-customize">
+        <dashboard-customize-page-name :name.sync="state.name"
+                                       :dashboard-id="props.dashboardId"
+                                       @update:name="handleUpdateDashboardName"
+                                       @click-back-button="goBack"
+        />
+        <div class="filters-box">
+            <dashboard-labels editable />
+            <dashboard-toolset />
+        </div>
+        <p-divider />
+        <div class="dashboard-selectors">
+            <dashboard-variables-select-dropdown class="variable-selector-wrapper"
+                                                 is-manageable
+            />
+            <dashboard-refresh-dropdown :dashboard-id="props.dashboardId"
+                                        refresh-disabled
+            />
+        </div>
+        <dashboard-widget-container edit-mode
+                                    reuse-previous-data
+        />
+        <dashboard-customize-sidebar :loading="props.loading"
+                                     :save-button-text="props.saveButtonText"
+                                     :hide-cancel-button="props.hideCancelButton"
+                                     @save="handleSave"
+                                     @cancel="goBack"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import {
+    computed, onBeforeUnmount, onMounted, reactive, watch,
+} from 'vue';
+import type { TranslateResult } from 'vue-i18n';
+
+import { PDivider } from '@spaceone/design-system';
+
+import { SpaceRouter } from '@/router';
+import { store } from '@/store';
+
+import ErrorHandler from '@/common/composables/error/errorHandler';
+
+import type {
+    DashboardConfig,
+} from '@/services/dashboards/config';
+import DashboardCustomizePageName
+    from '@/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue';
+import DashboardCustomizeSidebar from '@/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue';
+import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
+import DashboardToolset from '@/services/dashboards/shared/dashboard-toolset/DashboardToolset.vue';
+import DashboardVariablesSelectDropdown from '@/services/dashboards/shared/dashboard-variables/DashboardVariablesSelectDropdown.vue';
+import DashboardWidgetContainer from '@/services/dashboards/shared/dashboard-widget-container/DashboardWidgetContainer.vue';
+import DashboardLabels from '@/services/dashboards/shared/DashboardLabels.vue';
+import DashboardRefreshDropdown from '@/services/dashboards/shared/DashboardRefreshDropdown.vue';
+import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
+
+interface Props {
+    dashboardId?: string;
+    loading?: boolean;
+    saveButtonText?: TranslateResult;
+    hideCancelButton?: boolean;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{(e: 'go-back'): void,
+    (e: 'save'): void}>();
+const dashboardDetailStore = useDashboardDetailInfoStore();
+const dashboardDetailState = dashboardDetailStore.$state;
+
+const state = reactive({
+    name: dashboardDetailState.name,
+    apiParam: computed<Partial<DashboardConfig>>(() => ({
+        name: dashboardDetailState.name,
+        labels: dashboardDetailState.labels,
+        settings: dashboardDetailState.settings,
+        layouts: [dashboardDetailState.dashboardWidgetInfoList],
+        variables: dashboardDetailState.variables,
+        variables_schema: dashboardDetailState.variablesSchema,
+        tags: { created_by: store.state.user.userId },
+    })),
+    isCreateMode: computed(() => !props.dashboardId),
+});
+
+/* Api */
+const getDashboardData = async () => {
+    try {
+        await dashboardDetailStore.getDashboardInfo(props.dashboardId);
+    } catch (e) {
+        ErrorHandler.handleError(e);
+        await SpaceRouter.router.push({ name: DASHBOARDS_ROUTE.ALL._NAME });
+    }
+};
+
+
+
+/* Event */
+const handleUpdateDashboardName = (name: string) => {
+    state.name = name;
+};
+const handleSave = async () => {
+    dashboardDetailStore.$patch({ name: state.name });
+    emit('save');
+};
+const goBack = () => {
+    emit('go-back');
+};
+
+// for preventing refresh
+const handleUnload = (event) => {
+    event.preventDefault(); event.returnValue = '';
+};
+
+watch(() => dashboardDetailState.name, (name: string) => {
+    state.name = name;
+});
+
+onMounted(() => {
+    getDashboardData();
+    window.addEventListener('beforeunload', handleUnload);
+});
+
+onBeforeUnmount(() => {
+    window.removeEventListener('beforeunload', handleUnload);
+});
+</script>
+
+<style lang="postcss" scoped>
+.dashboard-customize {
+    @apply relative;
+    .filters-box {
+        @apply flex justify-between items-start;
+        margin-bottom: 1.3125rem;
+    }
+
+    .dashboard-selectors {
+        @apply relative flex justify-between items-start z-10;
+        padding: 1.5rem 0 1.25rem;
+
+        .variable-selector-wrapper {
+            @apply relative flex items-center flex-wrap;
+            gap: 0.5rem;
+            padding-right: 1rem;
+        }
+    }
+}
+</style>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
This PR is previous PR to reuse DashboardCustomize component in DashbardCreatePage's third step.

### Things to Talk About
