### PR TITLE
fix(centered-layout): observe layout contents resize

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
+++ b/apps/web/src/services/dashboards/dashboard-create/DashboardCreatePage.vue
@@ -284,6 +284,7 @@ export default {
     &.step-3 {
         width: 100%;
         height: 100%;
+        min-height: calc(100vh - 8rem);
     }
     .button-area {
         @apply flex justify-end mt-8 gap-4;

--- a/packages/mirinae/src/layouts/centered-layout/PCenteredLayout.vue
+++ b/packages/mirinae/src/layouts/centered-layout/PCenteredLayout.vue
@@ -1,7 +1,5 @@
 <template>
-    <div ref="containerRef"
-         class="p-centered-layout"
-    >
+    <div class="p-centered-layout">
         <div v-if="$slots['top-contents']"
              class="top-contents-wrapper"
         >
@@ -11,7 +9,11 @@
              class="layout-contents-wrapper"
              :class="{ 'contents-over-wrapper': isContentsOverWrapper }"
         >
-            <slot />
+            <div ref="layoutContentsRef"
+                 class="layout-contents"
+            >
+                <slot />
+            </div>
         </div>
     </div>
 </template>
@@ -19,13 +21,14 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue';
 
-const containerRef = ref<HTMLElement|null>(null);
 const layoutWrapperRef = ref<HTMLElement|null>(null);
+const layoutContentsRef = ref<HTMLElement|null>(null);
 const isContentsOverWrapper = ref(false);
 
 const observer = new ResizeObserver((entries) => {
-    const containerClientHeight = containerRef.value?.clientHeight ?? 0;
-    if (entries[0].target.scrollHeight > containerClientHeight) {
+    if (!layoutWrapperRef.value) return;
+    const wrapperClientHeight = layoutWrapperRef.value.clientHeight;
+    if (entries[0].target.scrollHeight > wrapperClientHeight) {
         isContentsOverWrapper.value = true;
     } else {
         isContentsOverWrapper.value = false;
@@ -33,7 +36,7 @@ const observer = new ResizeObserver((entries) => {
 });
 
 onMounted(() => {
-    if (layoutWrapperRef.value) observer.observe(layoutWrapperRef.value);
+    if (layoutContentsRef.value) observer.observe(layoutContentsRef.value);
 });
 onUnmounted(() => {
     observer.disconnect();
@@ -75,6 +78,11 @@ onUnmounted(() => {
         padding: 2rem 2.5rem;
         &.contents-over-wrapper {
             justify-content: flex-start;
+        }
+        .layout-contents {
+            display: flex;
+            width: 100%;
+            justify-content: center;
         }
     }
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

#### Fixed PCenteredLayout component bug
Add div inside of the wrapper div element to observe contents area's height changes.

### Things to Talk About
