### PR TITLE
fix: do not show session expired modal while routing to sign-in page

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -135,20 +135,23 @@ export default defineComponent({
 
         const state = reactive({
             showGNB: computed(() => vm.$route.matched[0]?.name === 'root'),
-            isExpired: computed(() => vm.$store.state.error.visibleSessionExpiredError && getRouteAccessLevel(vm.$route) >= ACCESS_LEVEL.AUTHENTICATED),
+            isExpired: computed(() => !state.isRoutingToSignIn && store.state.error.visibleSessionExpiredError && getRouteAccessLevel(vm.$route) >= ACCESS_LEVEL.AUTHENTICATED),
+            isRoutingToSignIn: false,
             isEmailVerified: computed(() => store.state.user.emailVerified),
             userId: computed(() => store.state.user.userId),
             email: computed(() => store.state.user.email),
             domainId: computed(() => store.state.domain.domainId),
             notificationEmailModalVisible: false,
         });
-        const goToSignIn = () => {
+        const goToSignIn = async () => {
+            state.isRoutingToSignIn = true;
             const res: Location = {
                 name: AUTH_ROUTE.SIGN_OUT._NAME,
                 query: { nextPath: vm.$route.fullPath },
             };
             store.commit('error/setVisibleSessionExpiredError', false);
-            vm.$router.push(res);
+            await vm.$router.push(res);
+            state.isRoutingToSignIn = false;
         };
         const showsBrowserRecommendation = () => !supportsBrowser() && !LocalStorageAccessor.getItem('showBrowserRecommendation');
         const updateUser = async () => {

--- a/apps/web/src/common/modules/navigations/lnb/modules/LNBRouterMenuItem.vue
+++ b/apps/web/src/common/modules/navigations/lnb/modules/LNBRouterMenuItem.vue
@@ -29,7 +29,6 @@ const state = reactive({
 const getIsHovered = (itemId: string) => state.hoveredItem && state.hoveredItem === itemId;
 const isSelectedMenu = (selectedMenuRoute: Location): boolean => {
     let currentPath = props.currentPath;
-    console.debug('currentPath', currentPath, selectedMenuRoute);
     if (!currentPath) return false;
 
     const resolved = SpaceRouter.router.resolve(selectedMenuRoute);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

- Fixed bug that shows session expired modal again while routing to sign-in page.
- Refactored App.vue to use script setup.

### Things to Talk About
