### PR TITLE
fix: make recentJobs undefindable for loading UI

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
@@ -227,7 +227,7 @@ const handleUpdateEditModalVisible = (value: boolean) => {
 };
 const handleCollectData = () => {
     collectorDataModalStore.$patch((_state) => {
-        const recentJob = collectorJobStore.recentJob;
+        const recentJob = collectorJobStore.recentJobForAllAccounts;
         _state.visible = true;
         _state.recentJob = recentJob ? {
             status: recentJob.status,

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/collector-job-store.ts
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/collector-job-store.ts
@@ -9,11 +9,11 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 import type { CollectorModel, JobModel, Schedule } from '@/services/asset-inventory/collector/model';
 
 
-const jobQueryHelper = new ApiQueryHelper().setPageLimit(5).setSort('created_at', true);
+const jobQueryHelper = new ApiQueryHelper().setSort('created_at', true);
 export const useCollectorJobStore = defineStore('collector-job', {
     state: () => ({
         collector: null as null|CollectorModel,
-        recentJobs: undefined as JobModel[]|undefined, // if undefined, it means that the first request is not yet finished
+        recentJobs: null as JobModel[]|null, // if null, it means that the first request is not yet finished
     }),
     getters: {
         schedule(): Schedule|null {
@@ -22,8 +22,11 @@ export const useCollectorJobStore = defineStore('collector-job', {
         isRecentJobLoaded(): boolean {
             return this.recentJobs !== null;
         },
-        recentJob(): JobModel|null {
-            if (Array.isArray(this.recentJobs) && this.recentJobs.length > 0) return this.recentJobs[this.recentJobs.length - 1];
+        recentJobForAllAccounts(): JobModel|null {
+            if (Array.isArray(this.recentJobs) && this.recentJobs.length > 0) {
+                const filteredJobs = this.recentJobs.filter((job) => !job.secret_id);
+                return filteredJobs[0] ?? null;
+            }
             return null;
         },
     },

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/AttachedServiceAccounts.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/AttachedServiceAccounts.vue
@@ -163,7 +163,7 @@ const handleToolboxTableRefresh = async () => {
 };
 const handleClickCollect = async (secret: SecretModel) => {
     collectorDataModalStore.$patch((_state) => {
-        const recentJob = collectorJobStore.recentJob;
+        const recentJob = collectorJobStore.recentJobForAllAccounts;
         _state.visible = true;
         _state.recentJob = recentJob ? {
             status: recentJob.status,

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectDataButtonGroup.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectDataButtonGroup.vue
@@ -17,7 +17,7 @@ const collectorJobStore = useCollectorJobStore();
 const state = reactive({
     isPopoverOpen: false,
     showStatus: computed(() => collectorJobStore.isRecentJobLoaded),
-    recentJob: computed<JobModel|null>(() => collectorJobStore.recentJob),
+    recentJob: computed<JobModel|null>(() => collectorJobStore.recentJobForAllAccounts),
 });
 const handleClickCollectDataButton = () => {
     emit('collect');

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
@@ -86,6 +86,7 @@ import PluginSummaryCards from '@/services/asset-inventory/collector/collector-d
 import type {
     CollectorModel,
     CollectorPluginModel,
+    JobModel,
     CollectorUpdateParameter,
     CollectorUpdatePluginParameter,
     RepositoryPluginModel,
@@ -116,7 +117,7 @@ const state = reactive({
         if (latestVersion) return latestVersion === version;
         return false;
     }),
-    recentJobs: computed(() => collectorJobState.recentJobs),
+    recentJobs: computed<JobModel[]|undefined>(() => collectorJobState.recentJobs),
     isEditMode: false,
     isVersionValid: false,
     isTagsValid: false,

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectorBaseInfoSection.vue
@@ -117,7 +117,7 @@ const state = reactive({
         if (latestVersion) return latestVersion === version;
         return false;
     }),
-    recentJobs: computed<JobModel[]|undefined>(() => collectorJobState.recentJobs),
+    recentJobs: computed<JobModel[]|null>(() => collectorJobState.recentJobs),
     isEditMode: false,
     isVersionValid: false,
     isTagsValid: false,

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/PluginSummaryCards.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/PluginSummaryCards.vue
@@ -13,12 +13,21 @@ import RecentCollectorJobList from '@/services/asset-inventory/collector/shared/
 
 const props = defineProps<{
     collector?: CollectorModel|null;
-    recentJobs?: JobModel[]|null;
+    recentJobs?: JobModel[];
     historyLink: Location
 }>();
 
 const state = reactive({
     timezone: computed(() => store.state.user.timezone),
+    sortedRecentJobs: computed<JobModel[]|undefined>(() => {
+        const recentJobs = props.recentJobs;
+        if (!recentJobs) return undefined;
+        return recentJobs.sort((a, b) => {
+            const aDate = new Date(a.created_at);
+            const bDate = new Date(b.created_at);
+            return aDate.getTime() - bDate.getTime();
+        });
+    }),
 });
 </script>
 
@@ -49,7 +58,7 @@ const state = reactive({
             </div>
         </div>
         <div class="plugin-summary-card">
-            <recent-collector-job-list :recent-jobs="props.recentJobs"
+            <recent-collector-job-list :recent-jobs="state.sortedRecentJobs"
                                        :history-link="props.historyLink"
                                        full-mode
             />

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/PluginSummaryCards.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/PluginSummaryCards.vue
@@ -13,21 +13,12 @@ import RecentCollectorJobList from '@/services/asset-inventory/collector/shared/
 
 const props = defineProps<{
     collector?: CollectorModel|null;
-    recentJobs?: JobModel[];
+    recentJobs?: JobModel[]|null;
     historyLink: Location
 }>();
 
 const state = reactive({
     timezone: computed(() => store.state.user.timezone),
-    sortedRecentJobs: computed<JobModel[]|undefined>(() => {
-        const recentJobs = props.recentJobs;
-        if (!recentJobs) return undefined;
-        return recentJobs.sort((a, b) => {
-            const aDate = new Date(a.created_at);
-            const bDate = new Date(b.created_at);
-            return aDate.getTime() - bDate.getTime();
-        });
-    }),
 });
 </script>
 
@@ -58,7 +49,7 @@ const state = reactive({
             </div>
         </div>
         <div class="plugin-summary-card">
-            <recent-collector-job-list :recent-jobs="state.sortedRecentJobs"
+            <recent-collector-job-list :recent-jobs="props.recentJobs"
                                        :history-link="props.historyLink"
                                        full-mode
             />

--- a/apps/web/src/services/asset-inventory/collector/collector-main/modules/CollectorContentItem.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-main/modules/CollectorContentItem.vue
@@ -36,7 +36,7 @@ const state = reactive({
     }),
     recentJob: computed<JobAnalyzeStatus|undefined>(() => {
         if (!props.item) return undefined;
-        return props.item.recentJobAnalyze[props.item.recentJobAnalyze.length - 1];
+        return props.item.recentJobAnalyze ? props.item.recentJobAnalyze[props.item.recentJobAnalyze.length - 1] : undefined;
     }),
 });
 
@@ -46,11 +46,11 @@ const handleClickCollectData = async () => {
     await collectorPageStore.setSelectedCollector(props.item.collectorId);
     await collectorDataModalStore.$patch((_state) => {
         if (!props.item) return;
-        const recentJobAnalyze = props.item.recentJobAnalyze[props.item.recentJobAnalyze.length - 1] || [];
+        const recentJobAnalyze = props.item.recentJobAnalyze ? props.item.recentJobAnalyze[props.item.recentJobAnalyze.length - 1] : undefined;
         _state.visible = true;
         _state.recentJob = {
-            jobId: recentJobAnalyze.job_id || '',
-            status: recentJobAnalyze.status as JobStatus,
+            jobId: recentJobAnalyze?.job_id || '',
+            status: recentJobAnalyze?.status as JobStatus,
         };
         _state.selectedCollector = collectorPageState.selectedCollector;
     });

--- a/apps/web/src/services/asset-inventory/collector/collector-main/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-main/modules/CollectorContents.vue
@@ -85,7 +85,7 @@ const state = reactive({
             ]);
 
             const matchedJob = collectorPageState.collectorJobStatus.find((status) => status.collector_id === d.collector_id);
-            const recentJobAnalyze = matchedJob ? matchedJob.job_status.slice(-5) : undefined;
+            const recentJobAnalyze = matchedJob ? matchedJob.job_status : undefined;
 
             return {
                 collectorId: d.collector_id,

--- a/apps/web/src/services/asset-inventory/collector/collector-main/modules/CollectorContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-main/modules/CollectorContents.vue
@@ -27,6 +27,7 @@ import CollectorContentItem from '@/services/asset-inventory/collector/collector
 import CollectorListNoData from '@/services/asset-inventory/collector/collector-main/modules/CollectorListNoData.vue';
 import CollectorScheduleModal
     from '@/services/asset-inventory/collector/collector-main/modules/modals/CollectorScheduleModal.vue';
+import type { CollectorItemInfo } from '@/services/asset-inventory/collector/collector-main/type';
 import { COLLECTOR_QUERY_HELPER_SET } from '@/services/asset-inventory/collector/collector-main/type';
 import CollectorDataModal
     from '@/services/asset-inventory/collector/shared/collector-data-modal/CollectorDataModal.vue';
@@ -69,9 +70,10 @@ const historyLinkQueryHelper = new QueryHelper();
 const storeState = reactive({
     plugins: computed<PluginReferenceMap>(() => store.getters['reference/pluginItems']),
 });
+
 const state = reactive({
     searchTags: computed(() => searchQueryHelper.setFilters(collectorPageState.searchFilters).queryTags),
-    items: computed(() => {
+    items: computed<CollectorItemInfo[]|undefined>(() => {
         const plugins = storeState.plugins;
         return collectorPageState.collectors?.map((d) => {
             historyLinkQueryHelper.setFilters([
@@ -83,7 +85,7 @@ const state = reactive({
             ]);
 
             const matchedJob = collectorPageState.collectorJobStatus.find((status) => status.collector_id === d.collector_id);
-            const recentJobAnalyze = matchedJob?.job_status.slice(-5) || [];
+            const recentJobAnalyze = matchedJob ? matchedJob.job_status.slice(-5) : undefined;
 
             return {
                 collectorId: d.collector_id,

--- a/apps/web/src/services/asset-inventory/collector/collector-main/type.ts
+++ b/apps/web/src/services/asset-inventory/collector/collector-main/type.ts
@@ -44,8 +44,8 @@ export interface CollectorItemInfo {
     plugin: CollectorPlugin;
     historyLink: CollectorLink,
     detailLink: CollectorLink;
-    schedule: Schedule;
-    recentJobAnalyze: JobAnalyzeStatus[];
+    schedule?: Schedule;
+    recentJobAnalyze?: JobAnalyzeStatus[];
     hasJobList?: boolean
 }
 

--- a/apps/web/src/services/asset-inventory/collector/collector-main/type.ts
+++ b/apps/web/src/services/asset-inventory/collector/collector-main/type.ts
@@ -4,6 +4,7 @@ import type { RouteQueryString } from '@/lib/router-query-string';
 
 import type {
     CollectorPluginModel, Schedule,
+    JobStatus,
 } from '@/services/asset-inventory/collector/model';
 
 export const COLLECTOR_QUERY_HELPER_SET = {
@@ -58,7 +59,7 @@ export interface CollectorMainPageQueryValue {
 
 export interface JobAnalyzeStatus {
     job_id: string;
-    status: string;
+    status: JobStatus;
     finished_at: string;
     remained_tasks: number;
     total_tasks: number;

--- a/apps/web/src/services/asset-inventory/collector/model.ts
+++ b/apps/web/src/services/asset-inventory/collector/model.ts
@@ -166,4 +166,5 @@ export interface JobModel {
     created_at: string;
     finished_at: string;
     updated_at: string;
+    secret_id?: string;
 }

--- a/apps/web/src/services/asset-inventory/collector/shared/RecentCollectorJobList.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/RecentCollectorJobList.vue
@@ -37,6 +37,15 @@ const storeState = reactive({
 
 const state = reactive({
     loading: computed(() => !Array.isArray(props.recentJobs)),
+    completedJobs: computed<MinimalJobInfo[]|undefined>(() => {
+        if (Array.isArray(props.recentJobs) && props.recentJobs.length > 0) {
+            return props.recentJobs.filter((job) => job.status !== 'IN_PROGRESS')
+                .sort((a, b) => dayjs(b.finished_at).unix() - dayjs(a.finished_at).unix())
+                .slice(0, 5)
+                .reverse();
+        }
+        return undefined;
+    }),
 });
 
 </script>
@@ -69,16 +78,16 @@ const state = reactive({
                 View All
             </p-anchor>
         </div>
-        <p-data-loader :data="!!props.recentJobs?.length"
+        <p-data-loader :data="!!state.completedJobs?.length"
                        :loading="state.loading"
                        loader-type="skeleton"
                        class="data-loader"
         >
-            <div v-if="props.recentJobs"
+            <div v-if="state.completedJobs"
                  :class="['jobs-wrapper', { 'is-mobile': isMobile() }]"
             >
                 <div class="jobs-contents">
-                    <collector-job-status-icon v-for="(job, index) in props.recentJobs"
+                    <collector-job-status-icon v-for="(job, index) in state.completedJobs"
                                                :key="`job-item-${index}`"
                                                :class="['collector-job-status-icon-wrapper', { 'is-mobile': isMobile() }]"
                                                :status="job.status"
@@ -87,7 +96,7 @@ const state = reactive({
                                                :style-type="props.fullMode ? 'white' : 'gray'"
                     />
                 </div>
-                <collector-job-status-icon v-if="props.recentJobs.length > 0 && !props.fullMode && props.historyLink"
+                <collector-job-status-icon v-if="state.completedJobs.length > 0 && !props.fullMode && props.historyLink"
                                            is-arrow
                                            :to="props.historyLink"
                                            class="more-button"

--- a/apps/web/src/services/asset-inventory/collector/shared/RecentCollectorJobList.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/RecentCollectorJobList.vue
@@ -69,7 +69,7 @@ const state = reactive({
                 View All
             </p-anchor>
         </div>
-        <p-data-loader :data="props.recentJobs"
+        <p-data-loader :data="!!props.recentJobs?.length"
                        :loading="state.loading"
                        loader-type="skeleton"
                        class="data-loader"


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

Make `recentJobs` in `collector-job-store` and `CollectorContents` undefinedable.
That is to display loading case in `RcentCollectorJobList`.
![image](https://github.com/cloudforet-io/console/assets/26986739/706c2253-40fd-4138-8dbf-baf91ddd5f8b)

Make recent job list in the detail page the same with the main page. (show recent 5 items within 5 days)

Filter in-progress job from `RcentCollectorJobList`.


### Things to Talk About
