### PR TITLE
fix(budget-toolbox): add usageRange component as readonly

### DIFF
--- a/apps/web/src/services/cost-explorer/budget/budget-main/modules/budget-toolbox/BudgetToolbox.vue
+++ b/apps/web/src/services/cost-explorer/budget/budget-main/modules/budget-toolbox/BudgetToolbox.vue
@@ -29,6 +29,8 @@ import type { ServiceAccountReferenceMap } from '@/store/modules/reference/servi
 
 import { useQueryTags } from '@/common/composables/query-tags';
 
+import BudgetToolboxUsageRange
+    from '@/services/cost-explorer/budget/budget-main/modules/budget-toolbox/BudgetToolboxUsageRange.vue';
 import type { Period } from '@/services/cost-explorer/type';
 
 
@@ -174,6 +176,8 @@ watch(() => state.sort, (sort) => { emit('update-sort', sort); });
 <template>
     <div class="budget-toolbox">
         <div class="top">
+            <budget-toolbox-usage-range readonly />
+            <p-divider vertical />
             <div class="period-box">
                 <span class="label">{{ $t('BILLING.COST_MANAGEMENT.BUDGET.MAIN.PERIOD') }}</span>
                 <p-select-status v-for="(status, idx) in state.periodList"
@@ -243,6 +247,7 @@ watch(() => state.sort, (sort) => { emit('update-sort', sort); });
             &.vertical {
                 height: 1rem;
             }
+            margin-right: 1rem;
         }
         .period-box {
             @apply relative inline-flex gap-4 items-center;

--- a/apps/web/src/services/cost-explorer/budget/budget-main/modules/budget-toolbox/BudgetToolboxUsageRange.vue
+++ b/apps/web/src/services/cost-explorer/budget/budget-main/modules/budget-toolbox/BudgetToolboxUsageRange.vue
@@ -16,6 +16,13 @@ type UsageRange = typeof USAGE_RANGE[keyof typeof USAGE_RANGE];
 
 type SelectedMap = Partial<Record<UsageRange, boolean>>;
 
+interface Props {
+    readonly: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    readonly: false,
+});
 
 const emit = defineEmits<{(e: 'update', range: BudgetUsageRange): void; }>();
 
@@ -69,6 +76,7 @@ const state = reactive({
 });
 
 const handleClick = (name: UsageRange) => {
+    if (props.readonly) return;
     const index = state.selected.findIndex((d) => d === name);
     if (index !== -1) state.selected.splice(index, 1);
     else state.selected.push(name);
@@ -82,6 +90,7 @@ const handleClick = (name: UsageRange) => {
         <div v-for="({name, label, color}) in state.items"
              :key="name"
              class="range"
+             :style="{ cursor: props.readonly ? 'unset' : 'pointer' }"
              :class="{disabled: !state.selectedMap[name]}"
              @click="handleClick(name)"
         >


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA
![image](https://github.com/cloudforet-io/console/assets/50662170/13691366-836c-4fb2-999a-c3c2b6e69e2c)


### Things to Talk About
