### PR TITLE
fix: use selected prop as v-model arg for p-select-status component

### DIFF
--- a/apps/web/src/services/alert-manager/alert/modules/AlertTableBottomFilters.vue
+++ b/apps/web/src/services/alert-manager/alert/modules/AlertTableBottomFilters.vue
@@ -80,7 +80,7 @@ watch([() => state.selectedAlertState, () => state.selectedUrgency, () => state.
             <span class="filter-label">{{ t('MONITORING.ALERT.ALERT_LIST.STATE') }}</span>
             <p-select-status v-for="(status, idx) in state.statusList"
                              :key="idx"
-                             v-model="state.selectedAlertState"
+                             v-model:selected="state.selectedAlertState"
                              :value="status.name"
             >
                 {{ status.label }}
@@ -90,7 +90,7 @@ watch([() => state.selectedAlertState, () => state.selectedUrgency, () => state.
             <span class="filter-label">{{ t('MONITORING.ALERT.ALERT_LIST.URGENCY') }}</span>
             <p-select-status v-for="(urgencyItem, idx) in state.urgencyList"
                              :key="idx"
-                             v-model="state.selectedUrgency"
+                             v-model:selected="state.selectedUrgency"
                              :value="urgencyItem.name"
                              class="mr-2"
             >

--- a/packages/mirinae/src/data-display/tables/toolbox-table/PToolboxTable.stories.mdx
+++ b/packages/mirinae/src/data-display/tables/toolbox-table/PToolboxTable.stories.mdx
@@ -152,7 +152,7 @@ This component is merged component of [Toolbox component](?path=/docs/navigation
                 <div class="p-4">
                     <strong class="mr-4">Select: </strong>
                     <p-select-status v-for="val in fields" :key="val.name" class="mr-2"
-                        v-model="selected" :value="val.name" />
+                        v-model:selected="selected" :value="val.name" />
                 </div>
             </template>
             </p-toolbox-table>

--- a/packages/mirinae/src/inputs/select-status/PSelectStatus.stories.mdx
+++ b/packages/mirinae/src/inputs/select-status/PSelectStatus.stories.mdx
@@ -64,7 +64,7 @@ export const Template = (args, { argTypes }) => ({
     <div class="w-full overflow p-8 flex flex-wrap">
         <p-select-status v-for="(value, idx) in values" :key="idx"
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             class="mr-4"
         >
             {{value}}
@@ -99,7 +99,7 @@ export const Template = (args, { argTypes }) => ({
         <p-select-status v-for="(value, idx) in values" :key="idx"
             :value="value"
             :icon="icons[idx]"
-            v-model="selected"
+            v-model:selected="selected"
             class="mr-4"
         >
             {{value}}
@@ -136,7 +136,7 @@ export const Template = (args, { argTypes }) => ({
         <p-select-status v-for="(value, idx) in values" :key="idx"
             :value="value"
             multi-selectable
-            v-model="selected"
+            v-model:selected="selected"
             class="mr-4"
         >
             {{value}}
@@ -170,7 +170,7 @@ export const Template = (args, { argTypes }) => ({
     <div class="w-full overflow p-8 flex flex-wrap">
         <p-select-status v-for="(value, idx) in values" :key="idx"
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             :disable-check-icon="true"
             class="mr-4"
         >

--- a/packages/mirinae/src/inputs/select-status/PSelectStatus.vue
+++ b/packages/mirinae/src/inputs/select-status/PSelectStatus.vue
@@ -70,7 +70,9 @@ const props = defineProps({
         default: false,
     },
 });
-const emit = defineEmits(['change']);
+const emit = defineEmits<{(e: 'change', selected: any, checked: boolean): void;
+    (e: 'update:selected', selected: any): void;
+}>();
 
 const {
     isSelected,
@@ -97,8 +99,10 @@ const onClick = () => {
     const newSelected = getSelected();
     if (props.multiSelectable) {
         emit('change', newSelected, !isSelected.value);
+        emit('update:selected', newSelected);
     } else {
         emit('change', newSelected, true);
+        emit('update:selected', newSelected);
     }
 };
 

--- a/packages/mirinae/src/inputs/select-status/story-helper.ts
+++ b/packages/mirinae/src/inputs/select-status/story-helper.ts
@@ -199,4 +199,17 @@ export const getSelectStatusArgTypes = (): ArgTypes => ({
             category: 'events',
         },
     },
+    onUpdateSelected: {
+        name: 'update:selected',
+        description: 'Event emitted when selected state is changed.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
 });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA

### Things to Talk About
