### PR TITLE
fix(dashboard-period): edit 'yearToMonth' dateType & refactor setting current month

### DIFF
--- a/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
+++ b/apps/web/src/services/dashboards/shared/DashboardCustomDateRangeModal.vue
@@ -28,12 +28,12 @@ const emit = defineEmits<{(event: 'update:visible', visible: boolean): void;
 
 const state = reactive({
     proxyVisible: useProxyValue('visible', props, emit),
-    dateType: DATA_TYPE.yearToDate,
+    dateType: DATA_TYPE.yearToMonth,
     invalid: computed(() => !state.selectedDates.length),
     selectedDates: [] as string[],
     dateLimitSetting: computed<DateOption>(() => {
-        const minDate = dayjs.utc().subtract(3, 'year').format('YYYY-MM-DD');
-        const maxDate = dayjs.utc().format('YYYY-MM-DD');
+        const minDate = dayjs.utc().subtract(3, 'year').format('YYYY-MM');
+        const maxDate = dayjs.utc().format('YYYY-MM');
         return { minDate, maxDate };
     }),
 });
@@ -45,14 +45,14 @@ const handleUpdateSelectedDates = (selectedDates: string[]) => {
     if (!selectedDates.length) return;
     const originDates = state.selectedDates;
 
-    if (dayjs.utc(originDates[0]).isSame(dayjs.utc(selectedDates[0]), 'day')) return;
+    if (dayjs.utc(originDates[0]).isSame(dayjs.utc(selectedDates[0]), 'month')) return;
     state.selectedDates = selectedDates;
 };
 const handleConfirm = () => {
     state.proxyVisible = false;
     const period: Period = {};
-    period.start = dayjs.utc(state.selectedDates[0]).format('YYYY-MM-01');
-    period.end = dayjs.utc(state.selectedDates[0]).endOf('month').format('YYYY-MM-DD');
+    period.start = dayjs.utc(state.selectedDates[0]).format('YYYY-MM');
+    period.end = dayjs.utc(state.selectedDates[0]).endOf('month').format('YYYY-MM');
     emit('confirm', period);
 };
 
@@ -61,7 +61,7 @@ watch(() => props.visible, (visible) => {
         if (props.selectedDateRange?.start) {
             state.selectedDates = [props.selectedDateRange?.start];
         } else {
-            state.selectedDates = [];
+            state.selectedDates = [dayjs.utc().format('YYYY-MM')];
         }
     } else {
         state.selectedDates = [];

--- a/apps/web/src/services/dashboards/shared/dashboard-toolset/DashboardDateDropdown.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-toolset/DashboardDateDropdown.vue
@@ -83,7 +83,7 @@ export default defineComponent({
                 ];
             }),
             selectedMonthLabel: computed(() => {
-                if (state.monthMenuItems[state.selectedMonthMenuIndex]?.name === 'custom') {
+                if (state.monthMenuItems[state.selectedMonthMenuIndex]?.name === 'custom' && (state.selectedDateRange?.start || state.selectedDateRange?.end)) {
                     return i18nDayjs.value.utc(dayjs.utc(state.selectedDateRange?.start).format('YYYY-MM')).format('MMMM YYYY');
                 }
                 return state.monthMenuItems[state.selectedMonthMenuIndex]?.label;
@@ -100,7 +100,6 @@ export default defineComponent({
         };
 
         const handleSelectMonthMenuItem = (selectedIndex: number) => {
-            state.selectedMonthMenuIndex = selectedIndex;
             if (state.monthMenuItems[selectedIndex].name === 'current') {
                 state.selectedDateRange = { start: undefined, end: undefined };
                 emit('update:date-range', state.selectedDateRange);
@@ -109,26 +108,27 @@ export default defineComponent({
                 setSelectedDateRange(state.monthMenuItems[selectedIndex].name, state.monthMenuItems[selectedIndex].name);
                 emit('update:date-range', state.selectedDateRange);
             }
+
+            const customItemIndex = state.monthMenuItems.findIndex((d) => d.name === 'custom');
+            if (selectedIndex !== customItemIndex) state.selectedMonthMenuIndex = selectedIndex;
         };
         const handleCustomRangeModalConfirm = (dateRange: DateRange) => {
             const { start, end } = dateRange;
             setSelectedDateRange(start, end);
             emit('update:date-range', state.selectedDateRange);
+            state.selectedMonthMenuIndex = state.monthMenuItems.findIndex((d) => d.name === 'custom');
             state.customRangeModalVisible = false;
         };
 
         const setInitialDateRange = () => {
-            const _current = dayjs.utc();
             const _start = dayjs.utc(props.dateRange?.start);
             const _end = dayjs.utc(props.dateRange?.end);
 
-            // 1. default month => start is (month 'current' + day '1'), end is (month 'current + day 'today')
-            // Index 0 is 'Current' menu index
 
+            // 1. default month => dateRange.start is undefined or dateRange.end is undefined
+            // Index 0 is 'Current' menu index
             if (!props.dateRange?.start
                 || !props.dateRange?.end
-                || (_start.isSame(_current, 'month')
-                && _end.isSame(_current, 'month'))
             ) {
                 return 0;
             }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
[QA - 748](https://pyengine.atlassian.net/browse/QA-748)

- Edit `dateType` to `yearToMonth`.
- Fix current month mis operation case.


https://github.com/cloudforet-io/console/assets/83635051/c905bbc1-64c8-4367-930d-5ecd2a27eb0b

