### PR TITLE
fix: apply loading to PLazyImg in CollectorPluginContents & make reset when enableHoursEdit prop is changed in CollectorScheduleForm

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/shared/CollectorPluginContents.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/CollectorPluginContents.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="plugin-data-contents">
         <p-lazy-img :src="state.icon"
+                    :loading="!props.plugin"
                     class="plugin-icon"
                     width="3rem"
                     height="3rem"

--- a/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorScheduleForm.vue
+++ b/apps/web/src/services/asset-inventory/collector/shared/collector-forms/CollectorScheduleForm.vue
@@ -146,7 +146,7 @@ const handleClickHour = (hour: number) => {
     updateSelectedHours();
 };
 
-watch(() => collectorFormStore.collectorId, (collectorId) => {
+watch([() => collectorFormStore.collectorId, () => props.enableHoursEdit], ([collectorId]) => {
     if (props.resetOnCollectorIdChange && !collectorId) return;
     collectorFormStore.resetSchedule();
     selectedUtcHoursSet.clear();


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA

### Things to Talk About
