### PR TITLE
feat: reflect the changes immediately and refresh when close view modal

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
+++ b/apps/web/src/services/dashboards/dashboard-detail/DashboardDetailPage.vue
@@ -76,7 +76,6 @@
         <dashboard-clone-modal :visible.sync="state.cloneModalVisible"
                                :dashboard="dashboardDetailState"
         />
-        <widget-view-mode-modal :visible="dashboardDetailState.widgetViewModeModalVisible" />
     </div>
 </template>
 
@@ -122,7 +121,7 @@ import DashboardCloneModal from '@/services/dashboards/shared/DashboardCloneModa
 import DashboardLabels from '@/services/dashboards/shared/DashboardLabels.vue';
 import DashboardRefreshDropdown from '@/services/dashboards/shared/DashboardRefreshDropdown.vue';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
-import WidgetViewModeModal from '@/services/dashboards/widgets/_components/WidgetViewModeModal.vue';
+
 
 const PUBLIC_ICON_COLOR = gray[500];
 

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-container/DashboardWidgetContainer.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-container/DashboardWidgetContainer.vue
@@ -25,6 +25,9 @@
                 />
             </template>
         </template>
+        <widget-view-mode-modal :visible="dashboardDetailState.widgetViewModeModalVisible"
+                                @refresh-widget="handleRefreshWidget"
+        />
     </div>
 </template>
 
@@ -53,6 +56,7 @@ import {
     useWidgetValidator,
 } from '@/services/dashboards/shared/dashboard-widget-container/composables/use-widget-validator';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
+import WidgetViewModeModal from '@/services/dashboards/widgets/_components/WidgetViewModeModal.vue';
 import type {
     WidgetExpose, WidgetProps,
 } from '@/services/dashboards/widgets/_configs/config';
@@ -65,6 +69,7 @@ interface Props {
 type WidgetComponent = ComponentPublicInstance<WidgetProps, WidgetExpose>;
 export default defineComponent<Props>({
     name: 'DashboardWidgetContainer',
+    components: { WidgetViewModeModal },
     directives: {
         intersectionObserver: vIntersectionObserver as DirectiveFunction,
     },
@@ -155,6 +160,10 @@ export default defineComponent<Props>({
                 refreshAllWidget();
             }
         });
+        const handleRefreshWidget = (widgetKey: string) => {
+            const targetWidgetRef = state.widgetRef.find((d) => d?.$el?.id === widgetKey);
+            targetWidgetRef?.refreshWidget();
+        };
         const refreshAllWidget = debounce(async () => {
             dashboardDetailStore.$patch({ loadingWidgets: true });
             const refreshWidgetPromises: WidgetExpose['refreshWidget'][] = [];
@@ -197,6 +206,7 @@ export default defineComponent<Props>({
             containerRef,
             reformedWidgetInfoList,
             handleIntersectionObserver,
+            handleRefreshWidget,
         };
     },
 });

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetMoreOptions.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetMoreOptions.vue
@@ -129,7 +129,7 @@ const {
 const handleUpdateSelectedOptions = (selected: MenuItem[]) => {
     const selectedProperties: string[] = union(state.requiredProperties, sortItems(selected).map((item) => item.name));
     emit('update:selected-properties', selectedProperties);
-    // hideContextMenu();
+    hideContextMenu();
 };
 const handleClickAddOptions = () => {
     initiateMenu();

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeModal.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeModal.vue
@@ -71,7 +71,7 @@ import {
 } from 'vue';
 
 import { PHeading, PIconButton, PButton } from '@spaceone/design-system';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 
 import { store } from '@/store';
 
@@ -90,6 +90,7 @@ import type {
     DashboardLayoutWidgetInfo, WidgetExpose, WidgetProps,
 } from '@/services/dashboards/widgets/_configs/config';
 import { getWidgetComponent } from '@/services/dashboards/widgets/_helpers/widget-helper';
+
 
 interface WidgetViewModeModalProps {
     visible: boolean;
@@ -158,7 +159,12 @@ watch(() => props.visible, async (visible) => {
         state.sidebarVisible = false;
     }
 });
-// watch(() => )
+watch([() => widgetFormState.inheritOptions, () => widgetFormState.widgetInfo?.widget_options.filters], async ([_inheritOptions, _filters]) => {
+    if (!state.initiated) return;
+    if (isEqual(_inheritOptions, widgetFormState.widgetInfo?.inherit_options)
+        && isEqual(_filters, widgetFormState.widgetInfo?.widget_options.filters)) return;
+    await state.widgetRef?.refreshWidget();
+}, { immediate: false });
 </script>
 
 <style lang="postcss" scoped>

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeModal.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeModal.vue
@@ -100,6 +100,7 @@ type WidgetComponent = ComponentPublicInstance<WidgetProps, WidgetExpose>;
 const props = withDefaults(defineProps<WidgetViewModeModalProps>(), {
     visible: false,
 });
+const emit = defineEmits<{(e: 'refresh-widget', widgetKey: string): void}>();
 
 const dashboardDetailStore = useDashboardDetailInfoStore();
 const dashboardDetailState = dashboardDetailStore.$state;
@@ -157,6 +158,7 @@ watch(() => props.visible, async (visible) => {
         state.initiated = true;
     } else {
         state.sidebarVisible = false;
+        emit('refresh-widget', widgetFormState.widgetKey as string);
     }
 });
 watch([() => widgetFormState.inheritOptions, () => widgetFormState.widgetInfo?.widget_options.filters], async ([_inheritOptions, _filters]) => {

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeSidebar.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeSidebar.vue
@@ -27,7 +27,7 @@
                         {{ $t('DASHBOARDS.VIEW_MODE.CANCEL') }}
                     </p-button>
                     <p-button style-type="primary"
-                              :disabled="!dashboardDetailStore.isWidgetLayoutValid || !dashboardDetailState.isNameValid"
+                              :disabled="!widgetFormState.isValid"
                               @click="handleClickSaveButton"
                     >
                         {{ $t('DASHBOARDS.VIEW_MODE.SAVE') }}
@@ -53,7 +53,6 @@ import { useProxyValue } from '@/common/composables/proxy-state';
 
 import DashboardWidgetInputForm
     from '@/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetInputForm.vue';
-import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
 import { useWidgetFormStore } from '@/services/dashboards/store/widget-form';
 
 
@@ -72,10 +71,8 @@ const emit = defineEmits<{(e: string, value: string): void,
     (e: 'save'): void,
 }>();
 
-const dashboardDetailStore = useDashboardDetailInfoStore();
-const dashboardDetailState = dashboardDetailStore.$state;
 const widgetFormStore = useWidgetFormStore();
-// const widgetFormState = widgetFormStore.$state;
+const widgetFormState = widgetFormStore.$state;
 const state = reactive({
     proxyVisible: useProxyValue('visible', props, emit),
 });

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeSidebar.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeSidebar.vue
@@ -40,20 +40,26 @@
 
 <script setup lang="ts">
 import {
-    defineEmits, onUnmounted, reactive, watch,
+    onUnmounted, reactive, watch,
 } from 'vue';
 
 import {
     PButton, PSidebar,
 } from '@spaceone/design-system';
+import { cloneDeep } from 'lodash';
+
+import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
 import { store } from '@/store';
 
+import ErrorHandler from '@/common/composables/error/errorHandler';
 import { useProxyValue } from '@/common/composables/proxy-state';
 
 import DashboardWidgetInputForm
     from '@/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetInputForm.vue';
+import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
 import { useWidgetFormStore } from '@/services/dashboards/store/widget-form';
+import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/_configs/config';
 
 
 interface Props {
@@ -67,19 +73,48 @@ const props = withDefaults(defineProps<Props>(), {
     widgetKey: undefined,
     widgetConfigId: undefined,
 });
-const emit = defineEmits<{(e: string, value: string): void,
-    (e: 'save'): void,
-}>();
+const emit = defineEmits<{(e: string, value: boolean): void}>();
 
+const dashboardDetailStore = useDashboardDetailInfoStore();
+const dashboardDetailState = dashboardDetailStore.$state;
 const widgetFormStore = useWidgetFormStore();
 const widgetFormState = widgetFormStore.$state;
 const state = reactive({
     proxyVisible: useProxyValue('visible', props, emit),
 });
 
+/* Api */
+const updateWidgetInfo = async () => {
+    try {
+        if (dashboardDetailStore.isProjectDashboard) {
+            await SpaceConnector.clientV2.dashboard.projectDashboard.update({
+                project_dashboard_id: dashboardDetailState.dashboardId,
+                layouts: dashboardDetailState.dashboardWidgetInfoList,
+            });
+        } else {
+            await SpaceConnector.clientV2.dashboard.domainDashboard.update({
+                domain_dashboard_id: dashboardDetailState.dashboardId,
+                layouts: dashboardDetailState.dashboardWidgetInfoList,
+            });
+        }
+    } catch (e) {
+        ErrorHandler.handleError(e);
+    }
+};
+
 /* Event */
-const handleClickSaveButton = () => {
-    emit('save');
+const handleClickSaveButton = async () => {
+    // update widget info in dashboard detail store
+    const widgetInfo: DashboardLayoutWidgetInfo = cloneDeep(widgetFormState.widgetInfo);
+    widgetInfo.widget_options = widgetFormState.widgetOptions ?? {};
+    widgetInfo.schema_properties = widgetFormState.schemaProperties ?? [];
+    widgetInfo.inherit_options = widgetFormState.inheritOptions ?? {};
+    dashboardDetailStore.updateWidgetInfo(props.widgetKey, widgetInfo);
+
+    // update widget info in widget form store
+    widgetFormStore.initWidgetForm(props.widgetKey);
+
+    await updateWidgetInfo();
     state.proxyVisible = false;
 };
 const handleCloseSidebar = () => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
Please see order by commits!!!


- Reflect the changes **immediately** whenever the widget form is modified.
- refresh widget when close the view modal

https://github.com/cloudforet-io/console/assets/18563857/796c5550-2087-4d2c-bc92-f1fc1d4a82b8

