### PR TITLE
feat(cost-query-set): create managed cost-query-set & edit cost-query…

### DIFF
--- a/apps/web/src/common/modules/navigations/lnb/LNB.vue
+++ b/apps/web/src/common/modules/navigations/lnb/LNB.vue
@@ -19,7 +19,7 @@ import type {
 import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
 
 interface Props {
-    header: string;
+    header?: string;
     backLink?: BackLink;
     topTitle?: TopTitle;
     menuSet: LNBMenu[];

--- a/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
@@ -20,20 +20,22 @@ import LNBRouterMenuItem from '@/common/modules/navigations/lnb/modules/LNBRoute
 import type { LNBItem, LNBMenu } from '@/common/modules/navigations/lnb/type';
 import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
 
-import { managedCostQuertSetIdList } from '@/services/cost-explorer/cost-analysis/config';
+import { managedCostQuerySetIdList } from '@/services/cost-explorer/cost-analysis/config';
 import RelocateDashboardNotification from '@/services/cost-explorer/modules/RelocateDashboardNotification.vue';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
-import { useCostQueryStore } from '@/services/cost-explorer/store/cost-query-store';
+import { useCostQuerySetStore } from '@/services/cost-explorer/store/cost-query-set-store';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
-const costQueryStore = useCostQueryStore();
+const DATA_SOURCE_DROPDOWN_KEY = 'data-source';
+
+const costQueryStore = useCostQuerySetStore();
 const costQueryState = costQueryStore.$state;
 
 const state = reactive({
     loading: true,
     header: computed(() => i18n.t(MENU_INFO_MAP[MENU_ID.COST_EXPLORER].translationId)),
     menuSet: computed<LNBMenu[]>(() => [
-        ...state.costAnalysisMenuSet,
+        ...filterCostAnalysisLNBMenuByPagePermission(state.costAnalysisMenuSet),
         ...filterLNBMenuByPermission([
             {
                 type: 'item',
@@ -47,11 +49,11 @@ const state = reactive({
         { type: MENU_ITEM_TYPE.FAVORITE_ONLY },
         {
             type: MENU_ITEM_TYPE.TOP_TITLE,
-            label: 'Cost Analysis',
+            label: i18n.t(MENU_INFO_MAP[MENU_ID.COST_EXPLORER_COST_ANALYSIS].translationId),
         },
         {
             type: MENU_ITEM_TYPE.DROPDOWN,
-            id: 'data-source',
+            id: DATA_SOURCE_DROPDOWN_KEY,
             selectOptions: {
                 items: costQueryState.dataSourceList.map((dataSource) => ({
                     name: dataSource,
@@ -70,7 +72,7 @@ const state = reactive({
             type: 'item',
             id: d.cost_query_set_id,
             label: d.name,
-            icon: managedCostQuertSetIdList.includes(d.cost_query_set_id) ? 'ic_main-filled' : undefined,
+            icon: managedCostQuerySetIdList.includes(d.cost_query_set_id) ? 'ic_main-filled' : undefined,
             to: {
                 name: COST_EXPLORER_ROUTE.COST_ANALYSIS._NAME,
                 params: {
@@ -97,8 +99,16 @@ const relocateNotificationState = reactive({
     isModalVisible: false,
 });
 
+const filterCostAnalysisLNBMenuByPagePermission = (menuSet: LNBItem[]): LNBItem[] => {
+    const pagePermission = store.getters['user/pagePermissionMap'];
+    const routeName = MENU_ID.COST_EXPLORER_COST_ANALYSIS;
+
+    if (pagePermission[routeName]) return [...menuSet];
+    return [];
+};
+
 const handleSelect = (id: string, selected: string) => {
-    if (id === 'data-source') costQueryStore.$patch({ selectedDataSource: selected });
+    if (id === DATA_SOURCE_DROPDOWN_KEY) costQueryStore.$patch({ selectedDataSource: selected });
 };
 
 const handleLearnMoreRelocateNotification = () => {

--- a/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
@@ -8,6 +8,8 @@ import { PButtonModal, PI } from '@spaceone/design-system';
 import { store } from '@/store';
 import { i18n } from '@/translations';
 
+import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
+
 import { filterLNBMenuByPermission } from '@/lib/access-control/page-permission-helper';
 import { MENU_ID } from '@/lib/menu/config';
 import { MENU_INFO_MAP } from '@/lib/menu/menu-info';
@@ -16,25 +18,23 @@ import LNB from '@/common/modules/navigations/lnb/LNB.vue';
 import LNBDividerMenuItem from '@/common/modules/navigations/lnb/modules/LNBDividerMenuItem.vue';
 import LNBRouterMenuItem from '@/common/modules/navigations/lnb/modules/LNBRouterMenuItem.vue';
 import type { LNBItem, LNBMenu } from '@/common/modules/navigations/lnb/type';
+import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
 
+import { managedCostQuertSetIdList } from '@/services/cost-explorer/cost-analysis/config';
 import RelocateDashboardNotification from '@/services/cost-explorer/modules/RelocateDashboardNotification.vue';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
-import { useCostAnalysisLNBStore } from '@/services/cost-explorer/store/cost-query-store';
+import { useCostQueryStore } from '@/services/cost-explorer/store/cost-query-store';
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
-const costQueryStore = useCostAnalysisLNBStore();
+const costQueryStore = useCostQueryStore();
+const costQueryState = costQueryStore.$state;
 
 const state = reactive({
     loading: true,
     header: computed(() => i18n.t(MENU_INFO_MAP[MENU_ID.COST_EXPLORER].translationId)),
     menuSet: computed<LNBMenu[]>(() => [
+        ...state.costAnalysisMenuSet,
         ...filterLNBMenuByPermission([
-            {
-                type: 'item',
-                id: MENU_ID.COST_EXPLORER_COST_ANALYSIS,
-                label: i18n.t(MENU_INFO_MAP[MENU_ID.COST_EXPLORER_COST_ANALYSIS].translationId),
-                to: { name: COST_EXPLORER_ROUTE.COST_ANALYSIS._NAME },
-            },
             {
                 type: 'item',
                 id: MENU_ID.COST_EXPLORER_BUDGET,
@@ -43,6 +43,44 @@ const state = reactive({
             },
         ], store.getters['user/pagePermissionList']),
     ]),
+    costAnalysisMenuSet: computed<LNBMenu[]>(() => [
+        { type: MENU_ITEM_TYPE.FAVORITE_ONLY },
+        {
+            type: MENU_ITEM_TYPE.TOP_TITLE,
+            label: 'Cost Analysis',
+        },
+        {
+            type: MENU_ITEM_TYPE.DROPDOWN,
+            id: 'data-source',
+            selectOptions: {
+                items: costQueryState.dataSourceList.map((dataSource) => ({
+                    name: dataSource,
+                    label: dataSource,
+                })),
+                defaultSelected: state.selectedDataSource,
+            },
+        },
+        ...state.queryMenuSet,
+        {
+            type: MENU_ITEM_TYPE.DIVIDER,
+        },
+    ]),
+    queryMenuSet: computed<LNBMenu>(() => {
+        const currentQueryMenuList: LNBMenu = costQueryState.costQuerySetList.map((d) => ({
+            type: 'item',
+            id: d.cost_query_set_id,
+            label: d.name,
+            icon: managedCostQuertSetIdList.includes(d.cost_query_set_id) ? 'ic_main-filled' : undefined,
+            to: {
+                name: COST_EXPLORER_ROUTE.COST_ANALYSIS._NAME,
+                params: {
+                    querySetId: d.cost_query_set_id,
+                },
+            },
+            favoriteType: FAVORITE_TYPE.COST_ANALYSIS,
+        }));
+        return currentQueryMenuList;
+    }),
 });
 
 const relocateNotificationState = reactive({
@@ -79,9 +117,7 @@ const handleDismissRelocateNotification = () => {
                :menu-set="state.menuSet"
                @select="handleSelect"
         >
-            <template v-if="relocateNotificationState.isShow"
-                      #default
-            >
+            <template #default>
                 <l-n-b-router-menu-item :item="relocateNotificationState.data">
                     <template #after-text>
                         <p-i name="ic_arrow-right-up"
@@ -91,7 +127,8 @@ const handleDismissRelocateNotification = () => {
                         />
                     </template>
                 </l-n-b-router-menu-item>
-                <relocate-dashboard-notification @click-dismiss="handleDismissRelocateNotification"
+                <relocate-dashboard-notification v-if="relocateNotificationState.isShow"
+                                                 @click-dismiss="handleDismissRelocateNotification"
                                                  @click-learn-more="handleLearnMoreRelocateNotification"
                 />
                 <l-n-b-divider-menu-item />

--- a/apps/web/src/services/cost-explorer/cost-analysis/config.ts
+++ b/apps/web/src/services/cost-explorer/cost-analysis/config.ts
@@ -1,6 +1,5 @@
-import dayjs from 'dayjs';
-
 import { GRANULARITY, GROUP_BY } from '@/services/cost-explorer/lib/config';
+import { getInitialDates } from '@/services/cost-explorer/lib/helper';
 import type { CostQuerySetModel, Period } from '@/services/cost-explorer/type';
 
 export const MANAGED_COST_QUERY_SET_IDS = {
@@ -9,16 +8,13 @@ export const MANAGED_COST_QUERY_SET_IDS = {
     MONTHLY_PRODUCT: 'Monthly cost by product',
 } as const;
 
-export const managedCostQuertSetIdList: string[] = [
+export const managedCostQuerySetIdList: string[] = [
     MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
     MANAGED_COST_QUERY_SET_IDS.MONTHLY_SERVICE_ACCOUNT,
     MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
 ];
 
-const defaultPeriod: Period = {
-    start: dayjs.utc().subtract(5, 'month').startOf('month').format(),
-    end: dayjs.utc().endOf('month').format(),
-};
+const defaultPeriod: Period = getInitialDates();
 
 export const managedCostQuerySets: CostQuerySetModel[] = [
     {

--- a/apps/web/src/services/cost-explorer/cost-analysis/config.ts
+++ b/apps/web/src/services/cost-explorer/cost-analysis/config.ts
@@ -1,0 +1,51 @@
+import dayjs from 'dayjs';
+
+import { GRANULARITY, GROUP_BY } from '@/services/cost-explorer/lib/config';
+import type { CostQuerySetModel, Period } from '@/services/cost-explorer/type';
+
+export const MANAGED_COST_QUERY_SET_IDS = {
+    MONTHLY_PROJECT: 'Monthly cost by project',
+    MONTHLY_SERVICE_ACCOUNT: 'Monthly cost by service account',
+    MONTHLY_PRODUCT: 'Monthly cost by product',
+} as const;
+
+export const managedCostQuertSetIdList: string[] = [
+    MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
+    MANAGED_COST_QUERY_SET_IDS.MONTHLY_SERVICE_ACCOUNT,
+    MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
+];
+
+const defaultPeriod: Period = {
+    start: dayjs.utc().subtract(5, 'month').startOf('month').format(),
+    end: dayjs.utc().endOf('month').format(),
+};
+
+export const managedCostQuerySets: CostQuerySetModel[] = [
+    {
+        cost_query_set_id: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
+        name: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
+        options: {
+            group_by: [GROUP_BY.PROJECT],
+            granularity: GRANULARITY.MONTHLY,
+            period: defaultPeriod,
+        },
+    },
+    {
+        cost_query_set_id: MANAGED_COST_QUERY_SET_IDS.MONTHLY_SERVICE_ACCOUNT,
+        name: MANAGED_COST_QUERY_SET_IDS.MONTHLY_SERVICE_ACCOUNT,
+        options: {
+            group_by: [GROUP_BY.SERVICE_ACCOUNT],
+            granularity: GRANULARITY.MONTHLY,
+            period: defaultPeriod,
+        },
+    },
+    {
+        cost_query_set_id: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
+        name: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
+        options: {
+            group_by: [GROUP_BY.PRODUCT],
+            granularity: GRANULARITY.MONTHLY,
+            period: defaultPeriod,
+        },
+    },
+];

--- a/apps/web/src/services/cost-explorer/store/cost-analysis-page-store.ts
+++ b/apps/web/src/services/cost-explorer/store/cost-analysis-page-store.ts
@@ -8,7 +8,7 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 import { GRANULARITY, GROUP_BY, MORE_GROUP_BY } from '@/services/cost-explorer/lib/config';
 import { convertFiltersInToNewType, getInitialDates, getRefinedCostQueryOptions } from '@/services/cost-explorer/lib/helper';
 import { useCostExplorerSettingsStore } from '@/services/cost-explorer/store/cost-explorer-settings-store';
-import { useCostAnalysisLNBStore } from '@/services/cost-explorer/store/cost-query-store';
+import { useCostQueryStore } from '@/services/cost-explorer/store/cost-query-store';
 import type {
     CostFiltersMap, CostQuerySetModel, CostQuerySetOption, Granularity, GroupBy, MoreGroupByItem, Period,
 } from '@/services/cost-explorer/type';
@@ -25,7 +25,7 @@ interface CostAnalysisPageState {
 
 const costExplorerSettingsStore = useCostExplorerSettingsStore();
 costExplorerSettingsStore.initState();
-const costQueryStore = useCostAnalysisLNBStore();
+const costQueryStore = useCostQueryStore();
 const costQueryState = costQueryStore.$state;
 
 const moreGroupByCategorySet = new Set(Object.values(MORE_GROUP_BY));
@@ -83,8 +83,8 @@ export const useCostAnalysisPageStore = defineStore('cost-analysis-page', {
         filters: {},
     }),
     getters: {
-        selectedQueryId: () => costQueryState.selectedQueryId,
-        costQueryList: () => costQueryState.costQueryList,
+        selectedQueryId: () => costQueryState.selectedQuerySetId,
+        costQueryList: () => costQueryState.costQuerySetList,
         selectedQuerySet: () => costQueryStore.selectedQuerySet,
         currentQuerySetOptions: (state): Partial<CostQuerySetOption> => getRefinedCostQueryOptions({
             granularity: state.granularity,
@@ -184,10 +184,10 @@ export const useCostAnalysisPageStore = defineStore('cost-analysis-page', {
             costExplorerSettingsStore.setCostAnalysisMoreGroupBy(moreGroupByItems);
         },
         selectQueryId(querySetId: string|undefined) {
-            costQueryStore.$patch({ selectedQueryId: querySetId });
+            costQueryStore.$patch({ selectedQuerySetId: querySetId });
         },
         async getCostQueryList() {
-            await costQueryStore.listCostQueryList();
+            await costQueryStore.listCostQuerySets();
         },
     },
 });

--- a/apps/web/src/services/cost-explorer/store/cost-analysis-page-store.ts
+++ b/apps/web/src/services/cost-explorer/store/cost-analysis-page-store.ts
@@ -8,7 +8,7 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 import { GRANULARITY, GROUP_BY, MORE_GROUP_BY } from '@/services/cost-explorer/lib/config';
 import { convertFiltersInToNewType, getInitialDates, getRefinedCostQueryOptions } from '@/services/cost-explorer/lib/helper';
 import { useCostExplorerSettingsStore } from '@/services/cost-explorer/store/cost-explorer-settings-store';
-import { useCostQueryStore } from '@/services/cost-explorer/store/cost-query-store';
+import { useCostQuerySetStore } from '@/services/cost-explorer/store/cost-query-set-store';
 import type {
     CostFiltersMap, CostQuerySetModel, CostQuerySetOption, Granularity, GroupBy, MoreGroupByItem, Period,
 } from '@/services/cost-explorer/type';
@@ -25,7 +25,7 @@ interface CostAnalysisPageState {
 
 const costExplorerSettingsStore = useCostExplorerSettingsStore();
 costExplorerSettingsStore.initState();
-const costQueryStore = useCostQueryStore();
+const costQueryStore = useCostQuerySetStore();
 const costQueryState = costQueryStore.$state;
 
 const moreGroupByCategorySet = new Set(Object.values(MORE_GROUP_BY));

--- a/apps/web/src/services/cost-explorer/store/cost-query-set-store.ts
+++ b/apps/web/src/services/cost-explorer/store/cost-query-set-store.ts
@@ -16,7 +16,7 @@ interface CostAnalysisLNBState {
     selectedDataSource?: string;
 }
 
-export const useCostQueryStore = defineStore('cost-query', {
+export const useCostQuerySetStore = defineStore('cost-query-set', {
     state: (): CostAnalysisLNBState => ({
         costQuerySetList: [],
         dataSourceList: [],

--- a/apps/web/src/services/cost-explorer/store/cost-query-store.ts
+++ b/apps/web/src/services/cost-explorer/store/cost-query-store.ts
@@ -6,40 +6,41 @@ import { store } from '@/store';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
 
+import { managedCostQuerySets } from '@/services/cost-explorer/cost-analysis/config';
 import type { CostQuerySetModel } from '@/services/cost-explorer/type';
 
 interface CostAnalysisLNBState {
-    costQueryList: CostQuerySetModel[];
+    costQuerySetList: CostQuerySetModel[];
     dataSourceList: string[];
-    selectedQueryId?: string;
+    selectedQuerySetId?: string;
     selectedDataSource?: string;
 }
 
-export const useCostAnalysisLNBStore = defineStore('cost-analysis-l-n-b', {
+export const useCostQueryStore = defineStore('cost-query', {
     state: (): CostAnalysisLNBState => ({
-        costQueryList: [],
+        costQuerySetList: [],
         dataSourceList: [],
-        selectedQueryId: undefined,
+        selectedQuerySetId: undefined,
         selectedDataSource: undefined,
     }),
     getters: {
         selectedQuerySet: (state): CostQuerySetModel|undefined => {
-            if (!state.selectedQueryId) return undefined;
-            return state.costQueryList.find((item) => item.cost_query_set_id === state.selectedQueryId);
+            if (!state.selectedQuerySetId) return undefined;
+            return state.costQuerySetList.find((item) => item.cost_query_set_id === state.selectedQuerySetId);
         },
     },
     actions: {
-        async listCostQueryList(): Promise<void> {
+        async listCostQuerySets(): Promise<void> {
             try {
                 const { results } = await SpaceConnector.client.costAnalysis.costQuerySet.list({
                     query: {
                         filter: [{ k: 'user_id', v: store.state.user.userId, o: 'eq' }],
                     },
                 });
-                this.costQueryList = results;
+                this.costQuerySetList = [...managedCostQuerySets, ...results];
             } catch (e) {
                 ErrorHandler.handleError(e);
-                this.costQueryList = [];
+                this.costQuerySetList = [...managedCostQuerySets];
             }
         },
     },


### PR DESCRIPTION
…-store name

### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

- Create managed cost-query-sets
- Add cost-query menuSet in CostExplorer LNB
- edit cost-query-store naming
![image](https://github.com/cloudforet-io/console/assets/83635051/a2f9bd91-383c-45a2-8a22-d8761ddbb5e9)


### Things to Talk About
