### PR TITLE
fix: resolving Build Error Due to Variable Usage in defineProps

### DIFF
--- a/apps/web/src/common/components/guidance/InfoMessage.vue
+++ b/apps/web/src/common/components/guidance/InfoMessage.vue
@@ -15,7 +15,7 @@ interface Props {
 }
 
 withDefaults(defineProps<Props>(), {
-    styleType: STYLE_TYPE.gray,
+    styleType: 'gray',
     message: '',
     block: false,
 });

--- a/apps/web/src/services/cost-explorer/widgets/modules/CostDashboardSimpleCardWidget.vue
+++ b/apps/web/src/services/cost-explorer/widgets/modules/CostDashboardSimpleCardWidget.vue
@@ -5,8 +5,6 @@ import {
 } from 'vue';
 import type { RouteLocation } from 'vue-router';
 
-
-import { CURRENCY_SYMBOL } from '@/store/modules/settings/config';
 import type { CurrencySymbol } from '@/store/modules/settings/type';
 
 const UNIT_TYPE = Object.freeze({
@@ -31,8 +29,8 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
     loading: true,
     title: '',
-    currencySymbol: CURRENCY_SYMBOL.USD,
-    unitType: UNIT_TYPE.CURRENCY,
+    currencySymbol: '$',
+    unitType: 'CURRENCY',
     value: 0,
     showDivider: true,
     description: '',

--- a/apps/web/src/services/project/project-detail/project-alert/project-alert-event-rule/modules/EventRuleConditionForm.vue
+++ b/apps/web/src/services/project/project-detail/project-alert/project-alert-event-rule/modules/EventRuleConditionForm.vue
@@ -28,7 +28,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-    conditionsPolicy: CONDITIONS_POLICY.ALL,
+    conditionsPolicy: 'ALL',
     conditions: () => ([]),
 });
 const emit = defineEmits<{(e: 'update:conditionsPolicy', value: ConditionsPolicy): void;

--- a/apps/web/src/services/project/project-detail/project-alert/project-alert-event-rule/modules/EventRuleForm.vue
+++ b/apps/web/src/services/project/project-detail/project-alert/project-alert-event-rule/modules/EventRuleForm.vue
@@ -40,7 +40,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
     projectId: undefined,
-    mode: EDIT_MODE.CREATE,
+    mode: 'CREATE',
     eventRuleId: undefined,
 });
 const emit = defineEmits<{(e: 'confirm'): void;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA

### Things to Talk About
