### PR TITLE
fix(home-dashboard): dispose chart on before unmount and do not declare chart as deep reactive state

### DIFF
--- a/apps/web/.stylelintcache
+++ b/apps/web/.stylelintcache
@@ -1,0 +1,1 @@
+[{"/Users/mzc01-wanjin/Documents/workspace/console/apps/web/src/styles/style.pcss":"1"},{"size":409,"mtime":1681893847424,"hashOfConfig":"2"},"t3t0ok"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,8 +21,8 @@
   },
   "main": "dist/cloudforet-component.common.js",
   "dependencies": {
-    "@amcharts/amcharts4": "^4.10.32",
-    "@amcharts/amcharts4-geodata": "^4.1.18",
+    "@amcharts/amcharts4": "^4.10.37",
+    "@amcharts/amcharts4-geodata": "^4.1.27",
     "@amcharts/amcharts5": "^5.2.31",
     "@amcharts/amcharts5-geodata": "^5.0.6",
     "@cloudforet/core-lib": "*",

--- a/apps/web/src/services/auth/sign-in/SignInPage.vue
+++ b/apps/web/src/services/auth/sign-in/SignInPage.vue
@@ -63,9 +63,12 @@ export default {
                 let component;
                 const auth = state.authType;
                 if (auth) {
-                    const path = `./external/${auth}/template/${auth}.vue`;
                     try {
-                        component = defineAsyncComponent(() => import(path));
+                        /*
+                         NOTE: See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations for supported dynamic import formats.
+                         If this is intended to be left as-is, you can use the @vite-ignore comment inside the import() call to suppress this warning.
+                        */
+                        component = defineAsyncComponent(() => import(`./external/${auth}/template/${auth}.vue`));
                     } catch (e) {
                         ErrorHandler.handleError(e);
                     }

--- a/apps/web/src/services/auth/sign-in/local/template/ID_PW.vue
+++ b/apps/web/src/services/auth/sign-in/local/template/ID_PW.vue
@@ -1,3 +1,58 @@
+<template>
+    <div class="local-wrapper">
+        <form class="form"
+              onsubmit="return false"
+        >
+            <p-field-group :label="isDomainOwner ? t('COMMON.SIGN_IN.ADMIN_ID') : t('COMMON.SIGN_IN.USER_ID')"
+                           :invalid="validationState.isIdValid === false"
+                           required
+            >
+                <template #default="{invalid}">
+                    <p-text-input :value="state.userId"
+                                  :placeholder="!isMobile() ? 'E-mail Address' : 'User ID'"
+                                  :invalid="invalid"
+                                  block
+                                  @update:value="handleUpdateUserId"
+                    />
+                </template>
+            </p-field-group>
+            <p-field-group :label="t('COMMON.SIGN_IN.PASSWORD')"
+                           required
+                           :invalid="validationState.isPasswordValid === false"
+            >
+                <template #default="{invalid}">
+                    <p-text-input :value="state.password"
+                                  type="password"
+                                  placeholder="Password"
+                                  :invalid="invalid"
+                                  block
+                                  @update:value="handleUpdatePassword"
+                                  @keyup.enter="signIn"
+                    />
+                </template>
+            </p-field-group>
+        </form>
+        <div class="util-wrapper">
+            <p class="reset-pw-button">
+                <router-link id="reset-pw-button"
+                             :to="{ name: AUTH_ROUTE.PASSWORD.STATUS.FIND._NAME, query: { status: 'find' } }"
+                >
+                    {{ t('AUTH.PASSWORD.FIND.FORGOT_PASSWORD') }}
+                </router-link>
+            </p>
+            <p-button :style-type="buttonStyleType"
+                      type="submit"
+                      size="lg"
+                      class="sign-in-btn"
+                      :loading="state.loading"
+                      @click="signIn"
+            >
+                {{ t('COMMON.SIGN_IN.SIGN_IN') }}
+            </p-button>
+        </div>
+    </div>
+</template>
+
 <script lang="ts" setup>
 /* eslint-disable camelcase */
 import { PButton, PTextInput, PFieldGroup } from '@spaceone/design-system';
@@ -66,6 +121,15 @@ const checkPassword = async () => {
     }
 };
 
+const handleUpdateUserId = (userId: string) => {
+    state.userId = userId;
+    checkUserId();
+};
+const handleUpdatePassword = async (password: string) => {
+    state.password = password;
+    await checkPassword();
+};
+
 const signIn = async () => {
     state.loading = true;
     checkUserId();
@@ -97,61 +161,6 @@ const signIn = async () => {
 const buttonStyleType = computed(() => (props.isDomainOwner ? 'primary' : 'substitutive'));
 
 </script>
-
-<template>
-    <div class="local-wrapper">
-        <form class="form"
-              onsubmit="return false"
-        >
-            <p-field-group :label="isDomainOwner ? t('COMMON.SIGN_IN.ADMIN_ID') : t('COMMON.SIGN_IN.USER_ID')"
-                           :invalid="validationState.isIdValid === false"
-                           required
-            >
-                <template #default="{invalid}">
-                    <p-text-input v-model="state.userId"
-                                  :placeholder="!isMobile() ? 'E-mail Address' : 'User ID'"
-                                  :invalid="invalid"
-                                  block
-                                  @update:value="checkUserId"
-                    />
-                </template>
-            </p-field-group>
-            <p-field-group :label="t('COMMON.SIGN_IN.PASSWORD')"
-                           required
-                           :invalid="validationState.isPasswordValid === false"
-            >
-                <template #default="{invalid}">
-                    <p-text-input v-model="state.password"
-                                  type="password"
-                                  placeholder="Password"
-                                  :invalid="invalid"
-                                  block
-                                  @update:value="checkPassword"
-                                  @keyup.enter="signIn"
-                    />
-                </template>
-            </p-field-group>
-        </form>
-        <div class="util-wrapper">
-            <p class="reset-pw-button">
-                <router-link id="reset-pw-button"
-                             :to="{ name: AUTH_ROUTE.PASSWORD.STATUS.FIND._NAME, query: { status: 'find' } }"
-                >
-                    {{ t('AUTH.PASSWORD.FIND.FORGOT_PASSWORD') }}
-                </router-link>
-            </p>
-            <p-button :style-type="buttonStyleType"
-                      type="submit"
-                      size="lg"
-                      class="sign-in-btn"
-                      :loading="state.loading"
-                      @click="signIn"
-            >
-                {{ t('COMMON.SIGN_IN.SIGN_IN') }}
-            </p-button>
-        </div>
-    </div>
-</template>
 
 <style lang="postcss" scoped>
 /* custom design-system component - p-text-input */

--- a/apps/web/src/services/home-dashboard/modules/TopProjects.vue
+++ b/apps/web/src/services/home-dashboard/modules/TopProjects.vue
@@ -10,7 +10,7 @@ import {
 import bytes from 'bytes';
 import { range } from 'lodash';
 import {
-    computed, onUnmounted, reactive, ref, watch,
+    computed, onBeforeUnmount, reactive, ref, watch,
 } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { LocationQueryRaw, RouteLocationRaw } from 'vue-router';
@@ -81,6 +81,10 @@ const state = reactive({
 
 /* Util */
 const drawChart = (chartContext) => {
+    if (state.chart) {
+        state.chart.dispose();
+        state.chart = null;
+    }
     const chart = am4core.create(chartContext, am4charts.XYChart);
     if (!config.get('AMCHARTS_LICENSE.ENABLED')) chart.logo.disabled = true;
     chart.paddingRight = 10;
@@ -243,7 +247,7 @@ watch([() => chartRef.value, () => state.chartData], ([chartContext, data]) => {
     }
 });
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
     if (state.chart) state.chart.dispose();
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,8 +175,8 @@
       "version": "1.12.0-dev54",
       "license": "Apache-2.0",
       "dependencies": {
-        "@amcharts/amcharts4": "^4.10.32",
-        "@amcharts/amcharts4-geodata": "^4.1.18",
+        "@amcharts/amcharts4": "^4.10.37",
+        "@amcharts/amcharts4-geodata": "^4.1.27",
         "@amcharts/amcharts5": "^5.2.31",
         "@amcharts/amcharts5-geodata": "^5.0.6",
         "@cloudforet/core-lib": "*",
@@ -35173,7 +35173,7 @@
       "version": "1.12.0-dev11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@amcharts/amcharts4": "^4.10.32",
+        "@amcharts/amcharts4": "^4.10.37",
         "@egjs/vue-flicking": "^3.7.4",
         "@faker-js/faker": "^7.3.0",
         "@juggle/resize-observer": "^3.3.1",
@@ -38581,7 +38581,7 @@
     "@spaceone/design-system": {
       "version": "file:packages/mirinae",
       "requires": {
-        "@amcharts/amcharts4": "^4.10.32",
+        "@amcharts/amcharts4": "^4.10.37",
         "@cloudforet/stylelint-config-custom": "*",
         "@egjs/vue-flicking": "^3.7.4",
         "@faker-js/faker": "^7.3.0",
@@ -61371,8 +61371,8 @@
     "web": {
       "version": "file:apps/web",
       "requires": {
-        "@amcharts/amcharts4": "^4.10.32",
-        "@amcharts/amcharts4-geodata": "^4.1.18",
+        "@amcharts/amcharts4": "^4.10.37",
+        "@amcharts/amcharts4-geodata": "4.1.27",
         "@amcharts/amcharts5": "^5.2.31",
         "@amcharts/amcharts5-geodata": "^5.0.6",
         "@babel/preset-env": "^7.21.4",

--- a/packages/mirinae/package.json
+++ b/packages/mirinae/package.json
@@ -50,7 +50,7 @@
     "icon": "node ./cli/svg-gen.js -s ./src/foundation/icons/icon-assets -t src/foundation/icons/p-icons"
   },
   "dependencies": {
-    "@amcharts/amcharts4": "^4.10.32",
+    "@amcharts/amcharts4": "^4.10.37",
     "@egjs/vue-flicking": "^3.7.4",
     "@faker-js/faker": "^7.3.0",
     "@juggle/resize-observer": "^3.3.1",


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

- Updated amcharts4 version
- Updated to use onBeforUnmount for chart dispose logics 
- Updated NOT to use deep reactivity system for chart registry to prevent maximum call stack

### Things to Talk About
