### PR TITLE
feat: index mode revival and apply proxySelectedItem from dropdown-button 

### DIFF
--- a/packages/mirinae/src/inputs/datetime-picker/PDatetimePicker.stories.mdx
+++ b/packages/mirinae/src/inputs/datetime-picker/PDatetimePicker.stories.mdx
@@ -159,7 +159,7 @@ Please refer to the table below. <br/>
             template: `
                 <div>
                 <p class="py-2">Select dataType.</p>
-                <p-select-dropdown :selected="selectedDataType" :menu="menu"/>
+                <p-select-dropdown :selected.sync="selectedDataType" :menu="menu"/>
                 <p class="py-2">Min Date = Today</p>
                 <p-datetime-picker v-model="start" :min-date="now" :data-type="selectedDataType" />
                 <p class="py-2">Max Date = Today</p>

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
@@ -54,6 +54,7 @@ export const Template = (args, { argTypes }) => ({
             :show-select-header="showSelectHeader"
             :show-select-marker="showSelectMarker"
             :menu-position="menuPosition"
+            :index-mode="indexMode"
             :handler="handler"
             :disable-handler="disableHandler"
             :page-size="pageSize"

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -51,6 +51,7 @@ interface SelectDropdownProps {
     showSelectHeader?: boolean;
     showSelectMarker?: boolean;
     menuPosition?: ContextMenuPosition;
+    indexMode?: boolean;
 
     /* others */
     handler?: AutocompleteHandler;
@@ -74,6 +75,7 @@ const props = withDefaults(defineProps<SelectDropdownProps>(), {
     loading: false,
     searchText: '',
     menuPosition: CONTEXT_MENU_POSITION.LEFT,
+    indexMode: false,
     /* others */
     handler: undefined,
     pageSize: undefined,
@@ -97,6 +99,7 @@ const state = reactive({
     proxySelectedItem: useProxyValue<SelectDropdownMenuItem[]|string|number>('selected', props, emit),
     selectedItems: computed<SelectDropdownMenuItem[]>(() => {
         if (!state.proxySelectedItem) return [];
+        if (props.indexMode) return props.menu[state.proxySelectedItem ?? ''] || null;
         if (Array.isArray(state.proxySelectedItem)) return state.proxySelectedItem;
         return props.menu.filter((m) => m.name === state.proxySelectedItem);
     }),
@@ -202,7 +205,11 @@ const handleEnterKey = () => {
     focusOnContextMenu(undefined);
 };
 const updateSelected = (selected: SelectDropdownMenuItem[]) => {
-    state.proxySelectedItem = selected;
+    if (props.multiSelectable) {
+        state.proxySelectedItem = selected;
+    } else {
+        state.proxySelectedItem = selected[0]?.name;
+    }
 };
 const updateSearchText = debounce(async (searchText: string) => {
     state.proxySearchText = searchText;

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -86,7 +86,7 @@ const props = withDefaults(defineProps<SelectDropdownProps>(), {
 const emit = defineEmits<{(e: 'update:visible-menu', visibleMenu: boolean): void;
     (e: 'update:search-text', searchText: string): void;
     (e: 'update:selected', selected: SelectDropdownMenuItem[]): void;
-    (e: 'select', item: SelectDropdownMenuItem, isSelected: boolean): void;
+    (e: 'select', item: SelectDropdownMenuItem|number|string, isSelected: boolean): void;
     (e: 'delete-tag', item: SelectDropdownMenuItem, index: number): void;
     (e: 'click-show-more'): void;
     (e: 'clear-selection'): void;
@@ -179,8 +179,12 @@ const handleClickDropdownButton = () => {
     else showMenu();
 };
 const handleSelectMenuItem = (item: SelectDropdownMenuItem, _, isSelected: boolean) => {
-    if (!props.multiSelectable) hideMenu();
-    emit('select', item, isSelected);
+    if (!props.multiSelectable) {
+        hideMenu();
+        emit('select', item.name || '', isSelected);
+    } else {
+        emit('select', item, isSelected);
+    }
 };
 const handleClickShowMore = async () => {
     if (!props.disableHandler) {

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/components/dropdown-button.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/components/dropdown-button.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { reactive, toRef } from 'vue';
+import { toRef } from 'vue';
 
 import PBadge from '@/data-display/badge/PBadge.vue';
 import PTag from '@/data-display/tags/PTag.vue';
 import PI from '@/foundation/icons/PI.vue';
-import { useProxyValue } from '@/hooks';
 import {
     useSelectDropdownButtonDisplay,
 } from '@/inputs/dropdown/select-dropdown/composables/select-dropdown-button-display';
@@ -52,10 +51,6 @@ const emit = defineEmits<{(e: 'update:selectedItems', selected: SelectDropdownMe
     (e: 'enter-key'): void;
 }>();
 
-const state = reactive({
-    proxySelectedItems: useProxyValue<SelectDropdownMenuItem[]|string|number>('selectedItems', props, emit),
-});
-
 /* dropdown button display */
 const {
     displayValueOnDropdownButton,
@@ -63,12 +58,12 @@ const {
     displayBadgeValueOnDropdownButton,
 } = useSelectDropdownButtonDisplay({
     multiSelectable: toRef(props, 'multiSelectable'),
-    selected: toRef(state, 'proxySelectedItems'),
+    selected: toRef(props, 'selectedItems'),
     appearanceType: toRef(props, 'appearanceType'),
 });
 
 const handleClickDeleteAll = () => {
-    if (state.proxySelectedItems) {
+    if (props.selectedItems) {
         emit('click-delete');
     }
 };
@@ -85,9 +80,9 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
         disabled: props.disabled,
         readonly: props.readonly,
         opened: props.isVisibleMenu,
-        selected: state.proxySelectedItem,
+        selected: props.selectedItems,
         'is-fixed-width': props.isFixedWidth,
-        'selection-highlight': props.selectionHighlight && state.proxySelectedItem,
+        'selection-highlight': props.selectionHighlight && props.selectedItems,
     }"
     >
         <span v-if="props.styleType === SELECT_DROPDOWN_STYLE_TYPE.ICON_BUTTON"
@@ -145,7 +140,7 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
                         <div v-else-if="showTagsOnDropdownButton"
                              class="tags-wrapper"
                         >
-                            <p-tag v-for="(item, idx) in state.proxySelectedItems"
+                            <p-tag v-for="(item, idx) in props.selectedItems"
                                    :key="item.name"
                                    class="selected-tag"
                                    @delete="handleTagDelete(item, idx)"
@@ -157,7 +152,7 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
                 </div>
             </slot>
             <div class="extra-button-wrapper">
-                <span v-if="props.showDeleteAllButton && state.proxySelectedItems.length > 0"
+                <span v-if="props.showDeleteAllButton && props.selectedItems.length > 0"
                       class="delete-all-button"
                       @click.stop="handleClickDeleteAll"
                 >

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/components/dropdown-button.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/components/dropdown-button.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { toRef } from 'vue';
+import { reactive, toRef } from 'vue';
 
 import PBadge from '@/data-display/badge/PBadge.vue';
 import PTag from '@/data-display/tags/PTag.vue';
 import PI from '@/foundation/icons/PI.vue';
+import { useProxyValue } from '@/hooks';
 import {
     useSelectDropdownButtonDisplay,
 } from '@/inputs/dropdown/select-dropdown/composables/select-dropdown-button-display';
@@ -45,10 +46,15 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 /* event emits */
-const emit = defineEmits<{(e: 'click-delete', item?: SelectDropdownMenuItem, idx?: number): void;
+const emit = defineEmits<{(e: 'update:selectedItems', selected: SelectDropdownMenuItem[]|string|number): void;
+    (e: 'click-delete', item?: SelectDropdownMenuItem, idx?: number): void;
     (e: 'click-dropdown-button'): void;
     (e: 'enter-key'): void;
 }>();
+
+const state = reactive({
+    proxySelectedItems: useProxyValue<SelectDropdownMenuItem[]|string|number>('selectedItems', props, emit),
+});
 
 /* dropdown button display */
 const {
@@ -57,12 +63,12 @@ const {
     displayBadgeValueOnDropdownButton,
 } = useSelectDropdownButtonDisplay({
     multiSelectable: toRef(props, 'multiSelectable'),
-    selected: toRef(props, 'selectedItems'),
+    selected: toRef(state, 'proxySelectedItems'),
     appearanceType: toRef(props, 'appearanceType'),
 });
 
 const handleClickDeleteAll = () => {
-    if (props.selectedItems.length) {
+    if (state.proxySelectedItems) {
         emit('click-delete');
     }
 };
@@ -79,9 +85,9 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
         disabled: props.disabled,
         readonly: props.readonly,
         opened: props.isVisibleMenu,
-        selected: props.selectedItems.length > 0,
+        selected: state.proxySelectedItem,
         'is-fixed-width': props.isFixedWidth,
-        'selection-highlight': props.selectionHighlight && props.selectedItems.length > 0,
+        'selection-highlight': props.selectionHighlight && state.proxySelectedItem,
     }"
     >
         <span v-if="props.styleType === SELECT_DROPDOWN_STYLE_TYPE.ICON_BUTTON"
@@ -108,46 +114,50 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
                   class="show-alert-dot"
             />
             <slot name="input-left-area" />
-            <div class="selection-display-wrapper">
-                <span v-if="displayValueOnDropdownButton === undefined"
-                      class="placeholder"
-                >
-                    {{ props.selectionLabel
-                        ? props.selectionLabel
-                        : props.placeholder || $t('COMPONENT.SELECT_DROPDOWN.SELECT') }}
-                </span>
-                <span v-else
-                      class="selection-wrapper"
-                >
-                    <b v-if="props.selectionLabel">
-                        {{ props.selectionLabel }}:
-                    </b>
-                    <span v-if="displayValueOnDropdownButton"
-                          class="selected-item"
+            <slot name="item"
+                  v-bind="{...props}"
+            >
+                <div class="selection-display-wrapper">
+                    <span v-if="displayValueOnDropdownButton === undefined"
+                          class="placeholder"
                     >
-                        <span class="selected-item-text">{{ displayValueOnDropdownButton }}</span>
-                        <p-badge v-if="displayBadgeValueOnDropdownButton"
-                                 :style-type="props.disabled ? 'gray200' : 'blue200'"
-                                 :badge-type="props.disabled ? 'solid' : 'subtle'"
-                        >
-                            {{ displayBadgeValueOnDropdownButton }}
-                        </p-badge>
+                        {{ props.selectionLabel
+                            ? props.selectionLabel
+                            : props.placeholder || $t('COMPONENT.SELECT_DROPDOWN.SELECT') }}
                     </span>
-                    <div v-else-if="showTagsOnDropdownButton"
-                         class="tags-wrapper"
+                    <span v-else
+                          class="selection-wrapper"
                     >
-                        <p-tag v-for="(item, idx) in props.selectedItems"
-                               :key="item.name"
-                               class="selected-tag"
-                               @delete="handleTagDelete(item, idx)"
+                        <b v-if="props.selectionLabel">
+                            {{ props.selectionLabel }}:
+                        </b>
+                        <span v-if="displayValueOnDropdownButton"
+                              class="selected-item"
                         >
-                            {{ item.label || item.name }}
-                        </p-tag>
-                    </div>
-                </span>
-            </div>
+                            <span class="selected-item-text">{{ displayValueOnDropdownButton }}</span>
+                            <p-badge v-if="displayBadgeValueOnDropdownButton"
+                                     :style-type="props.disabled ? 'gray200' : 'blue200'"
+                                     :badge-type="props.disabled ? 'solid' : 'subtle'"
+                            >
+                                {{ displayBadgeValueOnDropdownButton }}
+                            </p-badge>
+                        </span>
+                        <div v-else-if="showTagsOnDropdownButton"
+                             class="tags-wrapper"
+                        >
+                            <p-tag v-for="(item, idx) in state.proxySelectedItems"
+                                   :key="item.name"
+                                   class="selected-tag"
+                                   @delete="handleTagDelete(item, idx)"
+                            >
+                                {{ item.label || item.name }}
+                            </p-tag>
+                        </div>
+                    </span>
+                </div>
+            </slot>
             <div class="extra-button-wrapper">
-                <span v-if="props.showDeleteAllButton && props.selectedItems.length > 0"
+                <span v-if="props.showDeleteAllButton && state.proxySelectedItems.length > 0"
                       class="delete-all-button"
                       @click.stop="handleClickDeleteAll"
                 >
@@ -398,10 +408,20 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
     &.is-fixed-width {
         .dropdown-button {
             .selection-display-wrapper {
+                @apply truncate;
                 flex: 1;
-                width: calc(100% - 3rem);
                 .placeholder, .selected-item-text {
                     @apply truncate;
+                }
+                .selection-wrapper {
+                    @apply relative;
+                    width: 100%;
+                }
+                .selected-item-text {
+                    @apply absolute;
+                    top: 25%;
+                    left: 0.5rem;
+                    width: calc(100% - 2.5rem);
                 }
             }
         }

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/composables/select-dropdown-button-display.ts
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/composables/select-dropdown-button-display.ts
@@ -5,14 +5,14 @@ import type { SelectDropdownAppearanceType, SelectDropdownMenuItem } from '@/inp
 
 interface UseDropdownButtonDisplay {
     multiSelectable: Ref<boolean|undefined>;
-    selected: Ref<SelectDropdownMenuItem[]>;
+    selected: Ref<SelectDropdownMenuItem[]|string|number>;
     appearanceType: Ref<SelectDropdownAppearanceType|undefined>;
 }
 export const useSelectDropdownButtonDisplay = ({
     multiSelectable, selected, appearanceType,
 }: UseDropdownButtonDisplay) => {
     const displayValueOnDropdownButton = computed(() => {
-        if (multiSelectable.value) {
+        if (multiSelectable.value && Array.isArray(selected.value)) {
             if (appearanceType.value === 'badge') {
                 if (selected.value[0]) return selected.value[0].label || selected.value[0].name;
                 return undefined;
@@ -31,7 +31,7 @@ export const useSelectDropdownButtonDisplay = ({
     });
     const showTagsOnDropdownButton = computed(() => multiSelectable.value && appearanceType.value === 'stack');
     const displayBadgeValueOnDropdownButton = computed(() => {
-        if (multiSelectable.value && appearanceType.value === 'badge') {
+        if (multiSelectable.value && appearanceType.value === 'badge' && Array.isArray(selected.value)) {
             if (selected.value.length > 1) return `+${selected.value.length - 1}`;
             return undefined;
         }

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/story-helper.ts
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/story-helper.ts
@@ -283,6 +283,24 @@ const extraArgTypes: ArgTypes = {
             options: [...Object.values(CONTEXT_MENU_POSITION)],
         },
     },
+    indexMode: {
+        name: 'indexMode',
+        type: { name: 'boolean' },
+        description: 'Whether to `selected` props works with item\'s index or not.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'false',
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
     handler: {
         name: 'handler',
         type: { name: 'function' },

--- a/packages/mirinae/src/navigation/toolbox/PToolbox.vue
+++ b/packages/mirinae/src/navigation/toolbox/PToolbox.vue
@@ -344,6 +344,7 @@ export default defineComponent<ToolboxProps>({
             display: flex;
         }
         .dropdown-list {
+            min-width: 6.5rem;
             .p-dropdown-btn {
                 min-width: 6rem;
             }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
- Revert to Index mode for admin role logic
- Apply proxySelectedItem from dropdown-button 
- minor fixed

### Things to Talk About
