### PR TITLE
feat: add ignoreOutsideClick prop into PPopver & make popover open when collect data button is clicked 

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/CollectorDetailPage.vue
@@ -268,6 +268,9 @@ onMounted(async () => {
     collectorFormStore.$reset();
     collectorDataModalStore.$reset();
     const collector = await getCollector();
+    collectorJobStore.$patch((_state) => {
+        _state.collector = collector;
+    });
     if (collector) {
         collectorFormStore.setOriginCollector(collector);
         resume();

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectDataButtonGroup.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectDataButtonGroup.vue
@@ -25,6 +25,7 @@ const state = reactive({
     showStatus: computed(() => width.value > screens.mobile.max),
 });
 const handleClickCollectDataButton = () => {
+    state.isPopoverOpen = true;
     emit('collect');
 };
 
@@ -32,29 +33,26 @@ const handleClickCollectDataButton = () => {
 
 <template>
     <div class="collect-data-button-group">
-        <p-popover :is-visible.sync="state.isPopoverOpen"
-                   :ignore-target-click="false"
+        <p-button style-type="tertiary"
+                  size="md"
+                  icon-left="ic_collect"
+                  class="collect-data-button"
+                  :class="{dependent: state.showStatus}"
+                  @click="handleClickCollectDataButton"
+        >
+            {{ $t('INVENTORY.COLLECTOR.DETAIL.COLLECT_DATA') }}
+        </p-button>
+        <p-popover v-if="state.showStatus"
+                   :is-visible.sync="state.isPopoverOpen"
                    ignore-outside-click
         >
-            <div class="buttons-wrapper">
-                <p-button style-type="tertiary"
-                          size="md"
-                          icon-left="ic_collect"
-                          class="collect-data-button"
-                          :class="{dependent: state.showStatus}"
-                          @click="handleClickCollectDataButton"
-                >
-                    {{ $t('INVENTORY.COLLECTOR.DETAIL.COLLECT_DATA') }}
-                </p-button>
-                <p-icon-button v-if="state.showStatus"
-                               :name="state.isPopoverOpen ? 'ic_chevron-up' : 'ic_chevron-down'"
-                               style-type="tertiary"
-                               shape="square"
-                               size="md"
-                               color="inherit"
-                               class="status-button"
-                />
-            </div>
+            <p-icon-button :name="state.isPopoverOpen ? 'ic_chevron-up' : 'ic_chevron-down'"
+                           style-type="tertiary"
+                           shape="square"
+                           size="md"
+                           color="inherit"
+                           class="status-button"
+            />
             <template #content>
                 <div class="collect-status-wrapper">
                     <collector-current-status
@@ -70,10 +68,8 @@ const handleClickCollectDataButton = () => {
 
 <style scoped lang="postcss">
 .collect-data-button-group {
-    .buttons-wrapper {
-        display: flex;
-        flex-wrap: wrap;
-    }
+    display: flex;
+    flex-wrap: wrap;
     .collect-data-button {
         &.dependent {
             border-top-right-radius: 0;

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectDataButtonGroup.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectDataButtonGroup.vue
@@ -34,6 +34,7 @@ const handleClickCollectDataButton = () => {
     <div class="collect-data-button-group">
         <p-popover :is-visible.sync="state.isPopoverOpen"
                    :ignore-target-click="false"
+                   ignore-outside-click
         >
             <div class="buttons-wrapper">
                 <p-button style-type="tertiary"

--- a/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectDataButtonGroup.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-detail/modules/CollectDataButtonGroup.vue
@@ -32,25 +32,28 @@ const handleClickCollectDataButton = () => {
 
 <template>
     <div class="collect-data-button-group">
-        <p-button style-type="tertiary"
-                  size="md"
-                  icon-left="ic_collect"
-                  class="collect-data-button"
-                  :class="{dependent: state.showStatus}"
-                  @click="handleClickCollectDataButton"
+        <p-popover :is-visible.sync="state.isPopoverOpen"
+                   :ignore-target-click="false"
         >
-            {{ $t('INVENTORY.COLLECTOR.DETAIL.COLLECT_DATA') }}
-        </p-button>
-        <p-popover v-if="state.showStatus"
-                   :is-visible.sync="state.isPopoverOpen"
-        >
-            <p-icon-button :name="state.isPopoverOpen ? 'ic_chevron-up' : 'ic_chevron-down'"
-                           style-type="tertiary"
-                           shape="square"
-                           size="md"
-                           color="inherit"
-                           class="status-button"
-            />
+            <div class="buttons-wrapper">
+                <p-button style-type="tertiary"
+                          size="md"
+                          icon-left="ic_collect"
+                          class="collect-data-button"
+                          :class="{dependent: state.showStatus}"
+                          @click="handleClickCollectDataButton"
+                >
+                    {{ $t('INVENTORY.COLLECTOR.DETAIL.COLLECT_DATA') }}
+                </p-button>
+                <p-icon-button v-if="state.showStatus"
+                               :name="state.isPopoverOpen ? 'ic_chevron-up' : 'ic_chevron-down'"
+                               style-type="tertiary"
+                               shape="square"
+                               size="md"
+                               color="inherit"
+                               class="status-button"
+                />
+            </div>
             <template #content>
                 <div class="collect-status-wrapper">
                     <collector-current-status
@@ -66,8 +69,10 @@ const handleClickCollectDataButton = () => {
 
 <style scoped lang="postcss">
 .collect-data-button-group {
-    display: flex;
-    flex-wrap: wrap;
+    .buttons-wrapper {
+        display: flex;
+        flex-wrap: wrap;
+    }
     .collect-data-button {
         &.dependent {
             border-top-right-radius: 0;

--- a/apps/web/tests/asset-inventory/collector/collector-details/collect-data.spec.ts
+++ b/apps/web/tests/asset-inventory/collector/collector-details/collect-data.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const COLLECTOR_INDEX = 0;
+const COLLECTOR_INDEX = 1;
 const IN_PROGRESS_SELECTOR = '.popper .label-description .current-status-progress';
 const SERVICE_ACCOUNT_INDEX = 0;
 
@@ -41,9 +41,6 @@ const checkIfApiResponsesAreCorrect = async (page) => {
 };
 
 const checkIfStatusIsInProgress = async (page) => {
-    // click on the status button
-    await page.locator('button.status-button').click();
-
     // check if the status is in progress
     await expect(await page.locator(IN_PROGRESS_SELECTOR)).toBeVisible();
 };

--- a/packages/mirinae/src/data-display/popover/PPopover.stories.mdx
+++ b/packages/mirinae/src/data-display/popover/PPopover.stories.mdx
@@ -20,7 +20,9 @@ export const Template = (args, { argTypes }) => ({
     template: `
         <div class="w-full overflow p-8 flex justify-center items-center" style="height: 250px;">
             <p-popover :position="proxyPosition" :isVisible="proxyIsVisible"
-                       :ignore-target-click="ignoreTargetClick" :trigger="trigger">
+                       :ignore-target-click="ignoreTargetClick" :trigger="trigger"
+                       :ignore-outside-click="ignoreOutsideClick"
+            >
                 <div v-if="defaultSlot" v-html="defaultSlot" />
                 <p-button v-else @click="handleClick">default</p-button>
                 <template #content>
@@ -90,6 +92,36 @@ export const Template = (args, { argTypes }) => ({
                 <p-text-input style-type="primary" :outline="true">default</p-text-input>
                 <template #content>
                     <p style="margin-top:12px">content slot</p>
+                </template>
+            </p-popover>
+        </div>
+    `,
+        }}
+    </Story>
+</Canvas>
+
+## Ignore Outside Click
+
+<br/>
+<br/>
+
+<Canvas>
+    <Story name="Ignore Outside Click">
+        {{
+            components: { PPopover, PTextInput, PButton },
+            template: `
+        <div class="w-full overflow p-8 flex flex-col gap-4" style="height: 300px;">
+            <p-popover ignore-outside-click>
+                <p-button>click me (ignore outside click)</p-button>
+                <template #content>
+                    <p style="margin-top:12px">This popover ignores outside click</p>
+                </template>
+            </p-popover>
+            <div style="height: 100px;"/>
+            <p-popover>
+                <p-button>click me (default)</p-button>
+                <template #content>
+                    <p style="margin-top:12px">This popover will be closed when you click outside</p>
                 </template>
             </p-popover>
         </div>

--- a/packages/mirinae/src/data-display/popover/PPopover.vue
+++ b/packages/mirinae/src/data-display/popover/PPopover.vue
@@ -50,7 +50,8 @@ interface PopoverProps {
     tag: string;
     position?: PopoverPlacement;
     trigger?: PopoverTrigger;
-    ignoreTargetClick: boolean;
+    ignoreTargetClick?: boolean;
+    ignoreOutsideClick?: boolean;
 }
 
 export default defineComponent<PopoverProps>({
@@ -94,6 +95,10 @@ export default defineComponent<PopoverProps>({
             type: Boolean,
             default: true,
         },
+        ignoreOutsideClick: {
+            type: Boolean,
+            default: false,
+        },
     },
     setup(props, { emit }) {
         const state = reactive({
@@ -121,9 +126,9 @@ export default defineComponent<PopoverProps>({
             hidePopover();
         };
         const handleClickOutside = () => {
-            hidePopover();
+            if (!props.ignoreOutsideClick) hidePopover();
         };
-        const bindEventToTargetRef = (eventType: keyof HTMLElementEventMap, handler, useCature = false) => state.targetRef?.addEventListener(eventType, handler, useCature);
+        const bindEventToTargetRef = (eventType, handler, useCature = false) => state.targetRef?.addEventListener(eventType, handler, useCature);
         const addEvent = () => {
             if (props.trigger === POPOVER_TRIGGER.CLICK) {
                 bindEventToTargetRef('click', handleClickTargetRef, true);

--- a/packages/mirinae/src/data-display/popover/story-helper.ts
+++ b/packages/mirinae/src/data-display/popover/story-helper.ts
@@ -103,14 +103,14 @@ export const getPopoverArgTypes = () => {
             name: 'ignoreOutsideClick',
             type: { name: 'boolean' },
             description: 'If the value is true, do not close the popover even if user click outside the popover.',
-            defaultValue: true,
+            defaultValue: false,
             table: {
                 type: {
                     summary: 'boolean',
                 },
                 category: 'props',
                 defaultValue: {
-                    summary: true,
+                    summary: false,
                 },
             },
             control: {

--- a/packages/mirinae/src/data-display/popover/story-helper.ts
+++ b/packages/mirinae/src/data-display/popover/story-helper.ts
@@ -99,6 +99,24 @@ export const getPopoverArgTypes = () => {
                 type: 'boolean',
             },
         },
+        ignoreOutsideClick: {
+            name: 'ignoreOutsideClick',
+            type: { name: 'boolean' },
+            description: 'If the value is true, do not close the popover even if user click outside the popover.',
+            defaultValue: true,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: true,
+                },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
         // model
         'v-model': {
             name: 'v-model',


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [x] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description


1. Add `ignoreOutsideClick` prop into `PPopver` component.

https://github.com/cloudforet-io/console/assets/26986739/478af228-c549-4215-ae67-2188bb90d2bf

![image](https://github.com/cloudforet-io/console/assets/26986739/131b6d79-cb9f-43e1-92be-4b46d225e0b6)

2. Make popover open when collect data button is clicked in `CollectDataButtonGroup`.
See the preview.
collector detail page > collect data button click - popover must be shown.
 

### Things to Talk About
