### PR TITLE
fix(p-definition-table): fix display error if the value is false

### DIFF
--- a/packages/mirinae/src/data-display/tables/definition-table/PDefinitionTable.vue
+++ b/packages/mirinae/src/data-display/tables/definition-table/PDefinitionTable.vue
@@ -127,7 +127,10 @@ export default defineComponent<DefinitionTableProps>({
     setup(props) {
         const state = reactive({
             contextKey: Math.floor(Math.random() * Date.now()),
-            isNoData: computed(() => every(state.items, (def) => !def.data)),
+            isNoData: computed(() => every(state.items, (def) => {
+                if (typeof def.data === 'boolean') return false;
+                return !def.data;
+            })),
             skeletons: computed(() => range(props.skeletonRows ?? 5)),
             items: computed(() => makeDefItems(props.fields, props.data)),
         });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
When determining `isNoData`, during the process of checking all the values in the table, `false` values themselves are considered as representing no data, resulting in the absence of data representation.


![image](https://github.com/cloudforet-io/console/assets/50662170/ef3701ee-a19f-4594-8243-e102d26a7993)


### Things to Talk About
