### PR TITLE
refactor: change the type of 'selectedItem' to allow for both string and number and style

### DIFF
--- a/apps/web/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceHistoryDateSelectDropdown.vue
+++ b/apps/web/src/services/asset-inventory/cloud-service/cloud-service-detail/modules/CloudServiceHistoryDateSelectDropdown.vue
@@ -18,7 +18,7 @@ import { computed, reactive, toRefs } from 'vue';
 import {
     PSelectDropdown,
 } from '@spaceone/design-system';
-import type { SelectDropdownMenu } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
 import dayjs from 'dayjs';
 import { range } from 'lodash';
 
@@ -48,16 +48,16 @@ export default {
         const state = reactive({
             proxySelectedYear: useProxyValue('selectedYear', props, emit),
             proxySelectedMonth: useProxyValue('selectedMonth', props, emit),
-            yearMenuItems: computed<SelectDropdownMenu[]>(() => {
+            yearMenuItems: computed<SelectDropdownMenuItem[]>(() => {
                 const currYear = dayjs.utc();
-                const menuItems: SelectDropdownMenu[] = [];
+                const menuItems: SelectDropdownMenuItem[] = [];
                 range(4).forEach((i) => {
                     const date = currYear.subtract(i, 'year').format('YYYY');
                     menuItems.push({ name: date, label: date });
                 });
                 return menuItems;
             }),
-            monthMenuItems: computed<SelectDropdownMenu[]>(() => {
+            monthMenuItems: computed<SelectDropdownMenuItem[]>(() => {
                 const months = i18nDayjs.value.months();
                 const menuItems = [
                     { name: 'all', label: i18n.t('INVENTORY.CLOUD_SERVICE.HISTORY.ALL_MONTH') },

--- a/apps/web/src/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue
+++ b/apps/web/src/services/asset-inventory/service-account/modules/ServiceAccountCredentialsForm.vue
@@ -129,7 +129,7 @@ import {
     PFieldGroup, PRadio, PTab, PJsonSchemaForm, PTextEditor, PSelectDropdown, PLink, PCopyButton, PI,
 } from '@spaceone/design-system';
 import { ACTION_ICON } from '@spaceone/design-system/src/inputs/link/type';
-import type { SelectDropdownMenu } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
 import type { JsonSchema } from '@spaceone/design-system/types/inputs/forms/json-schema-form/type';
 import type { TabItem } from '@spaceone/design-system/types/navigation/tabs/tab/type';
 import { isEmpty } from 'lodash';
@@ -199,7 +199,7 @@ export default defineComponent<Props>({
             providerData: {} as ProviderModel,
             showTrustedAccount: computed<boolean>(() => state.providerData?.capability?.support_trusted_service_account ?? false),
             trustedAccounts: [] as ServiceAccountModel[],
-            trustedAccountMenuItems: computed<SelectDropdownMenu[]>(() => state.trustedAccounts.map((d) => ({
+            trustedAccountMenuItems: computed<SelectDropdownMenuItem[]>(() => state.trustedAccounts.map((d) => ({
                 name: d.service_account_id,
                 label: d.name,
             }))),

--- a/apps/web/src/services/cost-explorer/budget/budget-main/modules/budget-toolbox/BudgetToolbox.vue
+++ b/apps/web/src/services/cost-explorer/budget/budget-main/modules/budget-toolbox/BudgetToolbox.vue
@@ -7,7 +7,7 @@ import type { TranslateResult } from 'vue-i18n';
 import {
     PToolbox, PSelectStatus, PButton, PSelectDropdown, PDivider,
 } from '@spaceone/design-system';
-import type { SelectDropdownMenu } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
 import type { ToolboxOptions } from '@spaceone/design-system/types/navigation/toolbox/type';
 import dayjs from 'dayjs';
 
@@ -37,7 +37,7 @@ export interface Pagination {
     pageLimit: number;
 }
 
-type I18nSelectDropdownMenu = SelectDropdownMenu | {
+type I18nSelectDropdownMenu = SelectDropdownMenuItem | {
     label: string | TranslateResult;
 };
 

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChartLegends.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisChartLegends.vue
@@ -6,7 +6,7 @@ import {
 import {
     PButton, PSelectDropdown, PStatus, PDataLoader,
 } from '@spaceone/design-system';
-import type { SelectDropdownMenu } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
 import { cloneDeep, sum } from 'lodash';
 
 import { useProxyValue } from '@/common/composables/proxy-state';
@@ -40,7 +40,7 @@ const state = reactive({
     }),
     //
     proxyLegends: useProxyValue('legends', props, emit),
-    groupByMenuItems: computed<SelectDropdownMenu[]>(() => costAnalysisPageState.groupBy.map((d) => {
+    groupByMenuItems: computed<SelectDropdownMenuItem[]>(() => costAnalysisPageState.groupBy.map((d) => {
         if (GROUP_BY_ITEM_MAP[d]) return GROUP_BY_ITEM_MAP[d];
         return {
             name: d, // tags.Name

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGroupByFilter.vue
@@ -5,7 +5,7 @@ import {
     PSelectButton, PFilterableDropdown,
 } from '@spaceone/design-system';
 import type { AutocompleteHandler } from '@spaceone/design-system/types/inputs/dropdown/filterable-dropdown/type';
-import type { SelectDropdownMenu } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
 import { xor } from 'lodash';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
@@ -30,11 +30,11 @@ const costAnalysisPageStore = useCostAnalysisPageStore();
 const costAnalysisPageState = costAnalysisPageStore.$state;
 
 const state = reactive({
-    selectedGroupByItems: computed<SelectDropdownMenu[]>(() => costAnalysisPageState.groupBy.map((d) => {
+    selectedGroupByItems: computed<SelectDropdownMenuItem[]>(() => costAnalysisPageState.groupBy.map((d) => {
         if (GROUP_BY_ITEM_MAP[d]) return GROUP_BY_ITEM_MAP[d];
         return { name: d, label: d.split('.')[1] };
     })),
-    selectedTagsMenu: [] as SelectDropdownMenu[],
+    selectedTagsMenu: [] as SelectDropdownMenuItem[],
 });
 
 /* fetcher */
@@ -88,7 +88,7 @@ const handleChangeDefaultGroupBy = async (selectedItems: GroupBySelectButtonItem
         });
     }
 };
-const handleSelectTagsGroupBy = (selectedItem: SelectDropdownMenu, isSelected: boolean) => {
+const handleSelectTagsGroupBy = (selectedItem: SelectDropdownMenuItem, isSelected: boolean) => {
     if (isSelected) {
         if (state.selectedGroupByItems.length + 1 > 3) {
             showErrorMessage('', i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.ALT_E_ADD_GROUP_BY'));

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
@@ -5,7 +5,7 @@ import {
 
 import { PSelectDropdown } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
-import type { SelectDropdownMenu } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
 import dayjs from 'dayjs';
 import { isEqual, range } from 'lodash';
 
@@ -25,7 +25,7 @@ import CustomDateRangeModal from '@/services/dashboards/shared/CustomDateRangeMo
 
 
 const today = dayjs.utc();
-interface PeriodItem extends SelectDropdownMenu {
+interface PeriodItem extends SelectDropdownMenuItem {
     period?: {
         start: string
         end: string;

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetInputForm.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetInputForm.vue
@@ -87,7 +87,7 @@ import {
     PFieldGroup, PTextInput, PJsonSchemaForm, PToggleButton, PDataLoader, PIconButton, PTextButton,
 } from '@spaceone/design-system';
 import type { FilterableDropdownMenuItem } from '@spaceone/design-system/types/inputs/dropdown/filterable-dropdown/type';
-import type { SelectDropdownMenu } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@spaceone/design-system/types/inputs/dropdown/select-dropdown/type';
 import type { JsonSchema } from '@spaceone/design-system/types/inputs/forms/json-schema-form/type';
 import {
     cloneDeep, isEmpty, isEqual, union, xor,
@@ -243,7 +243,7 @@ export default defineComponent<Props>({
         };
 
         /* utils */
-        const isSelected = (selectedItem: SelectDropdownMenu | FilterableDropdownMenuItem[]): boolean => {
+        const isSelected = (selectedItem: SelectDropdownMenuItem | FilterableDropdownMenuItem[]): boolean => {
             if (Array.isArray(selectedItem)) return !!selectedItem.length;
             return selectedItem && !isEmpty(selectedItem);
         };

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
@@ -123,7 +123,7 @@ export const Template = (args, { argTypes }) => ({
                     <tbody>
                         <tr>
                             <th v-for="styleType in styleTypes" :key="styleType" class="font-normal">
-                                <p-select-dropdown :menu="menuItems" :styleType="styleType" class="m-2"/>
+                                <p-select-dropdown :menu="menuItems" :styleType="styleType" class="my-2 mx-auto"/>
                             </th>
                         </tr>
                     </tbody>

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -227,12 +227,12 @@ watch(() => props.disabled, (disabled) => {
 });
 
 /* init */
-(async () => {
+(() => {
     if (!props.multiSelectable) return;
     if (!props.selected) return;
     if (Array.isArray(props.selected)) return;
 
-    throw new Error('If \'multiSelectable\' is \'true\', \'selected\' option must be array.');
+    throw new Error('If \'multiSelectable\' is \'true\', \'selected\' option must be an array.');
 })();
 </script>
 

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -208,7 +208,7 @@ const updateSelected = (selected: SelectDropdownMenuItem[]) => {
     if (props.multiSelectable) {
         state.proxySelectedItem = selected;
     } else {
-        state.proxySelectedItem = selected[0]?.label;
+        state.proxySelectedItem = selected[0]?.name;
     }
 };
 const updateSearchText = debounce(async (searchText: string) => {

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -44,7 +44,7 @@ interface SelectDropdownProps {
     visibleMenu?: boolean;
     menu?: SelectDropdownMenuItem[];
     loading?: boolean;
-    selected?: SelectDropdownMenuItem[];
+    selected?: SelectDropdownMenuItem[]|string|number;
     multiSelectable?: boolean;
     searchText?: string;
     readonly?: boolean;
@@ -63,7 +63,7 @@ const props = withDefaults(defineProps<SelectDropdownProps>(), {
     /* dropdown button */
     styleType: SELECT_DROPDOWN_STYLE_TYPE.DEFAULT,
     appearanceType: SELECT_DROPDOWN_APPEARANCE_TYPE.BASIC,
-    selected: () => [],
+    selected: undefined,
     placeholder: undefined,
     selectionLabel: undefined,
     showDeleteAllButton: false,
@@ -94,7 +94,15 @@ const slots = useSlots();
 
 const state = reactive({
     proxyVisibleMenu: useProxyValue<boolean>('visibleMenu', props, emit),
-    proxySelectedItem: useProxyValue<SelectDropdownMenuItem[]>('selected', props, emit),
+    proxySelectedItem: useProxyValue<SelectDropdownMenuItem[]|string|number>('selected', props, emit),
+    selectedItems: computed<SelectDropdownMenuItem[]>(() => {
+        if (!state.proxySelectedItem) return [];
+        if (Array.isArray(state.proxySelectedItem)) return state.proxySelectedItem;
+        return [{
+            label: state.proxySelectedItem,
+            value: state.proxySelectedItem,
+        }];
+    }),
     proxySearchText: useProxyValue('searchText', props, emit),
     showDeleteAllButton: computed(() => {
         if (!props.showDeleteAllButton) return false;
@@ -151,7 +159,7 @@ const {
     useMenuFiltering: true,
     useReorderBySelection: true,
     searchText: toRef(state, 'proxySearchText'),
-    selected: toRef(state, 'proxySelectedItem'),
+    selected: props.isFilterable ? toRef(state, 'selectedItems') : [],
     handler: toRef(props, 'handler'),
     menu: toRef(props, 'menu'),
     pageSize: toRef(props, 'pageSize'),
@@ -237,7 +245,7 @@ watch(() => props.disabled, (disabled) => {
                          :is-visible-menu="state.proxyVisibleMenu"
                          :readonly="props.readonly"
                          :multi-selectable="props.multiSelectable"
-                         :selected-items="state.proxySelectedItem"
+                         :selected-items="state.selectedItems"
                          @enter-key="handleEnterKey"
                          @click-delete="handleClickDelete"
                          @click-dropdown-button="handleClickDropdownButton"
@@ -257,7 +265,7 @@ watch(() => props.disabled, (disabled) => {
                         }"
                         :item-height-fixed="!props.isFilterable"
                         :no-select-indication="!props.isFilterable"
-                        :selected="state.proxySelectedItem"
+                        :selected="state.selectedItems"
                         :multi-selectable="props.multiSelectable"
                         :search-text="state.proxySearchText"
                         :searchable="props.isFilterable"

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -205,7 +205,11 @@ const handleEnterKey = () => {
     focusOnContextMenu(undefined);
 };
 const updateSelected = (selected: SelectDropdownMenuItem[]) => {
-    state.proxySelectedItem = selected;
+    if (props.multiSelectable) {
+        state.proxySelectedItem = selected;
+    } else {
+        state.proxySelectedItem = selected[0]?.label;
+    }
 };
 const updateSearchText = debounce(async (searchText: string) => {
     state.proxySearchText = searchText;
@@ -221,6 +225,15 @@ useIgnoreWindowArrowKeydownEvents({ predicate: state.proxyVisibleMenu });
 watch(() => props.disabled, (disabled) => {
     if (disabled) hideMenu();
 });
+
+/* init */
+(async () => {
+    if (!props.multiSelectable) return;
+    if (!props.selected) return;
+    if (Array.isArray(props.selected)) return;
+
+    throw new Error('If \'multiSelectable\' is \'true\', \'selected\' option must be array.');
+})();
 </script>
 
 <template>

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -226,6 +226,7 @@ watch(() => props.disabled, (disabled) => {
 <template>
     <div ref="containerRef"
          :class="{
+             [props.styleType]: true,
              'p-select-dropdown': true,
              'is-fixed-width': props.isFixedWidth,
          }"
@@ -255,14 +256,12 @@ watch(() => props.disabled, (disabled) => {
                         :class="{
                             'dropdown-context-menu': true,
                             default: !props.showSelectMarker,
-                            [menuPosition]: props.styleType !== SELECT_DROPDOWN_STYLE_TYPE.ICON_BUTTON && !useFixedMenuStyle }"
+                            [menuPosition]: !useFixedMenuStyle
+                        }"
                         :menu="refinedMenu"
                         :loading="props.loading || loading"
                         :readonly="props.readonly"
-                        :style="{
-                            ...contextMenuStyle,
-                            ...(props.styleType === SELECT_DROPDOWN_STYLE_TYPE.ICON_BUTTON && {width: 'auto'}),
-                        }"
+                        :style="contextMenuStyle"
                         :item-height-fixed="!props.isFilterable"
                         :no-select-indication="!props.isFilterable"
                         :selected="state.selectedItems"
@@ -322,6 +321,10 @@ watch(() => props.disabled, (disabled) => {
 
     &.is-fixed-width {
         display: initial;
+    }
+
+    &.icon-button {
+        min-width: unset;
     }
 }
 </style>

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/components/dropdown-button.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/components/dropdown-button.vue
@@ -297,10 +297,8 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
     }
     &.icon-button {
         @apply flex items-center justify-center text-gray-600 cursor-pointer;
-        min-width: unset;
         width: 2rem;
         height: 2rem;
-        margin: auto;
         .dropdown-icon-button-wrapper {
             @apply flex items-center justify-center rounded-full;
             width: 2rem;

--- a/packages/mirinae/src/inputs/forms/json-schema-form/helper.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/helper.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteHandler } from '@/inputs/dropdown/filterable-dropdown/type';
-import type { SelectDropdownMenu } from '@/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@/inputs/dropdown/select-dropdown/type';
 import type {
     ComponentName, InnerJsonSchema, JsonSchema, JsonSchemaFormProps, TextInputType,
 } from '@/inputs/forms/json-schema-form/type';
@@ -155,7 +155,7 @@ export const getInputTypeBySchemaProperty = (schemaProperty: InnerJsonSchema): T
 
 export const getInputPlaceholderBySchemaProperty = (schemaProperty: InnerJsonSchema) => schemaProperty.examples?.[0] ?? '';
 
-export const getMenuItemsBySchemaProperty = (schemaProperty: InnerJsonSchema): SelectDropdownMenu[]|undefined => {
+export const getMenuItemsBySchemaProperty = (schemaProperty: InnerJsonSchema): SelectDropdownMenuItem[]|undefined => {
     if (schemaProperty.reference) return undefined;
     // get menu items from menuItems
     if (Array.isArray(schemaProperty.menuItems) && schemaProperty.menuItems.length) {

--- a/packages/mirinae/src/inputs/forms/json-schema-form/type.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/type.ts
@@ -1,7 +1,7 @@
 import type { JSONSchemaType } from 'ajv';
 
 import type { AutocompleteHandler, FilterableDropdownMenuItem } from '@/inputs/dropdown/filterable-dropdown/type';
-import type { SelectDropdownMenu } from '@/inputs/dropdown/select-dropdown/type';
+import type { SelectDropdownMenuItem } from '@/inputs/dropdown/select-dropdown/type';
 import type { InputAppearanceType } from '@/inputs/input/text-input/type';
 import type { SupportLanguage } from '@/translations';
 
@@ -20,7 +20,7 @@ export type JsonSchema<Properties = object> = JSONSchemaType<Properties> & {
     order?: string[];
     disabled?: boolean;
     json?: boolean;
-    menuItems?: SelectDropdownMenu[];
+    menuItems?: SelectDropdownMenuItem[];
     reference?: Reference;
 };
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA

### Things to Talk About
For the following reasons, I have made changes to the existing 'selectDropdown' so that 'selected' can now accept an array, string, or number, and it is internally processed as an array within the component:

- When 'selected' is singular, forcing the user to create an array to pass it in is not user-friendly. For better usability, it seems more reasonable for the component to handle this.
- Ultimately, since the processed array is what goes into the context menu or dropdown button, it does not significantly compromise code internal consistency while potentially improving usability.