### PR TITLE
refactor: use useDocumentVisibility composable

### DIFF
--- a/apps/web/src/common/modules/navigations/gnb/modules/gnb-noti/GNBNoti.vue
+++ b/apps/web/src/common/modules/navigations/gnb/modules/gnb-noti/GNBNoti.vue
@@ -43,6 +43,7 @@
 <script lang="ts">
 
 import { vOnClickOutside } from '@vueuse/components';
+import { useDocumentVisibility } from '@vueuse/core';
 import {
     computed, defineComponent, onMounted, onUnmounted, reactive, toRefs, watch,
 } from 'vue';
@@ -132,13 +133,14 @@ export default defineComponent<Props>({
             userId: computed(() => store.state.user.userId),
         });
 
-        const handleBrowserVisibilityChange = () => {
-            if (document.hidden) {
+        const documentVisibility = useDocumentVisibility();
+        watch(documentVisibility, (visibility) => {
+            if (visibility === 'hidden') {
                 store.dispatch('display/stopCheckNotification');
             } else {
                 store.dispatch('display/startCheckNotification');
             }
-        };
+        }, { immediate: true });
 
         /* Event */
         const handleNotiButtonClick = () => {
@@ -148,18 +150,17 @@ export default defineComponent<Props>({
 
         onMounted(() => {
             store.dispatch('display/startCheckNotification');
-            document.addEventListener('visibilitychange', handleBrowserVisibilityChange, false);
             fetchNoticeReadState();
             fetchNoticeCount();
         });
         onUnmounted(() => {
             store.dispatch('display/stopCheckNotification');
-            document.removeEventListener('visibilitychange', handleBrowserVisibilityChange, false);
         });
 
         watch(() => store.state.user.isSessionExpired, (isSessionExpired) => {
             if (isSessionExpired) store.dispatch('display/stopCheckNotification');
         });
+
 
         return {
             ...toRefs(state),

--- a/apps/web/src/services/dashboards/shared/DashboardRefreshDropdown.vue
+++ b/apps/web/src/services/dashboards/shared/DashboardRefreshDropdown.vue
@@ -20,9 +20,10 @@
 </template>
 
 <script lang="ts">
+import { useDocumentVisibility } from '@vueuse/core';
 import type { SetupContext } from 'vue';
 import {
-    computed, defineComponent, onMounted, onUnmounted, reactive, toRefs, watch,
+    computed, defineComponent, onUnmounted, reactive, toRefs, watch,
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
@@ -139,22 +140,16 @@ export default defineComponent<Props>({
             }
         });
 
-        const handleBrowserVisibilityChange = () => {
-            if (document.hidden) {
-                clearRefreshInterval();
-            } else {
-                executeRefreshInterval();
-            }
-        };
 
-        onMounted(() => {
-            if (props.refreshDisabled) return;
-            executeRefreshInterval();
-            document.addEventListener('visibilitychange', handleBrowserVisibilityChange, false);
-        });
+        const documentVisibility = useDocumentVisibility();
+        watch(documentVisibility, (visibility) => {
+            if (visibility === 'hidden') {
+                clearRefreshInterval();
+            } else if (!props.refreshDisabled) executeRefreshInterval();
+        }, { immediate: true });
+
         onUnmounted(() => {
             clearRefreshInterval();
-            document.removeEventListener('visibilitychange', handleBrowserVisibilityChange, false);
         });
 
         const handleRefresh = () => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

Refactored to use vueuse composable for consistency.

1. GNB Notification

https://github.com/cloudforet-io/console/assets/26986739/d1c3256c-8dfe-4313-9671-3f2eedcafdf0

2. Dashboard Refresh

https://github.com/cloudforet-io/console/assets/26986739/88b121e6-454d-4c25-a489-187194b12ce4



### Things to Talk About
