### PR TITLE
fix(cost-analysis-route): refactor breadcrumbs and route type & apply dynamic cost-query-set-id

### DIFF
--- a/apps/web/src/common/composables/breadcrumbs/index.ts
+++ b/apps/web/src/common/composables/breadcrumbs/index.ts
@@ -39,22 +39,46 @@ export const useBreadcrumbs = () => {
                     const label = d.meta.label;
                     if (typeof label === 'function') {
                         const labelResult = label(vm.$route);
-                        if (labelResult) results.push({ name: labelResult, to: location, copiable: d.meta.copiable });
+                        if (labelResult) {
+                            results.push({
+                                name: labelResult,
+                                to: location,
+                                copiable: typeof d.meta.copiable === 'function' ? d.meta.copiable(vm.$route) : d.meta.copiable,
+                            });
+                        }
                     } else {
-                        results.push({ name: label, to: location, copiable: d.meta.copiable });
+                        results.push({
+                            name: label,
+                            to: location,
+                            copiable: typeof d.meta.copiable === 'function' ? d.meta.copiable(vm.$route) : d.meta.copiable,
+                        });
                     }
                 } else if (d.meta.translationId) {
                     const translationId = d.meta.translationId;
                     if (typeof translationId === 'function') {
                         const translationIdResult = translationId(vm.$route);
-                        if (translationIdResult) results.push({ name: i18n.t(translationIdResult), to: location, copiable: d.meta.copiable });
+                        if (translationIdResult) {
+                            results.push({
+                                name: i18n.t(translationIdResult),
+                                to: location,
+                                copiable: typeof d.meta.copiable === 'function' ? d.meta.copiable(vm.$route) : d.meta.copiable,
+                            });
+                        }
                     } else {
-                        results.push({ name: i18n.t(translationId), to: location, copiable: d.meta.copiable });
+                        results.push({
+                            name: i18n.t(translationId),
+                            to: location,
+                            copiable: typeof d.meta.copiable === 'function' ? d.meta.copiable(vm.$route) : d.meta.copiable,
+                        });
                     }
                 } else if (d.meta.menuId) {
                     const menuInfo = MENU_INFO_MAP[d.meta.menuId];
                     if (menuInfo) {
-                        results.push({ name: i18n.t(menuInfo.translationId), to: location, copiable: d.meta.copiable });
+                        results.push({
+                            name: i18n.t(menuInfo.translationId),
+                            to: location,
+                            copiable: typeof d.meta.copiable === 'function' ? d.meta.copiable(vm.$route) : d.meta.copiable,
+                        });
                     }
                 }
 

--- a/apps/web/src/services/cost-explorer/routes.ts
+++ b/apps/web/src/services/cost-explorer/routes.ts
@@ -8,7 +8,7 @@ import { ACCESS_LEVEL } from '@/lib/access-control/config';
 import { getRedirectRouteByPagePermission } from '@/lib/access-control/redirect-route-helper';
 import { MENU_ID } from '@/lib/menu/config';
 
-import { MANAGED_COST_QUERY_SET_IDS } from '@/services/cost-explorer/cost-analysis/config';
+import { MANAGED_COST_QUERY_SET_IDS, managedCostQuerySetIdList } from '@/services/cost-explorer/cost-analysis/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 
 const CostExplorerContainer = () => import('@/services/cost-explorer/CostExplorerContainer.vue');
@@ -18,6 +18,7 @@ const BudgetMainPage = () => import('@/services/cost-explorer/budget/budget-main
 const BudgetCreatePage = () => import('@/services/cost-explorer/budget/budget-create/BudgetCreatePage.vue');
 const BudgetBulkCreatePage = () => import('@/services/cost-explorer/budget/budget-bulk-create/BudgetBulkCreatePage.vue');
 const BudgetDetailPage = () => import('@/services/cost-explorer/budget/budget-detail/BudgetDetailPage.vue');
+const DYNAMIC_QUERY_SET_ID = 'dynamic';
 
 const costExplorerRoutes: RouteConfig = {
     path: 'cost-explorer',
@@ -55,8 +56,8 @@ const costExplorerRoutes: RouteConfig = {
                     name: COST_EXPLORER_ROUTE.COST_ANALYSIS.QUERY_SET._NAME,
                     meta: {
                         lnbVisible: true,
-                        label: ({ params }) => params.costQuerySetId,
-                        copiable: true,
+                        label: ({ params }) => (params.costQuerySetId === DYNAMIC_QUERY_SET_ID ? undefined : params.costQuerySetId),
+                        copiable: ({ params }) => ![...managedCostQuerySetIdList, DYNAMIC_QUERY_SET_ID].includes(params.costQuerySetId),
                     },
                     props: true,
                     component: CostAnalysisPage as any,

--- a/apps/web/src/shims-vue-router.d.ts
+++ b/apps/web/src/shims-vue-router.d.ts
@@ -25,6 +25,9 @@ import {
   interface RouteBreadcrumbsFormatter {
       (route: Route): Breadcrumb[];
   }
+  interface RouteCopiableFormatter {
+        (route: Route): boolean;
+  }
   interface RouteMeta {
     lnbVisible?: boolean;
     centeredLayout?: boolean;
@@ -32,7 +35,7 @@ import {
     label?: string|RouteLabelFormatter;
     translationId?: string|RouteTranslationIdFormatter;
     breadcrumbs?: RouteBreadcrumbsFormatter;
-    copiable?: boolean; // for breadcrumbs
+    copiable?: boolean|RouteCopiableFormatter; // for breadcrumbs
     isSignInPage?: boolean;
     accessLevel?: AccessLevel;
     accessInfo?: AccessInfo;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- Refactor `breadcrumbs` for dynamic `meta.copiable`, edit route custom type.
- Apply `dynamic` costQuerySetId.


![스크린샷 2023-09-08 오후 3 59 37](https://github.com/cloudforet-io/console/assets/83635051/d1c42f69-26f0-4951-939c-11a4c824d9b2)
![스크린샷 2023-09-08 오후 4 00 37](https://github.com/cloudforet-io/console/assets/83635051/894af7da-2f79-44f3-a6f8-b496deee20fd)


