### PR TITLE
fix: fixed collect-data modal state

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
@@ -237,7 +237,6 @@ const handleCollectData = () => {
         _state.collectDataType = COLLECT_DATA_TYPE.ENTIRE;
         _state.selectedCollector = collectorFormState.originCollector;
         _state.selectedSecret = undefined;
-        _state.secrets = null;
     });
 };
 

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
@@ -228,12 +228,11 @@ const handleUpdateEditModalVisible = (value: boolean) => {
 const handleCollectData = () => {
     collectorDataModalStore.$patch((_state) => {
         const recentJob = collectorJobStore.recentJob;
-        if (!recentJob) return;
         _state.visible = true;
-        _state.recentJob = {
+        _state.recentJob = recentJob ? {
             status: recentJob.status,
             jobId: recentJob.job_id,
-        };
+        } : null;
         _state.collectDataType = COLLECT_DATA_TYPE.ENTIRE;
         _state.selectedCollector = collectorFormState.originCollector;
         _state.selectedSecret = undefined;

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/AttachedServiceAccounts.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/AttachedServiceAccounts.vue
@@ -173,7 +173,6 @@ const handleClickCollect = async (secret: SecretModel) => {
         _state.selectedCollector = collectorFormState.originCollector;
         _state.collectDataType = COLLECT_DATA_TYPE.SINGLE;
         _state.selectedSecret = secret;
-        _state.secrets = state.secrets;
     });
 };
 

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/AttachedServiceAccounts.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/AttachedServiceAccounts.vue
@@ -164,12 +164,11 @@ const handleToolboxTableRefresh = async () => {
 const handleClickCollect = async (secret: SecretModel) => {
     collectorDataModalStore.$patch((_state) => {
         const recentJob = collectorJobStore.recentJob;
-        if (!recentJob) return;
         _state.visible = true;
-        _state.recentJob = {
+        _state.recentJob = recentJob ? {
             status: recentJob.status,
             jobId: recentJob.job_id,
-        };
+        } : null;
         _state.selectedCollector = collectorFormState.originCollector;
         _state.collectDataType = COLLECT_DATA_TYPE.SINGLE;
         _state.selectedSecret = secret;

--- a/apps/web/src/services/asset-inventory/collector/shared/collector-data-modal/CollectorDataModal.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-data-modal/CollectorDataModal.vue
@@ -11,13 +11,14 @@
         >
             <template #body>
                 <div v-if="state.isDuplicateJobs">
-                    <collector-data-duplication-inner :name="state.provider.label"
+                    <collector-data-duplication-inner :name="state.accountName"
                                                       :icon="state.provider.icon"
                     />
                 </div>
                 <collector-data-default-inner v-else
-                                              :name="state.provider.label"
+                                              :name="state.accountName"
                                               :icon="state.provider.icon"
+                                              :secrets-count="state.secrets.length"
                 />
             </template>
             <template #confirm-button>
@@ -48,6 +49,7 @@ import { showSuccessMessage } from '@/lib/helper/notice-alert-helper';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
+import type { SecretModel } from '@/services/asset-inventory/collector/model';
 import {
     useCollectorDataModalStore,
 } from '@/services/asset-inventory/collector/shared/collector-data-modal/collector-data-modal-store';
@@ -55,6 +57,7 @@ import CollectorDataDefaultInner
     from '@/services/asset-inventory/collector/shared/collector-data-modal/modules/CollectorDataDefaultInner.vue';
 import CollectorDataDuplicationInner
     from '@/services/asset-inventory/collector/shared/collector-data-modal/modules/CollectorDataDuplicationInner.vue';
+import { COLLECT_DATA_TYPE } from '@/services/asset-inventory/collector/shared/collector-data-modal/type';
 import { JOB_STATE } from '@/services/asset-inventory/collector/type';
 
 const collectorDataModalStore = useCollectorDataModalStore();
@@ -67,6 +70,7 @@ const storeState = reactive({
 
 const state = reactive({
     loading: false,
+    secrets: [] as SecretModel[],
     headerTitle: computed(() => (state.isDuplicateJobs
         ? i18n.t('INVENTORY.COLLECTOR.MAIN.COLLECT_DATA_MODAL.DUPLICATION_TITLE')
         : i18n.t('INVENTORY.COLLECTOR.MAIN.COLLECT_DATA_MODAL.TITLE'))),
@@ -78,6 +82,18 @@ const state = reactive({
     provider: computed(() => {
         const selectedCollector = collectorDataModalState.selectedCollector;
         return selectedCollector?.provider ? storeState.providers[selectedCollector.provider] : undefined;
+    }),
+    accountName: computed(() => {
+        const collectDataType = collectorDataModalState.collectDataType;
+        if (collectDataType === COLLECT_DATA_TYPE.ENTIRE) {
+            return state.provider.label;
+        }
+
+        const selectedSecret = collectorDataModalState.selectedSecret;
+        if (!selectedSecret) return '';
+        const id = selectedSecret.service_account_id;
+        const fullName = selectedSecret.name;
+        return fullName.split(id)[0] ?? '';
     }),
 });
 

--- a/apps/web/src/services/asset-inventory/collector/shared/collector-data-modal/CollectorDataModal.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-data-modal/CollectorDataModal.vue
@@ -117,14 +117,10 @@ const fetchSecrets = async (provider: string) => {
         const results = await SpaceConnector.client.secret.secret.list({
             query: apiQueryHelper.data,
         });
-        collectorDataModalStore.$patch((_state) => {
-            _state.secrets = results.results;
-        });
+        state.secrets = results.results;
     } catch (e) {
         ErrorHandler.handleError(e);
-        collectorDataModalStore.$patch((_state) => {
-            _state.secrets = [];
-        });
+        state.secrets = [];
     }
 };
 

--- a/apps/web/src/services/asset-inventory/collector/shared/collector-data-modal/collector-data-modal-store.ts
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-data-modal/collector-data-modal-store.ts
@@ -19,6 +19,5 @@ export const useCollectorDataModalStore = defineStore('collector-data-modal', {
 
         // Optional
         selectedSecret: undefined as SecretModel|undefined, // In detail page, This state is used for API.
-        secrets: null as SecretModel[]|null, // In detail page, This state is used for account count.
     }),
 });

--- a/apps/web/src/services/asset-inventory/collector/shared/collector-data-modal/modules/CollectorDataDefaultInner.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-data-modal/modules/CollectorDataDefaultInner.vue
@@ -9,18 +9,16 @@
             />
             <div v-if="collectorDataModalState.collectDataType === COLLECT_DATA_TYPE.ENTIRE">
                 <span>{{ props.name }} {{ $t('INVENTORY.COLLECTOR.ACCOUNT') }}</span>
-                <span v-if="collectorDataModalState.secrets && collectorDataModalState.secrets.length > 0">
-                    ({{ collectorDataModalState.secrets && collectorDataModalState.secrets.length }})
+                <span v-if="props.secretsCount > 0">
+                    ({{ props.secretsCount }})
                 </span>
             </div>
-            <span v-else>{{ state.serviceAccountName || '' }}</span>
+            <span v-else>{{ props.name }}</span>
         </div>
     </div>
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from 'vue';
-
 import { PLazyImg } from '@spaceone/design-system';
 
 import {
@@ -34,22 +32,13 @@ const collectorDataModalState = collectorDataModalStore.$state;
 interface Props {
     name: string;
     icon: string;
+    secretsCount: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     name: '',
     icon: '',
-});
-
-const state = reactive({
-    serviceAccountName: computed<string>(() => {
-        const selectedSecret = collectorDataModalState.selectedSecret;
-        if (!selectedSecret) return '';
-
-        const id = selectedSecret.service_account_id;
-        const fullName = selectedSecret.name;
-        return fullName.split(id)[0] ?? '';
-    }),
+    secretsCount: 0,
 });
 </script>
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- remove `secrets` state at collect-data-modal store
  - API call inside the modal.
- apply account name at single account collector's table
<img width="484" alt="스크린샷 2023-08-01 15 43 07" src="https://github.com/cloudforet-io/console/assets/83805167/b53f99bc-a792-4bc1-9b73-0df8ef2cd7e1">

- fixed the bug of modal display when there are no jobs


### Things to Talk About
