### PR TITLE
fix(collector-create): solve searched-list issue

### DIFF
--- a/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep1.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep1.vue
@@ -2,8 +2,9 @@
     <div ref="containerRef"
          class="create-collector-step-1"
     >
-        <p-search v-model="state.searchValue"
+        <p-search :value.sync="state.searchValue"
                   @search="handleSearch"
+                  @delete="handleDeleteSearchValue"
         />
         <div class="contents-container">
             <step1-search-filter @selectRepository="handleChangeRepository" />
@@ -106,6 +107,7 @@ const state = reactive({
     selectedRepository: '',
     currentPage: 1,
     totalCount: 0,
+    initialLoad: true,
 });
 
 
@@ -147,10 +149,10 @@ const loadMorePlugin = async () => {
     connectObserver();
 };
 
-const handleSearch = async (value) => {
+const handleSearch = async () => {
     disconnectObserver();
-    state.searchValue = value;
     state.pluginList = await getPlugins();
+    state.initialLoad = false;
     connectObserver();
 };
 const handleClickNextStep = (item: RepositoryPluginModel) => {
@@ -159,6 +161,12 @@ const handleClickNextStep = (item: RepositoryPluginModel) => {
 };
 const handleChangeRepository = (value:string) => {
     state.selectedRepository = value;
+};
+
+const handleDeleteSearchValue = () => {
+    state.searchValue = '';
+    if (state.initialLoad) return;
+    handleSearch();
 };
 
 const pluginListContainerRef = ref<HTMLElement|null>(null);
@@ -171,6 +179,7 @@ watch([() => collectorFormState.provider, () => state.selectedRepository], async
     disconnectObserver();
     state.currentPage = 1;
     state.pluginList = await getPlugins();
+    state.initialLoad = true;
     connectObserver();
 }, { immediate: true });
 
@@ -178,6 +187,7 @@ watch([() => collectorFormState.provider, () => state.selectedRepository], async
 onMounted(() => {
     collectorFormStore.$reset();
 });
+
 </script>
 
 <style lang="postcss" scoped>

--- a/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep1.vue
+++ b/apps/web/src/services/asset-inventory/collector/collector-create/modules/CreateCollectorStep1.vue
@@ -107,7 +107,8 @@ const state = reactive({
     selectedRepository: '',
     currentPage: 1,
     totalCount: 0,
-    initialLoad: true,
+    // this state is for preventing duplicated getPlugins call
+    isInitialLoad: true,
 });
 
 
@@ -152,7 +153,9 @@ const loadMorePlugin = async () => {
 const handleSearch = async () => {
     disconnectObserver();
     state.pluginList = await getPlugins();
-    state.initialLoad = false;
+
+    // this is for preventing duplicated getPlugins call
+    if (state.isInitialLoad && state.searchValue) state.isInitialLoad = false;
     connectObserver();
 };
 const handleClickNextStep = (item: RepositoryPluginModel) => {
@@ -165,8 +168,9 @@ const handleChangeRepository = (value:string) => {
 
 const handleDeleteSearchValue = () => {
     state.searchValue = '';
-    if (state.initialLoad) return;
+    if (state.isInitialLoad) return;
     handleSearch();
+    state.isInitialLoad = true;
 };
 
 const pluginListContainerRef = ref<HTMLElement|null>(null);
@@ -179,7 +183,7 @@ watch([() => collectorFormState.provider, () => state.selectedRepository], async
     disconnectObserver();
     state.currentPage = 1;
     state.pluginList = await getPlugins();
-    state.initialLoad = true;
+    state.isInitialLoad = true;
     connectObserver();
 }, { immediate: true });
 

--- a/packages/mirinae/src/inputs/search/search/PSearch.vue
+++ b/packages/mirinae/src/inputs/search/search/PSearch.vue
@@ -7,21 +7,21 @@
              class="input-container"
              :class="{ focused, invalid, disabled }"
         >
-            <p-i v-if="!disableIcon && !focused && !value && !readonly"
+            <p-i v-if="!disableIcon && !focused && !proxyValue && !readonly"
                  class="left-icon"
                  name="ic_search"
                  color="inherit"
             />
             <slot name="left"
-                  v-bind="{ value, placeholder: placeholderText }"
+                  v-bind="{ value: proxyValue, placeholder: placeholderText }"
             />
             <span class="input-wrapper">
                 <slot name="default"
-                      v-bind="{ value, placeholder: placeholderText }"
+                      v-bind="{ value: proxyValue, placeholder: placeholderText }"
                 >
                     <input ref="inputRef"
                            v-bind="$attrs"
-                           :value="value"
+                           :value="proxyValue"
                            :placeholder="placeholderText"
                            :disabled="disabled"
                            :readonly="readonly"
@@ -30,10 +30,10 @@
                 </slot>
             </span>
             <slot name="right"
-                  v-bind="{ value, placeholder: placeholderText }"
+                  v-bind="{ value: proxyValue, placeholder: placeholderText }"
             >
                 <div class="right">
-                    <span v-if="value"
+                    <span v-if="proxyValue"
                           class="delete-btn"
                           @click="handleDelete"
                     >
@@ -239,7 +239,7 @@ export default defineComponent<SearchProps>({
         const inputListeners = {
             ...listeners,
             input(e) {
-                emit('update:value', e.target.value);
+                state.proxyValue = e.target.value;
                 showMenu();
                 filterMenu(e.target.value);
                 makeByPassListeners(listeners, 'input', e.target.value, e);
@@ -278,8 +278,8 @@ export default defineComponent<SearchProps>({
         };
         const handleDelete = () => {
             if (props.disabled) return;
-            emit('delete', props.value);
-            emit('update:value', '');
+            state.proxyValue = '';
+            emit('delete', state.proxyValue);
         };
 
         watch(() => props.isFocused, (isFocused) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
[Quest-733](https://pyengine.atlassian.net/browse/QUEST-733)

- Add `delete` event to `PSearch`.
- ~Prevent duplicated `getPlugins` call case by using `isInitialLoad` state.~
- Solve `PSearch` issue
  - It didin't use internal `proxyValue`, just used `props.value` and emitted `update:value`.
  - So, refactored this, `props.value` => `proxyValue`
- Now, removed `isInitialLoad` that added prev commits.
- By using `keyword` from `PSearch` and not synced `inputValue`, handled duplicated call `getPlugins`. 


New video

https://github.com/cloudforet-io/console/assets/83635051/ed1b567d-5d99-4d70-8b50-22c6572e00dc

