### PR TITLE
feat(definition-table): apply custom width of key

### DIFF
--- a/apps/web/src/services/administration/iam/user/modules/user-management-tab/UserDetail.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-tab/UserDetail.vue
@@ -181,7 +181,6 @@ watch(() => userPageState.visibleUpdateModal, (value) => {
     }
     &.block {
         .extra {
-            width: 11.375rem;
             height: 1.5rem;
             margin-top: -0.125rem;
             margin-left: 0;

--- a/apps/web/src/services/alert-manager/alert/alert-detail/modules/alert-key-info/AlertKeyInfo.vue
+++ b/apps/web/src/services/alert-manager/alert/alert-detail/modules/alert-key-info/AlertKeyInfo.vue
@@ -3,6 +3,7 @@
         <p-definition-table :fields="fields"
                             :data="data"
                             :skeleton-rows="10"
+                            custom-width="10rem"
                             style-type="white"
                             block
         >
@@ -209,14 +210,6 @@ export default {
     :deep(.p-definition) {
         .key {
             @apply capitalize;
-            width: 10rem;
-        }
-        .value-wrapper {
-            max-width: calc(100% - 10rem);
-
-            @screen tablet {
-                max-width: none;
-            }
         }
     }
 }

--- a/packages/mirinae/src/data-display/tables/definition-table/PDefinitionTable.stories.mdx
+++ b/packages/mirinae/src/data-display/tables/definition-table/PDefinitionTable.stories.mdx
@@ -27,13 +27,13 @@ export const Template = (args, { argTypes }) => ({
     :disable-copy="disableCopy"
     :style-type="styleType"
     :block="block"
+    :custom-width="customWidth"
 />`,
     setup() {
         return {
         }
     }
 });
-
 
 # Definition Table
 
@@ -44,9 +44,8 @@ export const Template = (args, { argTypes }) => ({
 It uses the [Definition component](?path=/docs/data-display-tables-definition-table-definition--basic) internally. <br/>
 `fields` props is an array of objects whose properties are the set of definition component's props. <br/>
 
-
-
 ## Basic
+
 <Canvas>
     <Story name="Basic">
 {{
@@ -90,11 +89,8 @@ It uses the [Definition component](?path=/docs/data-display-tables-definition-ta
     </Story>
 </Canvas>
 
-<br/>
-<br/>
-
-
 ## No Data
+
 <Canvas>
     <Story name="No Data">
         {{
@@ -105,9 +101,6 @@ It uses the [Definition component](?path=/docs/data-display-tables-definition-ta
         }}
     </Story>
 </Canvas>
-
-<br/>
-<br/>
 
 ## Loading
 
@@ -149,9 +142,6 @@ It uses the [Definition component](?path=/docs/data-display-tables-definition-ta
     </Story>
 </Canvas>
 
-<br/>
-<br/>
-
 ## Slots
 
 | Slot name | Description |
@@ -164,12 +154,7 @@ It uses the [Definition component](?path=/docs/data-display-tables-definition-ta
 | loading | Slot for replacing loader. |
 | no-data | Slot for no data case. |
 
-<br/>
-<br/>
-
 ### SlotScope(Props)
-
-<br/>
 
 > Except for `no-data` and `loading` slots, all slots provide slot props below:
 
@@ -181,9 +166,6 @@ It uses the [Definition component](?path=/docs/data-display-tables-definition-ta
 | value | The actual data. it's usually the same with 'data'. it's different only when 'formatter(data)' is different value with 'data'. |
 | items | All field and data items ordered by `fields` props. |
 | index | Current item's index. |
-
-<br/>
-<br/>
 
 <Canvas>
     <Story name="Slots">
@@ -279,10 +261,6 @@ It uses the [Definition component](?path=/docs/data-display-tables-definition-ta
     </Story>
 </Canvas>
 
-<br/>
-<br/>
-
-
 ## Disable Copy
 
 If you give `true` to `disableCopy` props, it globally off all copy buttons. <br/>
@@ -297,7 +275,6 @@ fields: [
     { label: 'Provider', name: 'provider', disableCopy: true }, // will be hide copy button to this field
 ]
 ```
-
 
 <Canvas>
     <Story name="Disable Copy">
@@ -345,9 +322,6 @@ fields: [
     </Story>
 </Canvas>
 
-<br/>
-<br/>
-
 ## Custom Copy Value
 
 You can customize the value to be copied by giving ```copyValue``` or ```copyValueFormatter``` properties to each field item. <br/>
@@ -392,10 +366,6 @@ You can customize the value to be copied by giving ```copyValue``` or ```copyVal
     </Story>
 </Canvas>
 
-<br/>
-<br/>
-
-
 ## Block
 
 If you give `true` to `block` props, it will make all value column's width full. <br/>
@@ -411,7 +381,6 @@ fields: [
     { label: 'Provider', name: 'provider', block: true }, // will be make block to only this field
 ]
 ```
-
 
 <Canvas>
     <Story name="Block">
@@ -462,10 +431,6 @@ fields: [
     </Story>
 </Canvas>
 
-<br/>
-<br/>
-
-
 ## Style Types
 
 <Canvas>
@@ -509,9 +474,6 @@ fields: [
         }}
     </Story>
 </Canvas>
-
-<br/>
-<br/>
 
 ## UI Structure and CSS
 

--- a/packages/mirinae/src/data-display/tables/definition-table/PDefinitionTable.vue
+++ b/packages/mirinae/src/data-display/tables/definition-table/PDefinitionTable.vue
@@ -20,6 +20,7 @@
                               :disable-copy="disableCopy || item.disableCopy"
                               :formatter="item.formatter"
                               :block="block || item.block"
+                              :custom-width="customWidth || undefined"
                               :copy-value="item.copyValue"
                               :copy-value-formatter="item.copyValueFormatter"
                 >
@@ -122,6 +123,10 @@ export default defineComponent<DefinitionTableProps>({
         block: {
             type: Boolean,
             default: false,
+        },
+        customWidth: {
+            type: String,
+            default: undefined,
         },
     },
     setup(props) {

--- a/packages/mirinae/src/data-display/tables/definition-table/definition/PDefinition.stories.mdx
+++ b/packages/mirinae/src/data-display/tables/definition-table/definition/PDefinition.stories.mdx
@@ -30,6 +30,7 @@ export const Template = (args, { argTypes }) => ({
     :block="block"
     :copy-value="copyValue"
     :auto-key-width="autoKeyWidth"
+    :custom-width="customWidth"
 >
 </p-definition>`,
     setup(props) {
@@ -38,13 +39,11 @@ export const Template = (args, { argTypes }) => ({
     }
 });
 
-
 # Definition
 
 <br/>
 <br/>
 <br/>
-
 
 ## Basic
 
@@ -135,9 +134,6 @@ export const Template = (args, { argTypes }) => ({
     </Story>
 </Canvas>
 
-<br/>
-<br/>
-
 ## Custom Copy Value
 
 <Canvas>
@@ -180,9 +176,6 @@ export const Template = (args, { argTypes }) => ({
     </Story>
 </Canvas>
 
-<br/>
-<br/>
-
 ## With Formatter
 
 <Canvas>
@@ -220,10 +213,6 @@ export const Template = (args, { argTypes }) => ({
         }}
     </Story>
 </Canvas>
-
-<br/>
-<br/>
-
 
 ## Block
 
@@ -342,6 +331,49 @@ export const Template = (args, { argTypes }) => ({
                         booleanData: true,
                         numberData: 13,
                         longStringData: faker.lorem.sentence(30),
+                    }
+                });
+                return {
+                    ...toRefs(state),
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+## Custom Width of Key
+
+<Canvas>
+    <Story name="Custom Width of Key">
+        {{
+            components:{ PDefinition },
+            template: `
+<table>
+    <tbody>
+        <p-definition
+            name="string data"
+            :data="data.stringData"
+            custom-width="10rem"
+        />
+        <p-definition
+            name="object data"
+            :data="data.objectData"
+            custom-width="20rem"
+        />
+        <p-definition
+            name="array data"
+            :data="data.arrayData"
+            custom-width="30rem"
+        />
+    </tbody>
+</table>
+`,
+            setup() {
+                const state = reactive({
+                    data: {
+                        stringData: 'string data',
+                        objectData: {name: 'object data'},
+                        arrayData: ['array', 'data'],
                     }
                 });
                 return {

--- a/packages/mirinae/src/data-display/tables/definition-table/definition/PDefinition.vue
+++ b/packages/mirinae/src/data-display/tables/definition-table/definition/PDefinition.vue
@@ -4,6 +4,7 @@
     >
         <td class="key"
             :class="{'auto-width': autoKeyWidth, 'no-copy-button': disableCopy}"
+            :style="{ minWidth: customWidth }"
         >
             <slot name="key"
                   v-bind="{name, label, data, value: displayData}"
@@ -123,6 +124,10 @@ export default defineComponent<DefinitionProps>({
             type: Boolean,
             default: false,
         },
+        customWidth: {
+            type: String,
+            default: undefined,
+        },
     },
     setup(props) {
         const state = reactive({
@@ -145,30 +150,25 @@ export default defineComponent<DefinitionProps>({
     display: flex;
     > .key {
         @apply font-bold;
-        width: 18rem;
+        min-width: 18rem;
         padding: 0.65rem 1rem 0.35rem 1rem;
         font-size: 0.875rem;
         line-height: 1.25;
 
         &.auto-width {
-            width: auto;
+            min-width: auto;
         }
         &.no-copy-button {
             padding: 0.5rem 1rem;
         }
     }
     > .value-wrapper {
-        max-width: calc(100% - 18rem);
         display: inline-flex;
         align-items: center;
         flex-grow: 1;
         flex-wrap: wrap;
         padding: 0.5rem 1rem;
         font-size: 0.875rem;
-
-        &.auto-width {
-            max-width: none;
-        }
 
         > .value {
             line-height: 1.25;

--- a/packages/mirinae/src/data-display/tables/definition-table/definition/story-helper.ts
+++ b/packages/mirinae/src/data-display/tables/definition-table/definition/story-helper.ts
@@ -148,6 +148,21 @@ export const getDefinitionArgTypes = (): ArgTypes => ({
             },
         },
     },
+    customWidth: {
+        name: 'customWidth',
+        type: { name: 'string' },
+        description: 'Custom Width of key',
+        defaultValue: undefined,
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'undefined',
+            },
+        },
+    },
     /* slots */
     defaultSlot: {
         name: 'default',

--- a/packages/mirinae/src/data-display/tables/definition-table/definition/type.ts
+++ b/packages/mirinae/src/data-display/tables/definition-table/definition/type.ts
@@ -9,5 +9,6 @@ export interface DefinitionProps {
     block?: boolean;
     copyValue?: string|number;
     copyValueFormatter?: (data: any, props: DefinitionProps) => string|number;
-    autoKeyWidth?: string;
+    autoKeyWidth?: boolean;
+    customWidth?: string;
 }

--- a/packages/mirinae/src/data-display/tables/definition-table/story-helper.ts
+++ b/packages/mirinae/src/data-display/tables/definition-table/story-helper.ts
@@ -135,4 +135,19 @@ export const getDefinitionTableArgTypes = (): ArgTypes => ({
             },
         },
     },
+    customWidth: {
+        name: 'customWidth',
+        type: { name: 'string' },
+        description: 'Custom Width of table key',
+        defaultValue: undefined,
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'undefined',
+            },
+        },
+    },
 });

--- a/packages/mirinae/src/data-display/tables/definition-table/type.ts
+++ b/packages/mirinae/src/data-display/tables/definition-table/type.ts
@@ -13,6 +13,7 @@ export interface DefinitionTableProps {
     disableCopy?: boolean;
     styleType?: DEFINITION_TABLE_STYLE_TYPE;
     block?: boolean;
+    customWidth?: string;
 }
 
 export type DefinitionField = Omit<DefinitionProps, 'data'>;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [x] Apps
  - [x] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- apply custom width of key at definition-table(+ definition)

### Things to Talk About
