### PR TITLE
fix(select-dropdown): remove min-width at transparent style type

### DIFF
--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
@@ -185,13 +185,13 @@ export const Template = (args, { argTypes }) => ({
                         <tr>
                             <th>md</th>
                             <th v-for="styleType in styleTypes" :key="styleType" >
-                                <p-select-dropdown :size="size" :items="menuItems" :styleType="styleType" class="m-2 w-6/12" />
+                                <p-select-dropdown size="md" :items="menuItems" :styleType="styleType" class="m-2 w-6/12" />
                             </th>
                         </tr>
                         <tr>
                             <th>lg</th>
                             <th v-for="styleType in styleTypes" :key="styleType">
-                                <p-select-dropdown :size="size" :items="menuItems" :styleType="styleType" class="m-2 w-6/12" />
+                                <p-select-dropdown size="lg" :items="menuItems" :styleType="styleType" class="m-2 w-6/12" />
                             </th>
                         </tr>
                     </tbody>

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -339,6 +339,7 @@ export default defineComponent<SelectDropdownProps>({
         }
     }
     &.transparent {
+        min-width: unset;
         .dropdown-button {
             @apply border-transparent bg-transparent text-gray-900;
             padding-left: 0;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [x] Apps
  - [x] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA
- Console
  <img width="315" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/fbafe61c-88df-4a25-9e99-f1ffa5766c5f">

- Mirinae
  <img width="156" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/56bbb174-5c3f-4512-9cd7-3940edacaca1">


### Things to Talk About
