### PR TITLE
feat(show-more): add show-more button in cost-explorer LNB & add extra spec in LNB

### DIFF
--- a/apps/web/src/common/modules/navigations/lnb/LNB.vue
+++ b/apps/web/src/common/modules/navigations/lnb/LNB.vue
@@ -33,7 +33,9 @@ const props = withDefaults(defineProps<Props>(), {
     menuSet: () => [],
     showFavoriteOnly: undefined,
 });
-const emit = defineEmits<{(e: 'select', id: string, selected: string|number): void}>();
+const emit = defineEmits<{(e: 'select', id: string, selected: string|number): void;
+    (e: 'update:showFavoriteOnly', value: boolean): void;
+}>();
 const route = useRoute();
 const state = reactive({
     currentPath: computed(() => route.fullPath),
@@ -109,6 +111,12 @@ const handleSelect = (id: string, selected: string) => {
                                      @change-toggle="handleFavoriteToggle"
                     />
                 </div>
+                <div v-else-if="menuData.type === MENU_ITEM_TYPE.EXTRA"
+                     :key="`${idx}-${getUUID()}`"
+                     class="extra-menu-wrapper"
+                >
+                    <slot name="extra-menu" />
+                </div>
                 <l-n-b-menu-item v-else
                                  :key="`${idx}-${getUUID()}`"
                                  :menu-data="menuData"
@@ -162,6 +170,11 @@ const handleSelect = (id: string, selected: string) => {
         @apply flex justify-between items-center text-gray-500;
         font-size: 0.75rem;
         padding: 0 0.5rem;
+    }
+    .extra-menu-wrapper {
+        @apply flex items-center;
+        padding: 0 0.5rem;
+        height: 2rem;
     }
     .top-title {
         @apply text-gray-800 font-bold flex justify-between items-center;

--- a/apps/web/src/common/modules/navigations/lnb/LNB.vue
+++ b/apps/web/src/common/modules/navigations/lnb/LNB.vue
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<Props>(), {
     showFavoriteOnly: undefined,
 });
 const emit = defineEmits<{(e: 'select', id: string, selected: string|number): void;
-    (e: 'update:showFavoriteOnly', value: boolean): void;
+    (e: 'update:show-favorite-only', value: boolean): void;
 }>();
 const route = useRoute();
 const state = reactive({
@@ -111,11 +111,11 @@ const handleSelect = (id: string, selected: string) => {
                                      @change-toggle="handleFavoriteToggle"
                     />
                 </div>
-                <div v-else-if="menuData.type === MENU_ITEM_TYPE.EXTRA"
+                <div v-else-if="menuData.type === MENU_ITEM_TYPE.SLOT"
                      :key="`${idx}-${getUUID()}`"
-                     class="extra-menu-wrapper"
+                     class="slot-menu-wrapper"
                 >
-                    <slot name="extra-menu" />
+                    <slot :name="`slot-${menuData.id}`" />
                 </div>
                 <l-n-b-menu-item v-else
                                  :key="`${idx}-${getUUID()}`"
@@ -171,7 +171,7 @@ const handleSelect = (id: string, selected: string) => {
         font-size: 0.75rem;
         padding: 0 0.5rem;
     }
-    .extra-menu-wrapper {
+    .slot-menu-wrapper {
         @apply flex items-center;
         padding: 0 0.5rem;
         height: 2rem;

--- a/apps/web/src/common/modules/navigations/lnb/type.ts
+++ b/apps/web/src/common/modules/navigations/lnb/type.ts
@@ -14,7 +14,7 @@ export const MENU_ITEM_TYPE = {
     DIVIDER: 'divider',
     FAVORITE_ONLY: 'favorite-only',
     DROPDOWN: 'dropdown',
-    EXTRA: 'extra',
+    SLOT: 'slot',
 } as const;
 type MenuItemType = typeof MENU_ITEM_TYPE[keyof typeof MENU_ITEM_TYPE];
 

--- a/apps/web/src/common/modules/navigations/lnb/type.ts
+++ b/apps/web/src/common/modules/navigations/lnb/type.ts
@@ -14,6 +14,7 @@ export const MENU_ITEM_TYPE = {
     DIVIDER: 'divider',
     FAVORITE_ONLY: 'favorite-only',
     DROPDOWN: 'dropdown',
+    EXTRA: 'extra',
 } as const;
 type MenuItemType = typeof MENU_ITEM_TYPE[keyof typeof MENU_ITEM_TYPE];
 

--- a/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
@@ -3,7 +3,7 @@ import {
     computed, onMounted, onUnmounted, reactive,
 } from 'vue';
 
-import { PI } from '@spaceone/design-system';
+import { PI, PCollapsibleToggle } from '@spaceone/design-system';
 
 import { LocalStorageAccessor } from '@cloudforet/core-lib/local-storage-accessor';
 
@@ -32,6 +32,7 @@ import { useCostQuerySetStore } from '@/services/cost-explorer/store/cost-query-
 import { DASHBOARDS_ROUTE } from '@/services/dashboards/route-config';
 
 const DATA_SOURCE_DROPDOWN_KEY = 'data-source';
+const FOLDING_COUNT_BY_SHOW_MORE = 7;
 
 const costQuerySetStore = useCostQuerySetStore();
 const costQuerySetState = costQuerySetStore.$state;
@@ -77,7 +78,10 @@ const state = reactive({
             type: 'item',
             id: d.cost_query_set_id,
             label: d.name,
-            icon: managedCostQuerySetIdList.includes(d.cost_query_set_id) ? { name: 'ic_main-filled', color: gray[500] } : undefined,
+            icon: managedCostQuerySetIdList.includes(d.cost_query_set_id) ? {
+                name: 'ic_main-filled',
+                color: gray[500],
+            } : undefined,
             to: {
                 name: COST_EXPLORER_ROUTE.COST_ANALYSIS._NAME,
                 params: {
@@ -86,8 +90,17 @@ const state = reactive({
             },
             favoriteType: FAVORITE_TYPE.COST_ANALYSIS,
         }));
-        return currentQueryMenuList;
+        const showMoreExtraMenuSet: LNBMenu = [{
+            type: 'extra',
+        }];
+
+        return [
+            ...(state.showMoreQuerySetStatus ? currentQueryMenuList.slice(0, FOLDING_COUNT_BY_SHOW_MORE) : currentQueryMenuList),
+            ...(currentQueryMenuList.length > FOLDING_COUNT_BY_SHOW_MORE ? showMoreExtraMenuSet : []),
+        ];
     }),
+    showMoreQuerySetStatus: true,
+    showFavoriteOnly: false,
 });
 
 const relocateNotificationState = reactive({
@@ -160,6 +173,7 @@ costQuerySetStore.listCostQuerySets();
     <aside class="sidebar-menu">
         <l-n-b :header="state.header"
                :menu-set="state.menuSet"
+               :show-favorite-only.sync="state.showFavoriteOnly"
                @select="handleSelect"
         >
             <template #default>
@@ -180,8 +194,10 @@ costQuerySetStore.listCostQuerySets();
                 />
                 <l-n-b-divider-menu-item />
             </template>
+            <template #extra-menu>
+                <p-collapsible-toggle :is-collapsed.sync="state.showMoreQuerySetStatus" />
+            </template>
         </l-n-b>
-        <!--TODO: Should be replaced with lean-more modal-->
         <relocate-dashboard-modal :visible.sync="relocateNotificationState.isModalVisible" />
     </aside>
 </template>

--- a/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
@@ -90,13 +90,14 @@ const state = reactive({
             },
             favoriteType: FAVORITE_TYPE.COST_ANALYSIS,
         }));
-        const showMoreExtraMenuSet: LNBMenu = [{
-            type: 'extra',
+        const showMoreMenuSet: LNBMenu = [{
+            type: 'slot',
+            id: 'show-more',
         }];
 
         return [
             ...(state.showMoreQuerySetStatus ? currentQueryMenuList.slice(0, FOLDING_COUNT_BY_SHOW_MORE) : currentQueryMenuList),
-            ...(currentQueryMenuList.length > FOLDING_COUNT_BY_SHOW_MORE ? showMoreExtraMenuSet : []),
+            ...(currentQueryMenuList.length > FOLDING_COUNT_BY_SHOW_MORE ? showMoreMenuSet : []),
         ];
     }),
     showMoreQuerySetStatus: true,
@@ -194,7 +195,7 @@ costQuerySetStore.listCostQuerySets();
                 />
                 <l-n-b-divider-menu-item />
             </template>
-            <template #extra-menu>
+            <template #slot-show-more>
                 <p-collapsible-toggle :is-collapsed.sync="state.showMoreQuerySetStatus" />
             </template>
         </l-n-b>

--- a/apps/web/src/store/modules/favorite/type.ts
+++ b/apps/web/src/store/modules/favorite/type.ts
@@ -29,6 +29,7 @@ export interface FavoriteHasLoaded {
     [FAVORITE_TYPE.PROJECT]: boolean;
     [FAVORITE_TYPE.PROJECT_GROUP]: boolean;
     [FAVORITE_TYPE.DASHBOARD]: boolean;
+    [FAVORITE_TYPE.COST_ANALYSIS]: boolean;
 }
 
 export interface FavoriteState {
@@ -46,4 +47,5 @@ export const FAVORITE_TYPE_TO_STATE_NAME = {
     [FAVORITE_TYPE.PROJECT_GROUP]: 'projectGroupItems',
     [FAVORITE_TYPE.CLOUD_SERVICE]: 'cloudServiceItems',
     [FAVORITE_TYPE.DASHBOARD]: 'dashboardItems',
+    [FAVORITE_TYPE.COST_ANALYSIS]: 'costAnalysisItems',
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA
![image](https://github.com/cloudforet-io/console/assets/83635051/eadf2f5e-1e33-4c1f-83af-2e3225f42bf0)


+ Add favorite type

### Things to Talk About
It is first time that`show-more` has been created in LNB.
I think this case can be created again, but there is no specific usage. 
So I add extra-menu `<slot>` and `extra` menu type for creating this `show-more` item.