### PR TITLE
refactor: split widget state into several hooks and added new lifecycle hook

### DIFF
--- a/apps/web/src/services/dashboards/shared/dashboard-widget-container/DashboardWidgetContainer.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-container/DashboardWidgetContainer.vue
@@ -25,6 +25,7 @@ import {
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
 import WidgetViewModeModal from '@/services/dashboards/widgets/_components/WidgetViewModeModal.vue';
 import type {
+    DashboardLayoutWidgetInfo,
     WidgetExpose, WidgetProps,
 } from '@/services/dashboards/widgets/_configs/config';
 
@@ -87,6 +88,20 @@ const handleIntersectionObserver = async ([{ isIntersecting, target }]) => {
         }
     }
 };
+const handleUpdateData = (widgetKey: string, data: any) => {
+    dashboardDetailStore.$patch((_state) => {
+        _state.widgetDataMap[widgetKey] = data;
+    });
+};
+const handleUpdateWidgetInfo = (widgetKey: string, widgetInfo: Partial<DashboardLayoutWidgetInfo>) => {
+    const originWidgetInfo = dashboardDetailState.dashboardWidgetInfoList.find((d) => d.widget_key === widgetKey);
+    dashboardDetailStore.updateWidgetInfo(widgetKey, { ...originWidgetInfo, ...widgetInfo });
+};
+const handleUpdateValidation = (widgetKey: string, isValid: boolean) => {
+    dashboardDetailStore.updateWidgetValidation(widgetKey, isValid);
+};
+
+
 watch(reformedWidgetInfoList, (widgetInfoList) => {
     if (!Array.isArray(widgetInfoList)) return;
     const initiatedWidgetMap = {};
@@ -173,15 +188,42 @@ onMounted(async () => {
                            :title="widget.title"
                            :options="widget.widget_options"
                            :inherit-options="widget.inherit_options"
+                           :schema-properties="widget.schema_properties"
                            :size="widget.size"
                            :width="widget.width"
                            :theme="widget.theme"
                            :currency-rates="state.currencyRates"
-                           :edit-mode="props.editMode"
-                           :error-mode="props.editMode && dashboardDetailState.widgetValidMap[widget.widget_key] === false"
+                           :edit-mode="editMode"
+                           :error-mode="editMode && dashboardDetailState.widgetValidMap[widget.widget_key] === false"
                            :all-reference-type-info="state.allReferenceTypeInfo"
                            :initiated="!!state.initiatedWidgetMap[widget.widget_key]"
+                           :disable-refresh-on-variable-change="dashboardDetailState.widgetViewModeModalVisible"
+                           :dashboard-settings="dashboardDetailState.settings"
+                           :dashboard-variables-schema="dashboardDetailState.variablesSchema"
+                           :dashboard-variables="dashboardDetailState.variables"
+                           @update-data="handleUpdateData(widget.widget_key, $event)"
+                           @update-widget-info="handleUpdateWidgetInfo(widget.widget_key, $event)"
+                           @update-widget-validation="handleUpdateValidation(widget.widget_key, $event)"
                 />
+                <!--
+                <component :is="widget.component"
+                           :id="widget.widget_key"
+                           :key="widget.widget_key"
+                           ref="widgetRef"
+                           v-intersection-observer="handleIntersectionObserver"
+                           :widget-info="widget"
+                           :dashboard-info="dashboardDetailState.dashboardInfo"
+                           :currency-rates="currencyRates"
+                           :edit-mode="editMode"
+                           :error-mode="editMode && dashboardDetailState.widgetValidMap[widget.widget_key] === false"
+                           :all-reference-type-info="allReferenceTypeInfo"
+                           :initiated="!!initiatedWidgetMap[widget.widget_key]"
+                           :disable-refresh-on-variable-change="dashboardDetailState.widgetViewModeModalVisible && widget.widget_key !== widgetFormState.widgetKey"
+                           @update-data="handleUpdateData(widget.widget_key, $event)"
+                           @update-widget-info="handleUpdateWidgetInfo(widget.widget_key, $event)"
+                           @update-widget-validation="handleUpdateValidation(widget.widget_key, $event)"
+                />
+                -->
             </template>
         </template>
         <widget-view-mode-modal :visible="dashboardDetailState.widgetViewModeModalVisible"

--- a/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
+++ b/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
@@ -71,7 +71,7 @@ interface DashboardDetailInfoStoreActions {
     convertDashboardInfoByChangedVariableSchema: any;
 }
 const DEFAULT_REFRESH_INTERVAL = '5m';
-const DASHBOARD_DEFAULT = Object.freeze<{ settings: DashboardSettings }>({
+export const DASHBOARD_DEFAULT = Object.freeze<{ settings: DashboardSettings }>({
     settings: {
         date_range: {
             start: dayjs.utc().format('YYYY-MM-01'),

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetFrame.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetFrame.vue
@@ -32,7 +32,7 @@ import { WIDGET_SIZE } from '@/services/dashboards/widgets/_configs/config';
 import type { WidgetTheme } from '@/services/dashboards/widgets/_configs/view-config';
 
 
-interface WidgetFrameProps {
+export interface WidgetFrameProps {
     title: TranslateResult;
     size: WidgetSize;
     width?: number;

--- a/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeModal.vue
+++ b/apps/web/src/services/dashboards/widgets/_components/WidgetViewModeModal.vue
@@ -95,6 +95,19 @@ const handleRefreshWidget = () => {
     state.widgetRef?.refreshWidget();
 };
 
+const handleUpdateData = (widgetKey: string, data: any) => {
+    dashboardDetailStore.$patch((_state) => {
+        _state.widgetDataMap[widgetKey] = data;
+    });
+};
+const handleUpdateWidgetInfo = (widgetKey: string, widgetInfo: Partial<DashboardLayoutWidgetInfo>) => {
+    const originWidgetInfo = dashboardDetailState.dashboardWidgetInfoList.find((d) => d.widget_key === widgetKey);
+    dashboardDetailStore.updateWidgetInfo(widgetKey, { ...originWidgetInfo, ...widgetInfo });
+};
+const handleUpdateValidation = (widgetKey: string, isValid: boolean) => {
+    dashboardDetailStore.updateWidgetValidation(widgetKey, isValid);
+};
+
 watch(() => props.visible, async (visible) => {
     if (visible) {
         initSnapshot();
@@ -177,6 +190,7 @@ watch([() => widgetFormState.inheritOptions, () => widgetFormState.widgetOptions
                                :title="widgetFormState.widgetTitle"
                                :options="widgetFormState.widgetOptions"
                                :inherit-options="widgetFormState.inheritOptions"
+                               :schema-properties="widgetFormState.schemaProperties"
                                size="full"
                                :theme="widgetFormState.theme"
                                :currency-rates="state.currencyRates"
@@ -184,6 +198,12 @@ watch([() => widgetFormState.inheritOptions, () => widgetFormState.widgetOptions
                                :all-reference-type-info="state.allReferenceTypeInfo"
                                :disable-view-mode="true"
                                :initiated="state.initiated"
+                               :dashboard-settings="dashboardDetailState.settings"
+                               :dashboard-variables-schema="dashboardDetailState.variablesSchema"
+                               :dashboard-variables="dashboardDetailState.variables"
+                               @update-data="handleUpdateData(widgetFormState.widgetInfo.widget_key, $event)"
+                               @update-widget-info="handleUpdateWidgetInfo(widgetFormState.widgetInfo.widget_key, $event)"
+                               @update-widget-validation="handleUpdateValidation(widgetFormState.widgetInfo.widget_key, $event)"
                     />
                 </div>
             </div>

--- a/apps/web/src/services/dashboards/widgets/_configs/config.ts
+++ b/apps/web/src/services/dashboards/widgets/_configs/config.ts
@@ -13,6 +13,7 @@ import { ASSET_REFERENCE_TYPE_INFO } from '@/lib/reference/asset-reference-confi
 import { COST_REFERENCE_TYPE_INFO } from '@/lib/reference/cost-reference-config';
 import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
 
+import type { DashboardSettings, DashboardVariables, DashboardVariablesSchema } from '@/services/dashboards/config';
 import type { WidgetTheme } from '@/services/dashboards/widgets/_configs/view-config';
 
 
@@ -185,17 +186,18 @@ export interface BaseWidgetOptions {
     };
     filters?: WidgetFiltersMap;
 }
+export interface SelectorOptions {
+    enabled?: boolean;
+    type: 'cost-usage'|'days';
+}
 export interface CostWidgetOptions extends BaseWidgetOptions {
     cost_group_by?: CostGroupBy | string;
-    selector_options?: {
-        enabled?: boolean;
-        type: 'cost-usage'|'days';
-    };
+    selector_options?: SelectorOptions;
 }
 export interface AssetWidgetOptions extends BaseWidgetOptions {
     asset_group_by?: AssetGroupBy | string;
 }
-export type WidgetOptions = CostWidgetOptions|AssetWidgetOptions;
+export type WidgetOptions = CostWidgetOptions&AssetWidgetOptions;
 
 export interface DashboardLayoutWidgetInfo {
     widget_name: string; // widget config name
@@ -228,6 +230,7 @@ export interface WidgetProps {
     title?: string;
     options?: WidgetOptions;
     inheritOptions?: InheritOptions;
+    schemaProperties?: string[];
     size?: WidgetSize;
     width?: number;
     theme?: WidgetTheme; // e.g. 'violet', 'coral', 'peacock', ... default: violet
@@ -238,6 +241,16 @@ export interface WidgetProps {
     allReferenceTypeInfo: AllReferenceTypeInfo;
     initiated?: boolean;
     disableViewMode?: boolean;
+    disableRefreshOnVariableChange?: boolean;
+    dashboardSettings?: DashboardSettings;
+    dashboardVariablesSchema?: DashboardVariablesSchema;
+    dashboardVariables?: DashboardVariables;
+}
+
+export interface WidgetEmit {
+    (e: 'update-data', data: any): void;
+    (e: 'update-widget-info', widgetInfo: Partial<DashboardLayoutWidgetInfo>): void;
+    (e: 'update-widget-validation', validation: boolean): void;
 }
 
 export interface WidgetExpose<Data = any> {

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-helper.ts
@@ -122,7 +122,7 @@ export const getDateAxisSettings = (dateRange: DateRange): Partial<IDateAxisSett
  * @name getRefinedTreemapChartData
  * @description Convert raw data to TreemapChart data.
  */
-export const getRefinedTreemapChartData = (rawData: TreemapChartData['children'], groupBy: CostGroupBy, allReferenceTypeInfo: AllReferenceTypeInfo) => {
+export const getRefinedTreemapChartData = (rawData: TreemapChartData['children'], groupBy: CostGroupBy|undefined, allReferenceTypeInfo: AllReferenceTypeInfo) => {
     const chartData: TreemapChartData[] = [{
         name: 'Root',
         value: '',

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-helper.ts
@@ -82,9 +82,9 @@ export const getWidgetComponent = (widgetConfigId: string): AsyncComponent => {
  * => { provider: [{k: 'provider', v: 'aws', o: '='}, {k: 'provider', v: 'google', o: '='}] }
  * @description This helper is used to sync with the cost analysis page. Will be deprecated soon.
  */
-export const getWidgetLocationFilters = (widgetFilters: WidgetFiltersMap): WidgetFiltersMap => {
+export const getWidgetLocationFilters = (widgetFilters?: WidgetFiltersMap): WidgetFiltersMap => {
     const result: WidgetFiltersMap = {};
-    Object.entries(widgetFilters).forEach(([filterKey, filterItems]) => {
+    Object.entries(widgetFilters ?? {}).forEach(([filterKey, filterItems]) => {
         result[filterKey] = [];
         filterItems.forEach((filterItem) => {
             if (Array.isArray(filterItem.v)) {

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-cost-widget-frame-header-dropdown.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-cost-widget-frame-header-dropdown.ts
@@ -1,0 +1,32 @@
+import type { Ref } from 'vue';
+import { computed, ref } from 'vue';
+
+import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
+
+import type { SelectorOptions, SelectorType } from '@/services/dashboards/widgets/_configs/config';
+
+interface UseCostWidgetFrameHeaderDropdownOptions {
+    selectorOptions: Ref<SelectorOptions>;
+}
+export const useCostWidgetFrameHeaderDropdown = ({ selectorOptions }: UseCostWidgetFrameHeaderDropdownOptions) => {
+    const selectorItems = computed<MenuItem[]>(() => {
+        if (!selectorOptions.value.enabled) return [];
+        if (selectorOptions.value.type === 'cost-usage') {
+            if (!selectedSelectorType.value) selectedSelectorType.value = 'cost';
+            return [
+                { type: 'item', name: 'cost', label: 'Cost' },
+                { type: 'item', name: 'usage', label: 'Usage' },
+            ];
+        }
+        if (!selectedSelectorType.value) selectedSelectorType.value = 'day';
+        return [
+            { type: 'item', name: 'day', label: 'Day' },
+            { type: 'item', name: 'month', label: 'Month' },
+        ];
+    });
+    const selectedSelectorType = ref<SelectorType|undefined>(undefined);
+
+    return {
+        selectorItems, selectedSelectorType,
+    };
+};

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget-lifecycle-new.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget-lifecycle-new.ts
@@ -1,0 +1,254 @@
+import type { UnwrapRef } from 'vue';
+import {
+    onUnmounted, watch,
+} from 'vue';
+
+import {
+    cloneDeep, isEmpty, isEqual, union,
+} from 'lodash';
+
+import { i18n } from '@/translations';
+
+import type { Currency } from '@/store/modules/settings/type';
+
+import ErrorHandler from '@/common/composables/error/errorHandler';
+
+import type { DashboardVariables, DashboardVariablesSchema } from '@/services/dashboards/config';
+import type {
+    InheritOptions, WidgetProps, WidgetConfig, WidgetFilterKey, WidgetOptions, DashboardLayoutWidgetInfo, WidgetEmit,
+} from '@/services/dashboards/widgets/_configs/config';
+import { getWidgetFilterSchemaPropertyName } from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
+import { getWidgetInheritOptionsErrorMap } from '@/services/dashboards/widgets/_helpers/widget-validation-helper';
+import type { WidgetBaseState } from '@/services/dashboards/widgets/_hooks/use-widget/use-widget-base-state';
+
+
+interface UseWidgetLifecycleOptions<T extends WidgetBaseState = WidgetBaseState> {
+    props: WidgetProps;
+    emit: WidgetEmit;
+    widgetState: UnwrapRef<T>;
+    disposeWidget?: () => void;
+    refreshWidget: () => any;
+    onCurrencyUpdate?: (current?: Currency, previous?: Currency) => void|Promise<void>;
+    redrawChart?: () => void;
+    redrawOnLanguageChange?: boolean;
+}
+
+const checkRefreshableByDashboardVariables = (
+    inheritOptions: InheritOptions,
+    after?: DashboardVariables,
+    before?: DashboardVariables,
+): boolean => {
+    let _refresh = false;
+    Object.values(inheritOptions).forEach((inheritOption) => {
+        if (_refresh) return;
+        const _variableKey = inheritOption.variable_info?.key ?? '';
+        const _after = after?.[_variableKey];
+        const _before = before?.[_variableKey];
+        if (!_variableKey || (!_after && !_before)) return;
+        if (!isEqual(_after, _before)) _refresh = true;
+    });
+    return _refresh;
+};
+
+/* Dashboard Variable Schema */
+const getUpdatedDashboardVariableSchemaProperties = (
+    after?: DashboardVariablesSchema,
+    before?: DashboardVariablesSchema,
+): [WidgetFilterKey[], WidgetFilterKey[], WidgetFilterKey[]] => {
+    const added: WidgetFilterKey[] = [];
+    const deleted: WidgetFilterKey[] = [];
+    const changed: WidgetFilterKey[] = [];
+    const afterVariables = Object.keys(after?.properties ?? {});
+    const beforeVariables = Object.keys(before?.properties ?? {});
+    union(afterVariables, beforeVariables).forEach((variable) => {
+        if (!after?.properties[variable].use && !before?.properties[variable].use) return;
+        if (after?.properties[variable].use && before?.properties[variable].use) {
+            if (isEqual(after?.properties[variable], before?.properties[variable])) return; /* Not changed variable */
+            changed.push(variable as WidgetFilterKey);
+        } else if (after?.properties[variable].use && !before?.properties[variable].use) {
+            added.push(variable as WidgetFilterKey);
+        } else {
+            deleted.push(variable as WidgetFilterKey);
+        }
+    });
+    return [added, deleted, changed];
+};
+const isAffectedByChangedVariableSchemaProperties = (
+    dashboardVariables: string[],
+    inheritOptions: InheritOptions,
+): boolean => {
+    const enabledInheritOptions = Object.entries(inheritOptions)
+        .filter(([, v]) => v.enabled)
+        .map(([, v]) => v.variable_info?.key as WidgetFilterKey);
+    if (!enabledInheritOptions.length || !enabledInheritOptions.some((d) => dashboardVariables.includes(d))) return false;
+    return true;
+};
+const getAffectedWidgetInfoByAddingVariableSchemaProperty = (
+    dashboardVariables: WidgetFilterKey[],
+    inheritOptions: InheritOptions,
+    schemaProperties: string[],
+    widgetConfig: WidgetConfig,
+): Partial<DashboardLayoutWidgetInfo>|undefined => {
+    const _inheritOptions = cloneDeep(inheritOptions);
+    const _schemaProperties = [...schemaProperties];
+    const optionsSchemaProperties: string[] = Object.keys(widgetConfig.options_schema?.schema.properties ?? {});
+    let isAffected = false;
+    dashboardVariables.forEach((variableKey) => {
+        const property = getWidgetFilterSchemaPropertyName(variableKey);
+        const isInWidgetOptionsSchema = optionsSchemaProperties.some((d) => d.includes(property));
+        if (!isInWidgetOptionsSchema) return;
+
+        // enable widget option that match added variable
+        isAffected = true;
+        _inheritOptions[property] = { enabled: true, variable_info: { key: variableKey } };
+        _schemaProperties.push(property);
+    });
+    return isAffected ? {
+        inherit_options: _inheritOptions,
+        schema_properties: _schemaProperties,
+    }
+        : undefined;
+};
+const getAffectedWidgetInfoByDeletingVariableSchemaProperty = (
+    dashboardVariables: WidgetFilterKey[],
+    widgetOptions: WidgetOptions,
+    schemaProperties: string[],
+    widgetConfig: WidgetConfig,
+    inheritOptions: InheritOptions,
+): Partial<DashboardLayoutWidgetInfo>|undefined => {
+    // check whether the deleted variable exists in inherit options
+    const enabledInheritOptions = Object.entries(inheritOptions)
+        .filter(([, v]) => v.enabled)
+        .map(([, v]) => v.variable_info?.key as WidgetFilterKey);
+    if (!enabledInheritOptions.length || !enabledInheritOptions.some((d) => dashboardVariables.includes(d))) {
+        return undefined;
+    }
+
+    const _widgetOptions = cloneDeep(widgetOptions);
+    const _inheritOptions = cloneDeep(inheritOptions);
+    let _schemaProperties = [...schemaProperties];
+    // delete or update options using deleted variables
+    dashboardVariables.forEach((variableKey) => {
+        const property = getWidgetFilterSchemaPropertyName(variableKey);
+        const isFixedProperty: boolean = widgetConfig.options_schema?.fixed_properties?.includes(property) ?? false;
+
+        if (isFixedProperty) { /* fixed property case */
+            _widgetOptions[property] = widgetConfig.options?.[property] ?? undefined; // set default value to fixed option
+        } else { /* non-fixed property case */
+            _schemaProperties = _schemaProperties.filter((d) => d !== property);
+        }
+        _inheritOptions[property] = { enabled: false };
+    });
+
+    return {
+        schema_properties: _schemaProperties,
+        inherit_options: _inheritOptions,
+        widget_options: _widgetOptions,
+    };
+};
+const validateWidget = (
+    inheritOptions: InheritOptions,
+    widgetConfig: WidgetConfig,
+    dashboardVariableSchema?: DashboardVariablesSchema,
+): boolean => {
+    const _widgetSchemaErrorMap = getWidgetInheritOptionsErrorMap(inheritOptions, widgetConfig.options_schema?.schema, dashboardVariableSchema);
+    return isEmpty(_widgetSchemaErrorMap);
+};
+
+
+export const useWidgetLifecycle = ({
+    props,
+    emit,
+    widgetState,
+    disposeWidget,
+    refreshWidget,
+    onCurrencyUpdate,
+    redrawChart,
+    redrawOnLanguageChange,
+}: UseWidgetLifecycleOptions): void => {
+    const refreshWidgetAndEmitEvent = () => {
+        const newData = refreshWidget();
+        emit('update-data', newData);
+    };
+
+    onUnmounted(() => {
+        if (disposeWidget) disposeWidget();
+    });
+
+    watch(() => props.dashboardVariables, (after, before) => {
+        if (!props.initiated || props.errorMode || !props.inheritOptions || props.disableRefreshOnVariableChange) return;
+        const _isRefreshable = checkRefreshableByDashboardVariables(props.inheritOptions, after, before);
+        if (_isRefreshable) refreshWidgetAndEmitEvent();
+    }, { deep: true });
+
+    watch(() => props.dashboardVariablesSchema, (after, before) => {
+        if (!props.editMode || !props.inheritOptions || !props.schemaProperties || !props.options
+            || isEqual(after, before) || props.disableRefreshOnVariableChange) return;
+
+        const [
+            addedVariableSchemaProperties,
+            deletedVariableSchemaProperties,
+            changedVariableSchemaProperties,
+        ] = getUpdatedDashboardVariableSchemaProperties(after, before);
+        let isWidgetOptionChanged: boolean|undefined;
+        let isWidgetOptionAdded: boolean|undefined;
+        let isWidgetOptionDeleted: boolean|undefined;
+        if (addedVariableSchemaProperties.length) {
+            const affectedWidgetInfo = getAffectedWidgetInfoByAddingVariableSchemaProperty(
+                addedVariableSchemaProperties,
+                props.inheritOptions,
+                props.schemaProperties,
+                widgetState.widgetConfig,
+            );
+            isWidgetOptionAdded = !!affectedWidgetInfo;
+            if (affectedWidgetInfo) {
+                emit('update-widget-info', affectedWidgetInfo);
+            }
+        }
+        if (deletedVariableSchemaProperties.length) {
+            const affectedWidgetInfo = getAffectedWidgetInfoByDeletingVariableSchemaProperty(
+                deletedVariableSchemaProperties,
+                props.options,
+                props.schemaProperties,
+                widgetState.widgetConfig,
+                props.inheritOptions,
+            );
+            isWidgetOptionDeleted = !!affectedWidgetInfo;
+            if (affectedWidgetInfo) {
+                emit('update-widget-info', affectedWidgetInfo);
+                const isValid = validateWidget(affectedWidgetInfo.inherit_options ?? {}, widgetState.widgetConfig, after);
+                emit('update-widget-validation', isValid);
+            }
+        }
+        if (changedVariableSchemaProperties.length) {
+            isWidgetOptionChanged = isAffectedByChangedVariableSchemaProperties(changedVariableSchemaProperties, props.inheritOptions);
+        }
+
+        if (!props.initiated) return;
+        if (isWidgetOptionAdded || isWidgetOptionDeleted || isWidgetOptionChanged) {
+            refreshWidgetAndEmitEvent();
+        }
+    }, { deep: true });
+
+    if (widgetState.settings) {
+        watch(() => widgetState.settings, (current, previous) => {
+            if (!current || !previous || props.disableRefreshOnVariableChange) return;
+            if (current.date_range.start !== previous.date_range.start || current.date_range.end !== previous.date_range.end) {
+                refreshWidgetAndEmitEvent();
+            } else if (onCurrencyUpdate && current?.currency?.value !== previous?.currency?.value) {
+                onCurrencyUpdate();
+            }
+        });
+    }
+
+    if (redrawOnLanguageChange) {
+        try {
+            if (!redrawChart) throw Error('redrawChart is required');
+            watch(() => i18n.locale, async () => {
+                redrawChart();
+            });
+        } catch (e) {
+            ErrorHandler.handleError(e);
+        }
+    }
+};

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget-pagination.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget-pagination.ts
@@ -1,0 +1,17 @@
+import type { UnwrapRef } from 'vue';
+import { computed, ref } from 'vue';
+
+import type { WidgetBaseState } from '@/services/dashboards/widgets/_hooks/use-widget/use-widget-base-state';
+
+export const useWidgetPagination = (baseState: UnwrapRef<WidgetBaseState>) => {
+    const thisPage = ref(1);
+    const pageSize = computed(() => {
+        if (baseState.options?.pagination_options?.enabled) return baseState.options.pagination_options.page_size;
+        return undefined;
+    });
+
+    return {
+        thisPage,
+        pageSize,
+    };
+};

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-cost-widget-state.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-cost-widget-state.ts
@@ -1,0 +1,81 @@
+import type { ComputedRef, UnwrapRef } from 'vue';
+import {
+    computed, reactive, toRefs,
+} from 'vue';
+
+import { isEmpty } from 'lodash';
+
+import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
+
+
+import { store } from '@/store';
+
+import { CURRENCY } from '@/store/modules/settings/config';
+import type { Currency } from '@/store/modules/settings/type';
+
+import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
+
+import type {
+    WidgetProps,
+    Granularity,
+    WidgetFiltersMap,
+    CostGroupBy,
+} from '@/services/dashboards/widgets/_configs/config';
+import type { WidgetBaseState } from '@/services/dashboards/widgets/_hooks/use-widget/use-widget-base-state';
+import {
+    useWidgetBaseState,
+} from '@/services/dashboards/widgets/_hooks/use-widget/use-widget-base-state';
+import type { ChartType } from '@/services/dashboards/widgets/type';
+
+
+
+const getConvertedBudgetConsoleFilters = (widgetFiltersMap: WidgetFiltersMap): ConsoleFilter[] => {
+    const results: ConsoleFilter[] = [];
+    Object.entries(widgetFiltersMap).forEach(([filterKey, filterItems]) => {
+        if (!filterItems?.length) return;
+        if ((filterKey === REFERENCE_TYPE_INFO.project.type || filterKey === REFERENCE_TYPE_INFO.project_group.type)) {
+            filterItems.forEach((d) => {
+                results.push(d);
+            });
+        } else {
+            filterItems.forEach((d) => {
+                const value = Array.isArray(d.v) ? d.v : [d.v];
+                results.push({
+                    k: `cost_types.${d.k}`,
+                    v: [null, ...value],
+                    o: d.o,
+                });
+            });
+        }
+    });
+    return results;
+};
+
+
+export interface CostWidgetState extends WidgetBaseState {
+    currency: ComputedRef<Currency|undefined>;
+    groupBy: ComputedRef<CostGroupBy | undefined>;
+    granularity: ComputedRef<Granularity|undefined>;
+    chartType: ComputedRef<ChartType|undefined>;
+    budgetConsoleFilters: ComputedRef<ConsoleFilter[]>;
+}
+export function useCostWidgetState(
+    props: WidgetProps,
+) {
+    const baseState = useWidgetBaseState(props);
+
+    return reactive<CostWidgetState>({
+        ...toRefs(baseState) as WidgetBaseState,
+        currency: computed(() => {
+            if (baseState.settings?.currency.value === 'DEFAULT') return store.state.settings.currency;
+            return baseState.settings?.currency.value ?? CURRENCY.USD;
+        }),
+        groupBy: computed(() => baseState.options?.cost_group_by as CostGroupBy|undefined),
+        granularity: computed(() => baseState.options?.granularity),
+        chartType: computed<ChartType|undefined>(() => baseState.options?.chart_type),
+        budgetConsoleFilters: computed(() => {
+            if (!baseState.options?.filters || isEmpty(baseState.options.filters)) return [];
+            return getConvertedBudgetConsoleFilters(baseState.options.filters);
+        }),
+    }) as UnwrapRef<CostWidgetState>;
+}

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-cost-widget.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-cost-widget.ts
@@ -1,0 +1,46 @@
+import type { UnwrapRef } from 'vue';
+import {
+    reactive, toRefs,
+} from 'vue';
+
+import type { WidgetProps } from '@/services/dashboards/widgets/_configs/config';
+import type { CostWidgetState } from '@/services/dashboards/widgets/_hooks/use-widget/use-cost-widget-state';
+import {
+    useCostWidgetState,
+} from '@/services/dashboards/widgets/_hooks/use-widget/use-cost-widget-state';
+import type { WidgetFrameOptions } from '@/services/dashboards/widgets/_hooks/use-widget/use-widget-frame';
+import { useWidgetFrame } from '@/services/dashboards/widgets/_hooks/use-widget/use-widget-frame';
+
+interface AdditionalState {
+    dateRange: WidgetFrameOptions['dateRange'];
+    widgetLocation: WidgetFrameOptions['widgetLocation'];
+}
+
+/**
+ * @example
+ const { widgetState, widgetFrameProps } = useCostWidget(props, {
+    widgetLocation: computed<Location>(() => ({
+        name: COST_EXPLORER_ROUTE.COST_ANALYSIS._NAME,
+    })),
+    dateRange: computed<DateRange>(() => {
+        const end = widgetState.settings?.date_range?.end ?? dayjs.utc().format('YYYY-MM');
+        const start = widgetState.settings?.date_range?.start ?? dayjs.utc().format('YYYY-MM');
+        return { start, end };
+    }),
+ });
+ */
+export const useCostWidget = <T = AdditionalState>(props: WidgetProps, additionalState: AdditionalState) => {
+    const costWidgetState = useCostWidgetState(props);
+
+    const widgetState = reactive({
+        ...toRefs(costWidgetState),
+        ...additionalState,
+    }) as UnwrapRef<CostWidgetState & T>;
+
+    const { widgetFrameProps } = useWidgetFrame(props, widgetState);
+
+    return {
+        widgetState,
+        widgetFrameProps,
+    };
+};

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-widget-base-state.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-widget-base-state.ts
@@ -1,0 +1,115 @@
+import type { ComputedRef, UnwrapRef } from 'vue';
+import {
+    computed, reactive,
+} from 'vue';
+
+import dayjs from 'dayjs';
+import { flattenDeep, isEmpty, merge } from 'lodash';
+
+import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
+
+import { CURRENCY } from '@/store/modules/settings/config';
+
+import type { DashboardSettings, DashboardVariables } from '@/services/dashboards/config';
+import type {
+    WidgetConfig, WidgetOptions,
+    InheritOptions, WidgetProps,
+    WidgetFilter,
+} from '@/services/dashboards/widgets/_configs/config';
+import { getWidgetFilterDataKey } from '@/services/dashboards/widgets/_helpers/widget-filters-helper';
+import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
+import type { InheritOptionsErrorMap } from '@/services/dashboards/widgets/_helpers/widget-validation-helper';
+import { getWidgetInheritOptionsErrorMap } from '@/services/dashboards/widgets/_helpers/widget-validation-helper';
+
+
+const getRefinedOptions = (
+    configOptions?: WidgetOptions,
+    optionsData?: WidgetOptions,
+    inheritOptions?: InheritOptions,
+    dashboardVariables?: DashboardVariables,
+    optionsErrorMap?: InheritOptionsErrorMap,
+): WidgetOptions => {
+    const mergedOptions = merge({}, configOptions, optionsData);
+    if (!inheritOptions || !dashboardVariables) return mergedOptions;
+
+    const parentOptions: Partial<WidgetOptions> = convertInheritOptionsToWidgetFiltersMap(inheritOptions, dashboardVariables, optionsErrorMap);
+    const refined = merge({}, mergedOptions, parentOptions);
+    return refined;
+};
+
+const convertInheritOptionsToWidgetFiltersMap = (
+    inheritOptions: InheritOptions,
+    dashboardVariables: DashboardVariables,
+    optionsErrorMap?: InheritOptionsErrorMap,
+): Partial<WidgetOptions> => {
+    const result: Partial<WidgetOptions> = {
+        filters: {},
+    };
+    Object.entries(inheritOptions).forEach(([filterKey, inheritOption]) => {
+        if (optionsErrorMap?.[filterKey]) return;
+
+        const variableKey = inheritOption?.variable_info?.key;
+        if (!inheritOption?.enabled || !variableKey) return;
+
+        const variableValue = dashboardVariables[variableKey];
+        if (!variableValue || !variableValue?.length) return;
+
+        if (filterKey.startsWith('filters.')) {
+            const _filterKey = filterKey.replace('filters.', '');
+            const filterDataKey = getWidgetFilterDataKey(_filterKey);
+            result.filters = {
+                ...result.filters,
+                [_filterKey]: [{ k: filterDataKey, v: variableValue, o: '=' }],
+            };
+        } else {
+            result[filterKey] = variableValue;
+        }
+    });
+    return result;
+};
+
+
+export interface WidgetBaseState {
+    widgetConfig: ComputedRef<WidgetConfig>;
+    options: ComputedRef<WidgetOptions>;
+    settings: ComputedRef<DashboardSettings|undefined>;
+    consoleFilters: ComputedRef<ConsoleFilter[]>;
+}
+export function useWidgetBaseState(
+    props: WidgetProps,
+) {
+    const optionsErrorMap = computed(() => getWidgetInheritOptionsErrorMap(
+        props.inheritOptions,
+        state.widgetConfig?.options_schema?.schema,
+        props.dashboardVariablesSchema,
+    ));
+
+    const state = reactive<WidgetBaseState>({
+        widgetConfig: computed<WidgetConfig>(() => getWidgetConfig(props.widgetConfigId)),
+        options: computed<WidgetOptions>(() => getRefinedOptions(
+            state.widgetConfig.options,
+            props.options,
+            props.inheritOptions,
+            props.dashboardVariables,
+            optionsErrorMap.value,
+        )),
+        settings: computed<DashboardSettings|undefined>(() => (props.dashboardSettings ? {
+            ...props.dashboardSettings,
+            date_range: props.dashboardSettings.date_range?.enabled ? props.dashboardSettings.date_range : {
+                enabled: false,
+                start: dayjs.utc().format('YYYY-MM'),
+                end: dayjs.utc().format('YYYY-MM'),
+            },
+            currency: props.dashboardSettings.currency?.enabled ? props.dashboardSettings.currency : {
+                enabled: false,
+                value: CURRENCY.USD,
+            },
+        } : undefined)),
+        consoleFilters: computed<WidgetFilter[]>(() => {
+            if (!state.options?.filters || isEmpty(state.options.filters)) return [];
+            return flattenDeep<WidgetFilter[]>(Object.values(state.options.filters));
+        }),
+    }) as UnwrapRef<WidgetBaseState>;
+
+    return state;
+}

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-widget-frame.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-widget-frame.ts
@@ -1,0 +1,59 @@
+import type { ComputedRef, UnwrapRef } from 'vue';
+import { computed } from 'vue';
+import type { Location } from 'vue-router/types/router';
+
+import { i18n } from '@/translations';
+
+import type { Currency } from '@/store/modules/settings/type';
+
+import type { DateRange } from '@/services/dashboards/config';
+import type { WidgetFrameProps } from '@/services/dashboards/widgets/_components/WidgetFrame.vue';
+import type { WidgetProps } from '@/services/dashboards/widgets/_configs/config';
+import { WIDGET_SIZE } from '@/services/dashboards/widgets/_configs/config';
+import { getNonInheritedWidgetOptions } from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
+import type { WidgetBaseState } from '@/services/dashboards/widgets/_hooks/use-widget/use-widget-base-state';
+
+export interface WidgetFrameOptions {
+    dateRange?: DateRange|ComputedRef<DateRange>;
+    currency?: Currency|ComputedRef<Currency>;
+    widgetLocation?: Location|ComputedRef<Location>;
+}
+export const useWidgetFrame = (
+    props: UnwrapRef<WidgetProps>,
+    widgetState: UnwrapRef<WidgetBaseState & WidgetFrameOptions>,
+) => {
+    const title = computed(() => props.title ?? widgetState.widgetConfig.title);
+    const size = computed(() => {
+        if (props.size && widgetState.widgetConfig.sizes.includes(props.size)) return props.size;
+        return widgetState.widgetConfig.sizes[0];
+    });
+    const nonInheritOptionsTooltipText = computed<string | undefined>(() => {
+        const nonInheritOptions = getNonInheritedWidgetOptions(props.inheritOptions);
+        if (!nonInheritOptions.length) return undefined;
+
+        // TODO: widget option name must be changed to readable name.
+        // const tooltipText = nonInheritOptions.map((d) => `<p>• ${getWidgetOptionsSchemaPropertyName(d)}</p>`).join('\n');
+        const tooltipText = nonInheritOptions.map((d) => `<p>• ${d}</p>`).join('\n');
+        return `${i18n.t('DASHBOARDS.WIDGET.INHERIT_OPTIONS_TOOLTIP_TEXT_1')}</br></br>
+            ${i18n.t('DASHBOARDS.WIDGET.INHERIT_OPTIONS_TOOLTIP_TEXT_2')}</br>${tooltipText}`;
+    });
+    const widgetFrameProps = computed<Partial<WidgetFrameProps>>(() => ({
+        widgetKey: props.widgetKey,
+        width: props.width,
+        editMode: props.editMode,
+        widgetConfigId: props.widgetConfigId,
+        title: title.value,
+        size: size.value,
+        dateRange: widgetState.dateRange ?? widgetState.settings?.date_range,
+        currency: widgetState.currency,
+        disableFullSize: !widgetState.widgetConfig?.sizes.includes(WIDGET_SIZE.full),
+        isOnlyFullSize: widgetState.widgetConfig?.sizes.length === 1 && widgetState.widgetConfig?.sizes[0] === WIDGET_SIZE.full,
+        disableViewMode: props.disableViewMode,
+        widgetLocation: widgetState.widgetLocation,
+        errorMode: props.errorMode,
+        theme: props.theme,
+        nonInheritOptionsTooltipText: nonInheritOptionsTooltipText.value,
+    }));
+
+    return { widgetFrameProps };
+};


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

- Split widget state hook into several hooks
- Added useWidget to integrate hooks that always used together (frame props, widget state)
- Applied to CostMapWidget

### Things to Talk About
