### PR TITLE
fix(heading): do not give fixed height

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-main/CollectorMainPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-main/CollectorMainPage.vue
@@ -154,27 +154,10 @@ onMounted(async () => {
 </script>
 
 <style lang="postcss" scoped>
-/* custom design-system component - p-heading */
-:deep(.p-heading) {
-    @apply items-center;
-
-    .heading-wrapper {
-        flex: 1;
-
-        .total-count {
-            @apply font-normal;
-        }
-    }
-
-    .extra {
-        flex-grow: initial;
-
-        .history-button {
-            @apply bg-white rounded border border-gray-300 text-label-md font-bold;
-            width: 100%;
-            padding: 0.375rem 0.75rem;
-        }
-    }
+.history-button {
+    @apply bg-white rounded border border-gray-300 text-label-md font-bold;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
 }
 
 .collector-loader-wrapper {

--- a/packages/mirinae/src/data-display/heading/PHeading.vue
+++ b/packages/mirinae/src/data-display/heading/PHeading.vue
@@ -100,6 +100,7 @@ export default defineComponent<Props>({
 
 <style lang="postcss">
 .p-heading {
+    gap: 0.5rem;
     &.heading-main {
         display: flex;
         align-items: flex-start;
@@ -113,29 +114,22 @@ export default defineComponent<Props>({
                 }
             }
             > .total-count {
-                font-weight: bold;
-
                 @apply text-gray-900;
             }
-        }
-        > .extra {
-            margin-left: 0.5rem;
         }
     }
     &.heading-sub {
         display: flex;
         align-items: center;
-        height: 2rem;
+        line-height: 2rem;
         margin: 2rem 1rem 1rem 1rem;
         > .heading-wrapper {
             line-height: 1.2;
             > .total-count {
                 @apply text-gray-500;
                 padding-left: 0.125rem;
+                font-weight: normal;
             }
-        }
-        > .extra {
-            padding-left: 1rem;
         }
     }
     > .heading-wrapper {
@@ -164,6 +158,10 @@ export default defineComponent<Props>({
     }
     > .extra {
         flex-grow: 1;
+    }
+
+    @screen mobile {
+        flex-wrap: wrap;
     }
 }
 </style>

--- a/packages/mirinae/src/inputs/buttons/icon-button/PIconButton.stories.mdx
+++ b/packages/mirinae/src/inputs/buttons/icon-button/PIconButton.stories.mdx
@@ -29,6 +29,7 @@ export const Template = (args, { argTypes }) => ({
                 :loading="loading"
                 :size="size"
                 :animation="animation"
+                :shape="shape"
             />
         </div>
     `,

--- a/packages/mirinae/src/inputs/buttons/icon-button/story-helper.ts
+++ b/packages/mirinae/src/inputs/buttons/icon-button/story-helper.ts
@@ -2,7 +2,7 @@ import type { ArgTypes } from '@storybook/addons';
 import icon from 'vue-svgicon';
 
 import { ANIMATION_TYPE } from '@/foundation/icons/config';
-import { ICON_BUTTON_STYLE_TYPE } from '@/inputs/buttons/icon-button/type';
+import { ICON_BUTTON_SHAPE, ICON_BUTTON_STYLE_TYPE } from '@/inputs/buttons/icon-button/type';
 
 
 export const getIconButtonArgTypes = (): ArgTypes => ({
@@ -170,6 +170,25 @@ export const getIconButtonArgTypes = (): ArgTypes => ({
         control: {
             type: 'select',
             options: Object.values(ANIMATION_TYPE),
+        },
+    },
+    shape: {
+        name: 'shape',
+        type: { name: 'string' },
+        description: `Shape of icon button. ${Object.values(ICON_BUTTON_SHAPE).map((d) => `'${d}'`)} are available.`,
+        defaultValue: ICON_BUTTON_SHAPE.circle,
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: ICON_BUTTON_SHAPE.circle,
+            },
+        },
+        control: {
+            type: 'select',
+            options: Object.values(ICON_BUTTON_SHAPE),
         },
     },
     // slots


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

Checked all components that use PHeading component.

AS IS
![image](https://github.com/cloudforet-io/console/assets/26986739/850c8435-efa5-4a9e-98d5-0768def82f2e)

TO BE
![image](https://github.com/cloudforet-io/console/assets/26986739/afcb1000-0bfb-48af-9660-2c9c66c5c5f3)


### Things to Talk About

When we develop the text related component, we have to think about much more cases.
**We must consider when the text is very long.**
If this component has fixed height, the text will be hidden.
So, use `line-height` instead of `height`.
**Also, consider the mobile size.**




