### PR TITLE
feat(dashboard-date-range-modal): create new custom date range modal & renewal toolset

### DIFF
--- a/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
+++ b/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
@@ -4,6 +4,7 @@ import { computed, reactive, watch } from 'vue';
 import {
     PButtonModal, PFieldGroup, PDatetimePicker, useProxyValue,
 } from '@spaceone/design-system';
+import { DATA_TYPE } from '@spaceone/design-system/src/inputs/datetime-picker/type';
 import dayjs from 'dayjs';
 
 import type { Period } from '@/services/cost-explorer/type';
@@ -27,7 +28,7 @@ const emit = defineEmits<{(event: 'update:visible', visible: boolean): void;
 
 const state = reactive({
     proxyVisible: useProxyValue('visible', props, emit),
-    dateType: 'yearToMonth',
+    dateType: DATA_TYPE.yearToDate,
     invalid: computed(() => !state.selectedDates.length),
     selectedDates: [] as string[],
     dateLimitSetting: computed<DateOption>(() => {

--- a/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
+++ b/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed, reactive, watch } from 'vue';
+
+import {
+    PButtonModal, PFieldGroup, PDatetimePicker, useProxyValue,
+} from '@spaceone/design-system';
+import dayjs from 'dayjs';
+
+import type { Period } from '@/services/cost-explorer/type';
+
+const props = withDefaults(defineProps<{
+    visible: boolean;
+    selectedDateRange?: Period;
+}>(), {
+    visible: false,
+    selectedDateRange: () => ({}),
+});
+
+const emit = defineEmits<{(event: 'update:visible', visible: boolean): void;
+    (event: 'confirm', period: Period): void;
+}>();
+
+const state = reactive({
+    proxyVisible: useProxyValue('visible', props, emit),
+    dateType: 'yearToMonth',
+    invalid: computed(() => !state.selectedDates.length),
+    selectedDates: [] as string[],
+});
+
+const handleUpdateVisible = (visible: boolean) => {
+    state.proxyVisible = visible;
+};
+const handleUpdateSelectedDates = (selectedDates: string[]) => {
+    if (!selectedDates.length) return;
+    const originDates = state.selectedDates;
+
+    if (dayjs.utc(originDates[0]).isSame(dayjs.utc(selectedDates[0]), 'day')) return;
+    state.selectedDates = selectedDates;
+};
+const handleConfirm = () => {
+    state.proxyVisible = false;
+    const period: Period = {};
+    period.start = dayjs.utc(state.selectedDates[0]).format('YYYY-MM-01');
+    period.end = dayjs.utc(state.selectedDates[0]).endOf('month').format('YYYY-MM-DD');
+    emit('confirm', period);
+};
+
+watch(() => props.visible, (visible) => {
+    if (visible) {
+        if (props.selectedDateRange?.start) {
+            state.selectedDates = [props.selectedDateRange?.start];
+        } else {
+            state.selectedDates = [];
+        }
+    } else {
+        state.selectedDates = [];
+    }
+});
+
+</script>
+
+<template>
+    <p-button-modal :header-title="$t('Apply Custom Range')"
+                    centered
+                    size="sm"
+                    fade
+                    backdrop
+                    :visible.sync="state.proxyVisible"
+                    :disable="state.invalid"
+                    @update:visible="handleUpdateVisible"
+                    @confirm="handleConfirm"
+    >
+        <template #body>
+            <p-field-group class="period-select"
+                           :label="$t('Month')"
+                           required
+            >
+                <p-datetime-picker class="datetime-picker"
+                                   :data-type="state.dateType"
+                                   :selected-dates="state.selectedDates"
+                                   :invalid="state.invalid"
+                                   @update:selected-dates="handleUpdateSelectedDates"
+                />
+            </p-field-group>
+        </template>
+        <template #confirm-button>
+            {{ $t('Apply') }}
+        </template>
+    </p-button-modal>
+</template>
+
+<style scoped lang="postcss">
+.period-select {
+    .datetime-picker {
+        width: 100%;
+    }
+}
+</style>

--- a/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
+++ b/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
@@ -8,6 +8,11 @@ import dayjs from 'dayjs';
 
 import type { Period } from '@/services/cost-explorer/type';
 
+interface DateOption {
+    minDate?: string;
+    maxDate?: string;
+}
+
 const props = withDefaults(defineProps<{
     visible: boolean;
     selectedDateRange?: Period;
@@ -25,6 +30,11 @@ const state = reactive({
     dateType: 'yearToMonth',
     invalid: computed(() => !state.selectedDates.length),
     selectedDates: [] as string[],
+    dateLimitSetting: computed<DateOption>(() => {
+        const minDate = dayjs.utc().subtract(3, 'year').format('YYYY-MM-DD');
+        const maxDate = dayjs.utc().format('YYYY-MM-DD');
+        return { minDate, maxDate };
+    }),
 });
 
 const handleUpdateVisible = (visible: boolean) => {
@@ -79,6 +89,8 @@ watch(() => props.visible, (visible) => {
                                    :data-type="state.dateType"
                                    :selected-dates="state.selectedDates"
                                    :invalid="state.invalid"
+                                   :min-date="state.dateLimitSetting.minDate"
+                                   :max-date="state.dateLimitSetting.maxDate"
                                    @update:selected-dates="handleUpdateSelectedDates"
                 />
             </p-field-group>

--- a/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
+++ b/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
@@ -71,7 +71,7 @@ watch(() => props.visible, (visible) => {
 </script>
 
 <template>
-    <p-button-modal :header-title="$t('Apply Custom Range')"
+    <p-button-modal :header-title="$t('DASHBOARDS.DETAIL.CUSTOM_DATE_MODAL_TITLE')"
                     centered
                     size="sm"
                     fade
@@ -83,7 +83,7 @@ watch(() => props.visible, (visible) => {
     >
         <template #body>
             <p-field-group class="period-select"
-                           :label="$t('Month')"
+                           :label="$t('DASHBOARDS.DETAIL.CUSTOM_DATE_MODAL_MONTH')"
                            required
             >
                 <p-datetime-picker class="datetime-picker"
@@ -97,7 +97,7 @@ watch(() => props.visible, (visible) => {
             </p-field-group>
         </template>
         <template #confirm-button>
-            {{ $t('Apply') }}
+            {{ $t('DASHBOARDS.DETAIL.APPLY') }}
         </template>
     </p-button-modal>
 </template>

--- a/apps/web/src/services/dashboards/shared/dashboard-toolset/DashboardDateDropdown.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-toolset/DashboardDateDropdown.vue
@@ -1,42 +1,21 @@
 <template>
     <div class="dashboard-date-dropdown">
         <p-select-dropdown
-            style-type="transparent"
             :items="monthMenuItems"
             :selected="selectedMonthMenuIndex"
             index-mode
             menu-position="right"
             @select="handleSelectMonthMenuItem"
         >
-            <div>
-                <span>{{ selectedMonthLabel }}</span>
-                <p-badge
-                    v-if="selectedMonthBadge"
-                    style-type="indigo100"
-                    badge-type="subtle"
-                    class="ml-1"
-                >
-                    {{ selectedMonthBadge }}
-                </p-badge>
-            </div>
+            <span>{{ selectedMonthLabel }}</span>
             <template #menu-item--format="{ item }">
-                <div>
-                    <span>{{ item.label }}</span>
-                    <p-badge
-                        v-if="item.badge"
-                        style-type="indigo100"
-                        badge-type="subtle"
-                        class="ml-1"
-                    >
-                        {{ item.badge }}
-                    </p-badge>
-                </div>
+                <span>{{ item.label }}</span>
             </template>
         </p-select-dropdown>
-        <custom-date-range-modal :visible.sync="customRangeModalVisible"
-                                 granularity="MONTHLY"
-                                 :selected-date-range="dateRange"
-                                 @confirm="handleCustomRangeModalConfirm"
+        <dashboard-custom-date-range-modal :visible.sync="customRangeModalVisible"
+                                           granularity="MONTHLY"
+                                           :selected-date-range="dateRange"
+                                           @confirm="handleCustomRangeModalConfirm"
         />
     </div>
 </template>
@@ -47,7 +26,7 @@ import {
     computed, defineComponent, reactive, toRefs, watch,
 } from 'vue';
 
-import { PBadge, PSelectDropdown } from '@spaceone/design-system';
+import { PSelectDropdown } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
 import dayjs from 'dayjs';
 import { range } from 'lodash';
@@ -57,13 +36,12 @@ import { i18n } from '@/translations';
 import { useI18nDayjs } from '@/common/composables/i18n-dayjs';
 
 import type { DateRange } from '@/services/dashboards/config';
-import CustomDateRangeModal from '@/services/dashboards/shared/CustomDateRangeModal.vue';
+import DashboardCustomDateRangeModal from '@/services/dashboards/shared/DashboardCustomDateRangeModal.vue';
 
 export default defineComponent({
     name: 'DashboardDateDropdown',
     components: {
-        CustomDateRangeModal,
-        PBadge,
+        DashboardCustomDateRangeModal,
         PSelectDropdown,
     },
     props: {
@@ -91,7 +69,6 @@ export default defineComponent({
                     type: 'item',
                     name: 'current',
                     label: i18n.t('DASHBOARDS.DETAIL.CURRENT_MONTH'),
-                    badge: i18n.t('DASHBOARDS.DETAIL.AUTO'),
                 },
                 ...state.getMonthMenuItem,
                 { type: 'divider' },
@@ -101,9 +78,12 @@ export default defineComponent({
                     label: i18n.t('DASHBOARDS.DETAIL.CUSTOM'),
                 },
             ])),
-            selectedMonthLabel: computed(() => state.monthMenuItems[state.selectedMonthMenuIndex]?.label),
-            selectedMonthBadge: computed(() => state.monthMenuItems[state.selectedMonthMenuIndex]?.badge),
-            selectedMonthName: computed(() => state.monthMenuItems[state.selectedMonthMenuIndex]?.name),
+            selectedMonthLabel: computed(() => {
+                if (state.monthMenuItems[state.selectedMonthMenuIndex]?.name === 'custom') {
+                    return i18nDayjs.value.utc(dayjs.utc(state.selectedDateRange?.start).format('YYYY-MM-DD')).format('MMMM YYYY');
+                }
+                return state.monthMenuItems[state.selectedMonthMenuIndex]?.label;
+            }),
             selectedDateRange: {},
             selectedMonthMenuIndex: 0,
             customRangeModalVisible: false,

--- a/apps/web/src/services/dashboards/shared/dashboard-toolset/DashboardToolset.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-toolset/DashboardToolset.vue
@@ -1,29 +1,17 @@
 <template>
     <div class="dashboard-toolset">
-        <dashboard-date-range-badge v-show="dashboardDetailState.settings.date_range.enabled"
-                                    :date-range="dashboardDetailState.settings.date_range"
-        />
         <dashboard-date-dropdown v-show="dashboardDetailState.settings.date_range.enabled"
                                  :date-range="dashboardDetailState.settings.date_range"
                                  @update:date-range="handleUpdateDateRange"
-        />
-        <dashboard-currency-select-dropdown v-show="dashboardDetailState.settings.currency.enabled"
-                                            :currency="dashboardDetailState.settings.currency.value"
-                                            @update:currency="handleUpdateCurrency"
         />
     </div>
 </template>
 
 <script setup lang="ts">
-import type { Currency } from '@/store/modules/settings/type';
 
 import type { DashboardSettings } from '@/services/dashboards/config';
-import DashboardCurrencySelectDropdown
-    from '@/services/dashboards/shared/dashboard-toolset/DashboardCurrencySelectDropdown.vue';
 import DashboardDateDropdown from '@/services/dashboards/shared/dashboard-toolset/DashboardDateDropdown.vue';
-import DashboardDateRangeBadge from '@/services/dashboards/shared/dashboard-toolset/DashboardDateRangeBadge.vue';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
-
 
 const dashboardDetailStore = useDashboardDetailInfoStore();
 const dashboardDetailState = dashboardDetailStore.$state;
@@ -37,14 +25,7 @@ const handleUpdateDateRange = (dateRange: DashboardSettings['date_range']) => {
         };
     });
 };
-const handleUpdateCurrency = (currency: Currency) => {
-    dashboardDetailStore.$patch((_state) => {
-        _state.settings.currency = {
-            ..._state.settings.currency,
-            value: currency,
-        };
-    });
-};
+
 </script>
 
 <style scoped>

--- a/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
+++ b/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import {
     cloneDeep, isEmpty, isEqual,
 } from 'lodash';
@@ -74,8 +73,8 @@ const DEFAULT_REFRESH_INTERVAL = '5m';
 export const DASHBOARD_DEFAULT = Object.freeze<{ settings: DashboardSettings }>({
     settings: {
         date_range: {
-            start: dayjs.utc().format('YYYY-MM-01'),
-            end: dayjs.utc().format('YYYY-MM-DD'),
+            start: undefined,
+            end: undefined,
             enabled: false,
         },
         currency: {
@@ -179,8 +178,8 @@ export const useDashboardDetailInfoStore = defineStore<string, DashboardDetailIn
             this.settings = {
                 date_range: {
                     enabled: _dashboardInfo.settings?.date_range?.enabled ?? false,
-                    start: _dashboardInfo.settings?.date_range?.start ?? dayjs.utc().format('YYYY-MM-01'),
-                    end: _dashboardInfo.settings?.date_range?.end ?? dayjs.utc().format('YYYY-MM-DD'),
+                    start: _dashboardInfo.settings?.date_range?.start,
+                    end: _dashboardInfo.settings?.date_range?.end,
                 },
                 currency: {
                     enabled: _dashboardInfo.settings?.currency?.enabled ?? false,

--- a/packages/language-pack/console-translation-2.8.babel
+++ b/packages/language-pack/console-translation-2.8.babel
@@ -24139,6 +24139,27 @@
                         <name>DETAIL</name>
                         <children>
                             <concept_node>
+                                <name>APPLY</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
                                 <name>AUTO</name>
                                 <definition_loaded>false</definition_loaded>
                                 <description/>
@@ -24240,6 +24261,48 @@
                                     <translation>
                                         <language>ko-KR</language>
                                         <approved>true</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
+                                <name>CUSTOM_DATE_MODAL_MONTH</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                </translations>
+                            </concept_node>
+                            <concept_node>
+                                <name>CUSTOM_DATE_MODAL_TITLE</name>
+                                <definition_loaded>false</definition_loaded>
+                                <description/>
+                                <comment/>
+                                <default_text/>
+                                <translations>
+                                    <translation>
+                                        <language>en-US</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ja-JP</language>
+                                        <approved>false</approved>
+                                    </translation>
+                                    <translation>
+                                        <language>ko-KR</language>
+                                        <approved>false</approved>
                                     </translation>
                                 </translations>
                             </concept_node>

--- a/packages/language-pack/en.json
+++ b/packages/language-pack/en.json
@@ -1352,11 +1352,14 @@
 			}
 		},
 		"DETAIL": {
+			"APPLY": "Apply",
 			"AUTO": "Auto",
 			"CLONE": "Clone",
 			"CURRENT_MONTH": "Current month",
 			"CUSTOM": "Custom",
 			"CUSTOMIZE": "Customize",
+			"CUSTOM_DATE_MODAL_MONTH": "Month",
+			"CUSTOM_DATE_MODAL_TITLE": "Apply Custom Range",
 			"DEFAULT": "Default",
 			"DELETE": "Delete",
 			"EXPORT": "Export",

--- a/packages/language-pack/ja.json
+++ b/packages/language-pack/ja.json
@@ -1352,11 +1352,14 @@
 			}
 		},
 		"DETAIL": {
+			"APPLY": "",
 			"AUTO": "自動",
 			"CLONE": "複製",
 			"CURRENT_MONTH": "当月分",
 			"CUSTOM": "カスタム",
 			"CUSTOMIZE": "カスタマイズ",
+			"CUSTOM_DATE_MODAL_MONTH": "",
+			"CUSTOM_DATE_MODAL_TITLE": "",
 			"DEFAULT": "既定値",
 			"DELETE": "削除",
 			"EXPORT": "エクスポート",

--- a/packages/language-pack/ko.json
+++ b/packages/language-pack/ko.json
@@ -1352,11 +1352,14 @@
 			}
 		},
 		"DETAIL": {
+			"APPLY": "",
 			"AUTO": "자동",
 			"CLONE": "복제",
 			"CURRENT_MONTH": "최근월",
 			"CUSTOM": "커스텀",
 			"CUSTOMIZE": "편집",
+			"CUSTOM_DATE_MODAL_MONTH": "",
+			"CUSTOM_DATE_MODAL_TITLE": "",
 			"DEFAULT": "기본",
 			"DELETE": "삭제",
 			"EXPORT": "파일 저장",


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- `CustomDateRangeModal` is changed. So, I create New `DashboardCustomDateRangeModal.vue`.
- Currency and date-range-badge is removed.
- Remove default date range in `dashboard-detail-info` store. default value is `undefined`, that is shown as `Current Month`.

- Changed Toolset
![image](https://github.com/cloudforet-io/console/assets/83635051/aac974d3-88c5-4358-ab0f-c549bc372da6)

- New Modal
![image](https://github.com/cloudforet-io/console/assets/83635051/db929c90-7ab8-4da0-9476-5580038ee31c)


Please, see order by commits.

**_Dropdown's new design will be applied in next PR_**
