### PR TITLE
fix(period-select-dropdown): fix the method of initialization according to situation

### DIFF
--- a/apps/web/src/services/cost-explorer/cost-analysis/lib/period-helper.ts
+++ b/apps/web/src/services/cost-explorer/cost-analysis/lib/period-helper.ts
@@ -5,17 +5,17 @@ import { GRANULARITY } from '@/services/cost-explorer/lib/config';
 import type { Granularity, Period } from '@/services/cost-explorer/type';
 
 
-export const convertRelativePeriodToPeriod = (relativePeriod: RelativePeriod): { start: string; end: string; } => {
+export const convertRelativePeriodToPeriod = (relativePeriod?: RelativePeriod): { start: string; end: string; } => {
     const today = dayjs.utc();
-    if (relativePeriod.unit === 'month') {
+    if (relativePeriod?.unit === 'month') {
         return {
             start: today.subtract(relativePeriod.value, 'month').format('YYYY-MM'),
-            end: today.subtract(relativePeriod.exclude_today ? 1 : 0, 'month').format('YYYY-MM'),
+            end: today.subtract(relativePeriod.include_today ? 1 : 0, 'month').format('YYYY-MM'),
         };
-    } if (relativePeriod.unit === 'year') {
+    } if (relativePeriod?.unit === 'year') {
         return {
             start: today.subtract(relativePeriod.value, 'year').format('YYYY'),
-            end: today.subtract(relativePeriod.exclude_today ? 1 : 0, 'year').format('YYYY'),
+            end: today.subtract(relativePeriod.include_today ? 1 : 0, 'year').format('YYYY'),
         };
     }
     return {
@@ -25,12 +25,11 @@ export const convertRelativePeriodToPeriod = (relativePeriod: RelativePeriod): {
 };
 export const initiatePeriodByGranularity = (granularity?: Granularity): [Period, RelativePeriod|undefined] => {
     if (granularity === GRANULARITY.DAILY) {
-        const thisMonthRelativePeriod:RelativePeriod = { unit: 'month', value: 0, exclude_today: true };
-        return [convertRelativePeriodToPeriod(thisMonthRelativePeriod), undefined];
+        return [convertRelativePeriodToPeriod(), undefined];
     } if (granularity === GRANULARITY.YEARLY) {
-        const thisYearRelativePeriod:RelativePeriod = { unit: 'year', value: 0, exclude_today: true };
+        const thisYearRelativePeriod:RelativePeriod = { unit: 'year', value: 0, include_today: true };
         return [convertRelativePeriodToPeriod(thisYearRelativePeriod), thisYearRelativePeriod];
     }
-    const last6MonthsRelativePeriod:RelativePeriod = { unit: 'month', value: 5, exclude_today: true };
+    const last6MonthsRelativePeriod:RelativePeriod = { unit: 'month', value: 5, include_today: true };
     return [convertRelativePeriodToPeriod(last6MonthsRelativePeriod), last6MonthsRelativePeriod];
 };

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
@@ -7,7 +7,7 @@ import { PSelectDropdown } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
 import type { SelectDropdownMenu } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
 import dayjs from 'dayjs';
-import { range } from 'lodash';
+import { isEqual, range } from 'lodash';
 
 import { i18n } from '@/translations';
 
@@ -20,18 +20,28 @@ import {
 import type { RelativePeriod } from '@/services/cost-explorer/cost-analysis/type';
 import { GRANULARITY } from '@/services/cost-explorer/lib/config';
 import { useCostAnalysisPageStore } from '@/services/cost-explorer/store/cost-analysis-page-store';
-import type { Period } from '@/services/cost-explorer/type';
+import type { Granularity, Period } from '@/services/cost-explorer/type';
 import CustomDateRangeModal from '@/services/dashboards/shared/CustomDateRangeModal.vue';
 
 
 const today = dayjs.utc();
 interface PeriodItem extends SelectDropdownMenu {
-    period: {
+    period?: {
         start: string
         end: string;
     };
     relativePeriod?: RelativePeriod;
 }
+
+export interface ParamsForSelectedPeriod {
+    relativePeriod?: RelativePeriod;
+    period?: Period;
+    granularity?: Granularity;
+}
+
+const props = defineProps<{
+    paramsForSelectedPeriod?: ParamsForSelectedPeriod;
+}>();
 
 const costAnalysisPageStore = useCostAnalysisPageStore();
 const costAnalysisPageState = costAnalysisPageStore.$state;
@@ -112,6 +122,38 @@ const state = reactive({
 });
 
 /* Util */
+const getPeriodItemNameByRelativePeriod = (relativePeriod?: RelativePeriod) => state.allPeriodItems.find((item) => isEqual(item.relativePeriod, relativePeriod))?.name;
+const setSelectedItemByOptions = ({ relativePeriod, period, granularity }:ParamsForSelectedPeriod) => {
+    console.log('setSelectedItemByOptions', { relativePeriod, period, granularity });
+    if (!relativePeriod && !period && granularity) {
+        const [defaultPeriod, defaultRelativePeriod] = initiatePeriodByGranularity(granularity);
+        costAnalysisPageStore.$patch((_state) => {
+            _state.period = defaultPeriod;
+            _state.relativePeriod = defaultRelativePeriod;
+        });
+        if (granularity === GRANULARITY.DAILY) {
+            state.selectedPeriod = today.subtract(0, 'month').format('YYYY-MM');
+        } else {
+            console.log('어때', getPeriodItemNameByRelativePeriod(defaultRelativePeriod), defaultRelativePeriod);
+            state.selectedPeriod = getPeriodItemNameByRelativePeriod(defaultRelativePeriod);
+        }
+        return;
+    }
+    if (granularity) {
+        costAnalysisPageStore.$patch((_state) => {
+            _state.granularity = granularity;
+        });
+    }
+    if (relativePeriod) {
+        console.log('setSelectedItemByOptions', getPeriodItemNameByRelativePeriod(relativePeriod), relativePeriod);
+        state.selectedPeriod = getPeriodItemNameByRelativePeriod(relativePeriod);
+    } else if (granularity === GRANULARITY.DAILY) {
+        const selectedPeriodItem:PeriodItem|undefined = state.dailyPeriodItems.find((item) => isEqual(item.period, period));
+        state.selectedPeriod = selectedPeriodItem?.name;
+    } else {
+        state.selectedPeriod = 'custom';
+    }
+};
 const setPeriodMenuItemWithPeriod = (period?: Period) => {
     const start = dayjs.utc(period?.start).format('YYYY-MM');
     const end = dayjs.utc(period?.end).format('YYYY-MM');
@@ -143,19 +185,32 @@ const handleCustomRangeModalConfirm = (period: Period) => {
     state.customRangeModalVisible = false;
 };
 
-watch(() => costAnalysisPageState.granularity, (granularity) => {
-    const [period, relativePeriod] = initiatePeriodByGranularity(granularity);
-    costAnalysisPageStore.$patch((_state) => {
-        _state.period = period;
-        _state.relativePeriod = relativePeriod;
+// watch(() => costAnalysisPageState.granularity, (granularity) => {
+//     const [period, relativePeriod] = initiatePeriodByGranularity(granularity);
+//     costAnalysisPageStore.$patch((_state) => {
+//         _state.period = period;
+//         _state.relativePeriod = relativePeriod;
+//     });
+//     if (granularity === GRANULARITY.DAILY) {
+//         state.selectedPeriod = today.subtract(0, 'month').format('YYYY-MM');
+//     } else if (granularity === GRANULARITY.MONTHLY) {
+//         state.selectedPeriod = 'last6Month';
+//     } else {
+//         state.selectedPeriod = 'thisYear';
+//     }
+// });
+watch(() => props.paramsForSelectedPeriod, (params) => {
+    if (params) setSelectedItemByOptions(params);
+});
+
+watch(() => costAnalysisPageStore.selectedQuerySet, async (selectedQuery) => {
+    setSelectedItemByOptions({
+        relativePeriod: selectedQuery?.options?.relative_period,
+        period: selectedQuery?.options?.period,
+        granularity: selectedQuery?.options?.granularity,
     });
-    if (granularity === GRANULARITY.DAILY) {
-        state.selectedPeriod = today.subtract(0, 'month').format('YYYY-MM');
-    } else if (granularity === GRANULARITY.MONTHLY) {
-        state.selectedPeriod = 'last6Month';
-    } else {
-        state.selectedPeriod = 'thisYear';
-    }
+}, {
+    immediate: true,
 });
 watch(() => costAnalysisPageState.period, (period) => {
     if (period && !costAnalysisPageState.relativePeriod) {

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
@@ -124,7 +124,7 @@ const state = reactive({
 /* Util */
 const getPeriodItemNameByRelativePeriod = (relativePeriod?: RelativePeriod) => state.allPeriodItems.find((item) => isEqual(item.relativePeriod, relativePeriod))?.name;
 
-const setSelectedItemByGranularity = (granularity) => {
+const setSelectedItemByGranularity = (granularity:Granularity) => {
     if (granularity) {
         const [defaultPeriod, defaultRelativePeriod] = initiatePeriodByGranularity(granularity);
         costAnalysisPageStore.$patch((_state) => {
@@ -139,15 +139,10 @@ const setSelectedItemByGranularity = (granularity) => {
     }
 };
 const setSelectedItemByQuerySet = ({ relativePeriod, period, granularity }:ParamsForSelectedPeriod) => {
-    if (granularity) {
-        costAnalysisPageStore.$patch((_state) => {
-            _state.granularity = granularity;
-        });
-    }
     if (relativePeriod) {
         state.selectedPeriod = getPeriodItemNameByRelativePeriod(relativePeriod);
     } else if (granularity === GRANULARITY.DAILY) {
-        const selectedPeriodItem:PeriodItem|undefined = state.dailyPeriodItems.find((item) => isEqual(item.period, period));
+        const selectedPeriodItem:PeriodItem|undefined = state.dailyPeriodItems.find((item:PeriodItem) => isEqual(item.period, period));
         state.selectedPeriod = selectedPeriodItem?.name;
     } else {
         state.selectedPeriod = 'custom';
@@ -197,11 +192,6 @@ watch(() => costAnalysisPageStore.selectedQuerySet, async (selectedQuery) => {
 }, {
     immediate: true,
 });
-watch(() => costAnalysisPageState.period, (period) => {
-    if (period && !costAnalysisPageState.relativePeriod) {
-        state.selectedPeriod = 'custom';
-    }
-}, { immediate: true });
 </script>
 
 <template>

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
@@ -49,43 +49,42 @@ const state = reactive({
                 start: start.format('YYYY-MM'),
                 end: end.format('YYYY-MM'),
             },
-            enabled: [GRANULARITY.DAILY],
         };
     }))),
-    monthlyPeriodItems: computed(() => ([
+    monthlyPeriodItems: computed<PeriodItem[]>(() => ([
         {
             name: 'thisMonth',
             label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.PERIOD.THIS_MONTH'),
-            relativePeriod: { unit: 'month', value: 0 },
+            relativePeriod: { unit: 'month', value: 0, include_today: true },
         },
         {
             name: 'lastMonth',
             label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.PERIOD.LAST_MONTH'),
-            relativePeriod: { unit: 'month', value: 1, exclude_today: true },
+            relativePeriod: { unit: 'month', value: 1, include_today: false },
         },
         {
             name: 'last3Month',
             label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.PERIOD.LAST_3_MONTHS'),
-            relativePeriod: { unit: 'month', value: 2 },
+            relativePeriod: { unit: 'month', value: 2, include_today: true },
         },
         {
             name: 'last6Month',
             label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.PERIOD.LAST_6_MONTHS'),
-            relativePeriod: { unit: 'month', value: 5 },
+            relativePeriod: { unit: 'month', value: 5, include_today: true },
         }])),
-    yearlyPeriodItems: computed(() => ([
+    yearlyPeriodItems: computed<PeriodItem[]>(() => ([
         {
             name: 'thisYear',
             label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.PERIOD.THIS_YEAR'),
-            relativePeriod: { unit: 'year', value: 0 },
+            relativePeriod: { unit: 'year', value: 0, include_today: true },
         },
         {
             name: 'lastYear',
             label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.PERIOD.LAST_YEAR'),
-            relativePeriod: { unit: 'year', value: 1, exclude_today: true },
+            relativePeriod: { unit: 'year', value: 1, include_today: false },
         },
     ])),
-    allPeriodItems: computed(() => ([
+    allPeriodItems: computed<PeriodItem[]>(() => ([
         ...state.dailyPeriodItems,
         ...state.monthlyPeriodItems,
         ...state.yearlyPeriodItems,

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -65,6 +65,7 @@ const state = reactive({
     selectedQuerySetId: computed(() => costAnalysisPageStore.selectedQueryId),
     isManagedQuerySet: computed(() => managedCostQuerySetIdList.includes(state.selectedQuerySetId)),
     filtersPopoverVisible: false,
+    granularity: undefined as Granularity|undefined,
 });
 
 const {
@@ -83,7 +84,7 @@ onClickOutside(contextMenuRef, hideContextMenu);
 /* event */
 const handleSelectGranularity = async (granularity: Granularity) => {
     costAnalysisPageStore.$patch({ granularity });
-    state.paramsForSelectedPeriod = { granularity };
+    state.granularity = granularity;
 };
 const handleSaveQuerySet = async () => {
     try {
@@ -128,7 +129,7 @@ const handleClickFilter = () => {
                                    :selected="costAnalysisPageState.granularity"
                                    @select="handleSelectGranularity"
                 />
-                <cost-analysis-period-select-dropdown />
+                <cost-analysis-period-select-dropdown :local-granularity="state.granularity" />
                 <p-popover :is-visible="state.filtersPopoverVisible"
                            ignore-outside-click
                            trigger="click"

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -83,6 +83,7 @@ onClickOutside(contextMenuRef, hideContextMenu);
 /* event */
 const handleSelectGranularity = async (granularity: Granularity) => {
     costAnalysisPageStore.$patch({ granularity });
+    state.paramsForSelectedPeriod = { granularity };
 };
 const handleSaveQuerySet = async () => {
     try {

--- a/apps/web/src/services/cost-explorer/cost-analysis/type.ts
+++ b/apps/web/src/services/cost-explorer/cost-analysis/type.ts
@@ -44,5 +44,5 @@ export interface Legend {
 export type RelativePeriod = {
     unit: OpUnitType;
     value: number;
-    exclude_today: boolean;
+    include_today: boolean;
 };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
The "CostAnalysisPeriodSelectDropdown" is initialized in two different ways:
- When the "costQuerySet" is changed through the LNB (Left Navigation Bar).
- When the granularity is changed.
Since these two components are located in different places, it was not straightforward to manipulate them using a simple `watch`. Therefore, I ended up creating some unconventional code. Please confirm if this structure is appropriate.

### Things to Talk About
