### PR TITLE
fix: use selected prop as v-model arg for p-select-card, p-select-button component

### DIFF
--- a/apps/web/src/services/administration/iam/role/role-update/modules/RoleUpdatePageBaseInformation.vue
+++ b/apps/web/src/services/administration/iam/role/role-update/modules/RoleUpdatePageBaseInformation.vue
@@ -95,7 +95,7 @@ watch(() => props.initialFormData, (initialFormData) => {
                 :label="t('IAM.ROLE.DETAIL.DESCRIPTION')"
             >
                 <template #default="{invalid}">
-                    <p-text-input v-model="state.roleDescription"
+                    <p-text-input v-model:value="state.roleDescription"
                                   class="role-description-input input"
                                   :invalid="invalid"
                     />
@@ -107,7 +107,7 @@ watch(() => props.initialFormData, (initialFormData) => {
             >
                 <p-select-card v-for="(roleType, index) in state.roleTypes"
                                :key="roleType.key"
-                               v-model="state.selectedRoleType"
+                               v-model:selected="state.selectedRoleType"
                                :tab-index="index"
                                class="card"
                                :value="roleType.key"

--- a/apps/web/src/services/alert-manager/alert/modules/AlertTableBottomFilters.vue
+++ b/apps/web/src/services/alert-manager/alert/modules/AlertTableBottomFilters.vue
@@ -100,7 +100,7 @@ watch([() => state.selectedAlertState, () => state.selectedUrgency, () => state.
         <div class="filter filter-assigned">
             <p-select-button v-for="(item, idx) in state.assignedStateList"
                              :key="`assigned-${idx}`"
-                             v-model="state.selectedAssigned"
+                             v-model:selected="state.selectedAssigned"
                              :value="item.name"
                              size="sm"
                              style-type="gray"

--- a/apps/web/src/services/project/project-detail/modules/MaintenanceWindowFormModal.vue
+++ b/apps/web/src/services/project/project-detail/modules/MaintenanceWindowFormModal.vue
@@ -308,7 +308,7 @@ watch(() => props.visible, async (visible) => {
                     <template v-if="state.selectedScheduleType === SCHEDULE_TYPE.startNow">
                         <p-select-button v-for="{name, label} in state.durationItems"
                                          :key="name"
-                                         v-model="state.selectedDuration"
+                                         v-model:selected="state.selectedDuration"
                                          :value="name"
                                          class="mr-2"
                         >

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -29,7 +29,7 @@ module.exports = {
         'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
         'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
         'no-unsafe-optional-chaining': 1,
-        'no-undef': 1,
+        'no-undef': 0,
         'no-unused-vars': ['off'],
         'no-mixed-operators': 0,
         'no-promise-executor-return': 1,

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -166,5 +166,11 @@ module.exports = {
                 jest: true,
             },
         },
+        {
+            files: ['*.js'],
+            rules: {
+                'no-undef': 'error',
+            },
+        },
     ],
 };

--- a/packages/mirinae/src/feedbacks/loading/lazy-img/PLazyImg.vue
+++ b/packages/mirinae/src/feedbacks/loading/lazy-img/PLazyImg.vue
@@ -57,7 +57,7 @@ import PI from '@/foundation/icons/PI.vue';
 interface Props {
     height?: string;
     width?: string;
-    src: string;
+    src?: string;
     errorIcon?: string;
     errorIconColor?: string;
     loading?: boolean;

--- a/packages/mirinae/src/foundation/icons/PI.vue
+++ b/packages/mirinae/src/foundation/icons/PI.vue
@@ -23,8 +23,8 @@ interface Props {
     name: string;
     dir?: string;
     fill?: boolean;
-    width: string;
-    height: string;
+    width?: string;
+    height?: string;
     scale?: string;
     color?: string;
     original?: boolean;

--- a/packages/mirinae/src/inputs/select-button/PSelectButton.stories.mdx
+++ b/packages/mirinae/src/inputs/select-button/PSelectButton.stories.mdx
@@ -23,7 +23,7 @@ export const Template = (args, { argTypes }) => ({
     template: `
     <div class="h-full w-full overflow p-8">
         <p-select-button :value="value"
-            v-model="proxySelected"
+            v-model:selected="proxySelected"
             :predicate="predicate"
             :multi-selectable="multiSelectable"
             :style-type="styleType"
@@ -58,7 +58,7 @@ export const Template = (args, { argTypes }) => ({
     <div class="w-full overflow p-8 flex flex-wrap">
         <p-select-button v-for="value in values" :key="value"
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             class="mr-2"
         >
             {{value}}
@@ -92,7 +92,7 @@ export const Template = (args, { argTypes }) => ({
         <p-select-button v-for="value in values" :key="value"
             multi-selectable
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             class="mr-2"
         >
             {{value}}
@@ -132,7 +132,7 @@ export const Template = (args, { argTypes }) => ({
                         :size="size"
                         :style-type="styleType"
                         :value="value"
-                        v-model="selected"
+                        v-model:selected="selected"
                         class="mr-2"
                 >
                     {{value}}
@@ -170,7 +170,7 @@ export const Template = (args, { argTypes }) => ({
             template: `
     <div class="w-full overflow p-8 grid gap-4 grid-cols-3">
         <p-select-button v-for="value in values" :key="value.key"
-            v-model="selected"
+            v-model:selected="selected"
             :value="value"
             :predicate="predicate"
             class="mb-4"

--- a/packages/mirinae/src/inputs/select-button/PSelectButton.vue
+++ b/packages/mirinae/src/inputs/select-button/PSelectButton.vue
@@ -56,7 +56,9 @@ const props = defineProps({
         },
     },
 });
-const emit = defineEmits(['change']);
+const emit = defineEmits<{(e: 'change', selected: any, checked: boolean): void;
+    (e: 'update:selected', selected: any): void;
+}>();
 const attrs = useAttrs();
 
 const {
@@ -74,8 +76,10 @@ const onClick = () => {
     const newSelected = getSelected();
     if (props.multiSelectable) {
         emit('change', newSelected, !isSelected.value);
+        emit('update:selected', newSelected);
     } else {
         emit('change', newSelected, true);
+        emit('update:selected', newSelected);
     }
 };
 

--- a/packages/mirinae/src/inputs/select-button/story-helper.ts
+++ b/packages/mirinae/src/inputs/select-button/story-helper.ts
@@ -163,4 +163,17 @@ export const getSelectButtonArgTypes = (): ArgTypes => ({
             category: 'events',
         },
     },
+    onUpdateSelected: {
+        name: 'update:selected',
+        description: 'Event emitted when selected state is changed.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
 });

--- a/packages/mirinae/src/inputs/select-card/PSelectCard.stories.mdx
+++ b/packages/mirinae/src/inputs/select-card/PSelectCard.stories.mdx
@@ -25,7 +25,7 @@ export const Template = (args, { argTypes }) => ({
     template: `
     <div class="h-full w-full overflow p-8">
         <p-select-card :value="value"
-            v-model="proxySelected"
+            v-model:selected="proxySelected"
             :disabled="disabled"
             :predicate="predicate"
             :multi-selectable="multiSelectable"
@@ -67,7 +67,7 @@ export const Template = (args, { argTypes }) => ({
         <p-select-card v-for="(value, index) in values" :key="value"
             :tab-index="index"
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             :icon="icons[value]"
             :label="icons[value]"
             style="min-width: 10rem; max-width: 10rem; min-height: 10rem; max-height: 10rem; margin: 1rem;"
@@ -102,7 +102,7 @@ export const Template = (args, { argTypes }) => ({
         <p-select-card v-for="(value, index) in values" :key="value"
             :tab-index="index"
             :value="value" block
-            v-model="selected"
+            v-model:selected="selected"
             :icon="icons[value]"
             :label="icons[value]"
             class="mb-4"
@@ -137,7 +137,7 @@ export const Template = (args, { argTypes }) => ({
         <p-select-card v-for="(value, index) in values" :key="value"
             :tab-index="index"
             :value="value" block
-            v-model="selected"
+            v-model:selected="selected"
             :label="icons[value]"
             class="mb-4"
         />
@@ -172,7 +172,7 @@ export const Template = (args, { argTypes }) => ({
         <p-select-card v-for="(value, index) in values" :key="value"
             :tab-index="index"
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             :label="'label-' + value"
             :icon="true"
             style="min-width: 10rem; max-width: 10rem; min-height: 10rem; max-height: 10rem; margin: 1rem;"
@@ -208,7 +208,7 @@ export const Template = (args, { argTypes }) => ({
             :tab-index="index"
             multi-selectable
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             :icon="icons[value]"
             :label="icons[value]"
             style="min-width: 10rem; max-width: 10rem; min-height: 10rem; max-height: 10rem; margin: 1rem;"
@@ -243,7 +243,7 @@ export const Template = (args, { argTypes }) => ({
     <div class="w-full overflow p-8 grid gap-4 grid-cols-3">
         <p-select-card v-for="(value, index) in values" :key="value.key"
             :tab-index="index"
-            v-model="selected"
+            v-model:selected="selected"
             :value="value"
             :label="value.name"
             :predicate="predicate"
@@ -286,7 +286,7 @@ export const Template = (args, { argTypes }) => ({
         <p-select-card v-for="(value, index) in values" :key="value"
             :tab-index="index"
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             style="min-width: 8rem; min-height: 8rem; margin: 1rem;"
         >
             <strong :style="{color: value}">{{value}}</strong>
@@ -317,7 +317,7 @@ export const Template = (args, { argTypes }) => ({
     <div class="w-full overflow p-8 flex flex-wrap">
         <p-select-card v-for="(value, index) in values" :key="value"
             :value="value"
-            v-model="selected"
+            v-model:selected="selected"
             :label="icons[index]"
             :icon="icons[index]"
             :tab-index="index"

--- a/packages/mirinae/src/inputs/select-card/PSelectCard.vue
+++ b/packages/mirinae/src/inputs/select-card/PSelectCard.vue
@@ -61,7 +61,9 @@ const props = withDefaults(defineProps<Props>(), {
     label: '',
     tabIndex: undefined,
 });
-const emit = defineEmits(['change']);
+const emit = defineEmits<{(e: 'change', selected: any, checked: boolean): void;
+    (e: 'update:selected', selected: any): void;
+}>();
 const attrs = useAttrs();
 
 const {
@@ -98,8 +100,10 @@ const handleClick = () => {
     const newSelected = getSelected();
     if (props.multiSelectable) {
         emit('change', newSelected, !isSelected.value);
+        emit('update:selected', newSelected);
     } else {
         emit('change', newSelected, true);
+        emit('update:selected', newSelected);
     }
 };
 

--- a/packages/mirinae/src/inputs/select-card/story-helper.ts
+++ b/packages/mirinae/src/inputs/select-card/story-helper.ts
@@ -270,4 +270,17 @@ export const getSelectCardArgTypes = (): ArgTypes => ({
             category: 'events',
         },
     },
+    onUpdateSelected: {
+        name: 'update:selected',
+        description: 'Event emitted when selected state is changed.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
 });


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [x] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA

This PR updates eslint rule.
for more information, look [here](https://github.com/typescript-eslint/typescript-eslint/blob/1cf9243/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors).

### Things to Talk About
