### PR TITLE
feat(dashboard-create-page): add third step (customize step)

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/apps/web/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -195,30 +195,24 @@ export default {
             try {
                 state.loading = true;
 
+                const apiParam = {
+                    name: dashboardDetailState.name,
+                    labels: dashboardDetailState.labels,
+                    settings: dashboardDetailState.settings,
+                    layouts: [dashboardDetailState.dashboardWidgetInfoList],
+                    variables: dashboardDetailState.variables,
+                    variables_schema: dashboardDetailState.variablesSchema,
+                    tags: { created_by: store.state.user.userId },
+                    viewers: dashboardDetailStore.dashboardViewer,
+                };
                 if (dashboardDetailStore.isProjectDashboard) {
                     const result = await SpaceConnector.clientV2.dashboard.projectDashboard.create({
-                        name: dashboardDetailState.name,
-                        labels: dashboardDetailState.labels,
-                        settings: dashboardDetailState.settings,
-                        layouts: [dashboardDetailState.dashboardWidgetInfoList],
-                        variables: dashboardDetailState.variables,
-                        variables_schema: dashboardDetailState.variablesSchema,
-                        tags: { created_by: store.state.user.userId },
-                        viewers: dashboardDetailStore.dashboardViewer,
+                        ...apiParam,
                         project_id: dashboardDetailState.projectId,
                     });
                     dashboardDetailStore.$patch({ dashboardId: result.project_dashboard_id });
                 } else {
-                    const result = await SpaceConnector.clientV2.dashboard.domainDashboard.create({
-                        name: dashboardDetailState.name,
-                        labels: dashboardDetailState.labels,
-                        settings: dashboardDetailState.settings,
-                        layouts: [dashboardDetailState.dashboardWidgetInfoList],
-                        variables: dashboardDetailState.variables,
-                        variables_schema: dashboardDetailState.variablesSchema,
-                        tags: { created_by: store.state.user.userId },
-                        viewers: dashboardDetailStore.dashboardViewer,
-                    });
+                    const result = await SpaceConnector.clientV2.dashboard.domainDashboard.create(apiParam);
                     dashboardDetailStore.$patch({ dashboardId: result.domain_dashboard_id });
                 }
                 const routeName = dashboardDetailStore.isProjectDashboard ? DASHBOARDS_ROUTE.PROJECT.DETAIL._NAME : DASHBOARDS_ROUTE.WORKSPACE.DETAIL._NAME;

--- a/apps/web/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/apps/web/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="dashboard-create-page">
-        <div v-if="currentStep === steps[0].step"
-             class="dashboard-create-step1"
-        >
+    <div class="dashboard-create-page"
+         :class="`step-${currentStep}`"
+    >
+        <template v-if="currentStep === steps[0].step">
             <dashboard-create-header
                 :description="steps[currentStep - 1].description"
                 :total-steps="steps.length"
@@ -24,15 +24,13 @@
                     style-type="primary"
                     size="lg"
                     :disabled="!isValid"
-                    @click="handleGoStep('next')"
+                    @click="goStep('next')"
                 >
                     {{ $t('DASHBOARDS.CREATE.CONTINUE') }}
                 </p-button>
             </div>
-        </div>
-        <div v-if="currentStep === steps[1].step"
-             class="dashboard-create-step2"
-        >
+        </template>
+        <template v-if="currentStep === steps[1].step">
             <dashboard-create-header
                 :description="steps[currentStep - 1].description"
                 :total-steps="steps.length"
@@ -47,7 +45,7 @@
                     style-type="transparent"
                     size="lg"
                     icon-left="ic_arrow-left"
-                    @click="handleGoStep('prev')"
+                    @click="goStep('prev')"
                 >
                     {{ $t('DASHBOARDS.CREATE.GO_BACK') }}
                 </p-button>
@@ -55,12 +53,26 @@
                     style-type="primary"
                     size="lg"
                     :disabled="!isAllValid"
-                    @click="handleClickCreate"
+                    @click="goStep('next')"
                 >
-                    {{ $t('DASHBOARDS.CREATE.CREATE_NEW_DASHBOARD') }}
+                    {{ $t('DASHBOARDS.CREATE.CONTINUE') }}
                 </p-button>
             </div>
-        </div>
+        </template>
+        <template v-if="currentStep === steps[2].step">
+            <div class="dashboard-customize-wrapper">
+                <dashboard-create-header :total-steps="steps.length"
+                                         :current-step="currentStep"
+                                         description=""
+                />
+                <dashboard-customize :loading="loading"
+                                     :save-button-text="$t('DASHBOARDS.CREATE.CREATE_NEW_DASHBOARD')"
+                                     hide-cancel-button
+                                     @go-back="goStep('prev')"
+                                     @save="createDashboard"
+                />
+            </div>
+        </template>
     </div>
 </template>
 
@@ -71,9 +83,13 @@ import {
     PButton,
 } from '@spaceone/design-system';
 
+import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+
 import { SpaceRouter } from '@/router';
+import { store } from '@/store';
 import { i18n } from '@/translations';
 
+import ErrorHandler from '@/common/composables/error/errorHandler';
 import { useFormValidator } from '@/common/composables/form-validator';
 
 import {
@@ -85,14 +101,19 @@ import DashboardCreateHeader from '@/services/dashboards/dashboard-create/module
 import DashboardScopeForm from '@/services/dashboards/dashboard-create/modules/DashboardScopeForm.vue';
 import DashboardTemplateForm from '@/services/dashboards/dashboard-create/modules/DashboardTemplateForm.vue';
 import DashboardViewerForm from '@/services/dashboards/dashboard-create/modules/DashboardViewerForm.vue';
+import DashboardCustomize from '@/services/dashboards/dashboard-customize/modules/DashboardCustomize.vue';
 import type { DashboardModel } from '@/services/dashboards/model';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
 import type { ProjectItemResp } from '@/services/project/type';
 
+
+
+
 export default {
     name: 'CreateDashboardPage',
     components: {
+        DashboardCustomize,
         DashboardCreateHeader,
         DashboardViewerForm,
         DashboardTemplateForm,
@@ -101,6 +122,7 @@ export default {
     },
     setup() {
         const dashboardDetailStore = useDashboardDetailInfoStore();
+        const dashboardDetailState = dashboardDetailStore.$state;
         const {
             forms: { dashboardTemplate, dashboardProject },
             setForm,
@@ -119,11 +141,13 @@ export default {
         });
 
         const state = reactive({
+            loading: false,
             dashboardScope: DASHBOARD_SCOPE.DOMAIN as DashboardScope,
             dashboardViewerType: DASHBOARD_VIEWER.PUBLIC as DashboardViewer,
             steps: computed(() => [
                 { step: 1, description: i18n.t('DASHBOARDS.CREATE.STEP1_DESC') },
                 { step: 2, description: i18n.t('DASHBOARDS.CREATE.STEP2_DESC') },
+                { step: 3 },
             ]),
             currentStep: 1,
             isValid: computed(() => {
@@ -133,12 +157,15 @@ export default {
             }),
         });
 
-        const handleGoStep = (direction: 'prev'|'next') => {
+        const goStep = (direction: 'prev'|'next') => {
+            if (state.currentStep === 2 && direction === 'next') {
+                saveCurrentStateToStore();
+            }
             if (direction === 'prev') state.currentStep--;
             else state.currentStep++;
         };
 
-        const handleClickCreate = () => {
+        const saveCurrentStateToStore = () => {
             let _dashboardTemplate;
             if (state.dashboardScope === DASHBOARD_SCOPE.PROJECT) {
                 _dashboardTemplate = {
@@ -162,8 +189,50 @@ export default {
                 dashboardId: undefined,
                 placeholder: dashboardTemplate.value.name,
             });
-            const routeName = state.dashboardScope === DASHBOARD_SCOPE.PROJECT ? DASHBOARDS_ROUTE.PROJECT.CUSTOMIZE._NAME : DASHBOARDS_ROUTE.WORKSPACE.CUSTOMIZE._NAME;
-            SpaceRouter.router.push({ name: routeName });
+        };
+
+        const createDashboard = async () => {
+            try {
+                state.loading = true;
+
+                if (dashboardDetailStore.isProjectDashboard) {
+                    const result = await SpaceConnector.clientV2.dashboard.projectDashboard.create({
+                        name: dashboardDetailState.name,
+                        labels: dashboardDetailState.labels,
+                        settings: dashboardDetailState.settings,
+                        layouts: [dashboardDetailState.dashboardWidgetInfoList],
+                        variables: dashboardDetailState.variables,
+                        variables_schema: dashboardDetailState.variablesSchema,
+                        tags: { created_by: store.state.user.userId },
+                        viewers: dashboardDetailStore.dashboardViewer,
+                        project_id: dashboardDetailState.projectId,
+                    });
+                    dashboardDetailStore.$patch({ dashboardId: result.project_dashboard_id });
+                } else {
+                    const result = await SpaceConnector.clientV2.dashboard.domainDashboard.create({
+                        name: dashboardDetailState.name,
+                        labels: dashboardDetailState.labels,
+                        settings: dashboardDetailState.settings,
+                        layouts: [dashboardDetailState.dashboardWidgetInfoList],
+                        variables: dashboardDetailState.variables,
+                        variables_schema: dashboardDetailState.variablesSchema,
+                        tags: { created_by: store.state.user.userId },
+                        viewers: dashboardDetailStore.dashboardViewer,
+                    });
+                    dashboardDetailStore.$patch({ dashboardId: result.domain_dashboard_id });
+                }
+                const routeName = dashboardDetailStore.isProjectDashboard ? DASHBOARDS_ROUTE.PROJECT.DETAIL._NAME : DASHBOARDS_ROUTE.WORKSPACE.DETAIL._NAME;
+                await SpaceRouter.router.push({
+                    name: routeName,
+                    params: {
+                        dashboardId: dashboardDetailState.dashboardId as string,
+                    },
+                });
+            } catch (e) {
+                ErrorHandler.handleRequestError(e, i18n.t('DASHBOARDS.CUSTOMIZE.ALT_E_UPDATE_DASHBOARD'));
+            } finally {
+                state.loading = false;
+            }
         };
 
         return {
@@ -172,57 +241,47 @@ export default {
             dashboardProject,
             setForm,
             isAllValid,
-            handleClickCreate,
-            handleGoStep,
+            goStep,
+            createDashboard,
         };
     },
 };
 </script>
 
 <style lang="postcss" scoped>
-.button-area {
-    @apply flex justify-end mt-8 gap-4;
-}
 .dashboard-create-page {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     width: 100%;
-    .dashboard-create-step1 {
-        @apply w-full;
+    height: 100%;
+    &.step-1 {
+        @apply w-full h-full;
         max-width: 30rem;
-        padding: 2.5rem;
-        margin: 0 auto;
-
-        .p-button {
-            &.transparent {
-                &:focus {
-                    @apply text-gray-900;
-                }
-                &:hover {
-                    @apply text-blue-600;
-                }
-            }
-        }
 
         @screen tablet {
             @apply w-full;
         }
     }
-
-    .dashboard-create-step2 {
+    &.step-2 {
         width: 62.5rem;
-        margin: 0 auto;
-        padding: 2rem 1.5rem 4.0625rem;
 
         @screen tablet {
-            @apply w-full p-8;
+            @apply w-full;
 
             .button-area {
                 @apply flex-col w-full mt-4;
             }
         }
-        .dashboard-create-header {
-            @apply mb-8;
+    }
+    &.step-3 {
+        .dashboard-customize-wrapper {
+            width: 100%;
+            height: 100%;
         }
     }
+    .button-area {
+        @apply flex justify-end mt-8 gap-4;
+    }
 }
-
 </style>

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/DashboardCustomizePageName.vue
@@ -1,6 +1,6 @@
 <template>
     <p-heading show-back-button
-               @click-back-button="$router.go(-1)"
+               @click-back-button="handleClickBackButton"
     >
         <template v-if="props.dashboardId">
             <p-field-group v-if="dashboardDetailState.name"
@@ -64,7 +64,8 @@ const props = defineProps<{
     name: string;
     dashboardId?: string;
 }>();
-const emit = defineEmits<{(e: string, value: string): void}>();
+const emit = defineEmits<{(e: 'update:name', value?: string): void,
+    (e: 'click-back-button'): void}>();
 
 
 const dashboardDetailStore = useDashboardDetailInfoStore();
@@ -121,6 +122,9 @@ const handleEnter = () => {
     if (invalidState.nameInput) {
         updateName(props.name);
     }
+};
+const handleClickBackButton = () => {
+    emit('click-back-button');
 };
 
 watch(() => props.name, (d) => {

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/DashboardCustomizeSidebar.vue
@@ -68,7 +68,8 @@
         </portal>
         <portal to="widget-footer">
             <div class="footer-wrapper">
-                <p-button style-type="transparent"
+                <p-button v-if="!props.hideCancelButton"
+                          style-type="transparent"
                           :disabled="props.loading"
                           @click="handleClickCancelButton"
                 >
@@ -79,7 +80,7 @@
                           :loading="props.loading"
                           @click="handleClickSaveButton"
                 >
-                    {{ $t('DASHBOARDS.CUSTOMIZE.SAVE') }}
+                    {{ props.saveButtonText || $t('DASHBOARDS.CUSTOMIZE.SAVE') }}
                 </p-button>
             </div>
         </portal>
@@ -95,13 +96,13 @@ import {
     defineEmits,
     onMounted, onUnmounted, reactive,
 } from 'vue';
+import type { TranslateResult } from 'vue-i18n';
 import draggable from 'vuedraggable';
 
 import {
     PButton, PDivider, PI, PToggleButton, PFieldTitle,
 } from '@spaceone/design-system';
 
-import { SpaceRouter } from '@/router';
 import { store } from '@/store';
 
 import DashboardWidgetAddModal from '@/services/dashboards/dashboard-customize/modules/dashboard-widget-add-modal/DashboardWidgetAddModal.vue';
@@ -110,11 +111,14 @@ import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/_c
 
 interface Props {
     loading?: boolean;
+    saveButtonText?: TranslateResult;
+    hideCancelButton?: boolean;
 }
 
 const props = defineProps<Props>();
 const emit = defineEmits<{(e: string, value: string): void,
     (e: 'save'): void,
+    (e: 'cancel'): void,
 }>();
 
 const dashboardDetailStore = useDashboardDetailInfoStore();
@@ -141,7 +145,7 @@ const handleClickAddWidget = () => {
     state.addWidgetModalVisible = true;
 };
 const handleClickCancelButton = () => {
-    SpaceRouter.router.back();
+    emit('cancel');
     // TODO: revert dashboardState here
 };
 const handleClickSaveButton = () => {
@@ -215,12 +219,12 @@ onUnmounted(() => {
     }
 }
 .footer-wrapper {
-    @apply grid grid-cols-12 border-t border-gray-200;
+    @apply flex border-t border-gray-200;
     width: 100%;
     gap: 0.75rem;
     padding: 0.75rem 1rem;
-    button {
-        @apply col-span-6;
+    .p-button {
+        width: 100%;
     }
 }
 </style>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

Added step 3 for dashboard create page.
Originally, the url was changed to 'customize' page for step3. 
It is updated not to change the url.

https://github.com/cloudforet-io/console/assets/26986739/a5844550-c402-4ec9-9c32-baa3283e9c1a





### Things to Talk About
