### PR TITLE
fix: reset filters to origin data not `{}`

### DIFF
--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
@@ -11,6 +11,7 @@ import type {
     AutocompleteHandler, FilterableDropdownMenuItem,
 } from '@spaceone/design-system/types/inputs/dropdown/filterable-dropdown/type';
 
+import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancallable-fetcher';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
@@ -120,8 +121,15 @@ const handleDisabledFilters = (all?: boolean, disabledFilter?: string) => {
     }
 };
 const handleClickResetFilters = () => {
+    const _originConsoleFilters: ConsoleFilter[]|undefined = costAnalysisPageStore.selectedQuerySet?.options?.filters;
+    const _originFilters: Record<string, string[]> = {};
+    if (_originConsoleFilters?.length) {
+        _originConsoleFilters.forEach((d) => {
+            _originFilters[d.k as string] = d.v as string[];
+        });
+    }
     costAnalysisPageStore.$patch((_state) => {
-        _state.filters = {};
+        _state.filters = _originFilters;
     });
 };
 

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -72,6 +72,7 @@ const state = reactive({
     ])),
     selectedQuerySetId: computed(() => costAnalysisPageStore.selectedQueryId),
     isManagedQuerySet: computed(() => managedCostQuerySetIdList.includes(state.selectedQuerySetId)),
+    isDynamicQuerySet: computed<boolean>(() => costAnalysisPageStore.selectedQueryId === DYNAMIC_COST_QUERY_SET_PARAMS),
     filtersPopoverVisible: false,
     granularity: undefined as Granularity|undefined,
     isPeriodInvalid: computed<boolean>(() => costAnalysisPageStore.isPeriodInvalid),
@@ -209,7 +210,7 @@ watch(() => costAnalysisPageStore.selectedQueryId, (updatedQueryId) => {
                 </p-popover>
             </div>
             <div class="right-part">
-                <template v-if="!state.isManagedQuerySet">
+                <template v-if="!state.isManagedQuerySet && !state.isDynamicQuerySet">
                     <p-button class="save-button"
                               style-type="tertiary"
                               icon-left="ic_disk-filled"

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -193,9 +193,9 @@ watch(() => costAnalysisPageStore.selectedQueryId, (updatedQueryId) => {
                               @click="handleClickFilter"
                     >
                         {{ $t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.FILTERS') }}
-                        <p-badge v-if="!state.filtersPopoverVisible && state.selectedFiltersCount"
+                        <p-badge v-if="state.selectedFiltersCount"
                                  badge-type="subtle"
-                                 style-type="gray200"
+                                 :style-type="state.filtersPopoverVisible ? 'gray100' : 'gray200'"
                                  class="filters-badge"
                         >
                             {{ state.selectedFiltersCount }}

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -111,6 +111,7 @@ const {
     menu: state.saveDropdownMenuItems,
 });
 onClickOutside(containerRef, hideContextMenu);
+onClickOutside(contextMenuRef, hideContextMenu);
 
 /* event */
 const handleSelectGranularity = async (granularity: Granularity) => {
@@ -292,7 +293,7 @@ watch(() => costAnalysisPageStore.selectedQueryId, (updatedQueryId) => {
                 top: 2.125rem;
                 right: 0;
                 margin-top: -0.15rem;
-                z-index: 10;
+                z-index: 100;
                 .p-context-menu-item {
                     min-width: 10rem;
                 }

--- a/apps/web/src/services/cost-explorer/lib/helper.ts
+++ b/apps/web/src/services/cost-explorer/lib/helper.ts
@@ -57,7 +57,7 @@ export const getDataTableCostFields = (granularity: Granularity, period: Period,
     const costFields: DataTableFieldType[] = [];
     if (!hasGroupBy) {
         costFields.push({
-            name: 'totalCost', label: ' ', textAlign: 'right',
+            name: 'totalCost', label: ' ',
         });
     }
     const dateFields = getDataTableDateFields(granularity, period);

--- a/apps/web/src/services/cost-explorer/store/cost-analysis-page-store.ts
+++ b/apps/web/src/services/cost-explorer/store/cost-analysis-page-store.ts
@@ -38,7 +38,7 @@ const allReferenceStore = useAllReferenceStore();
 const costQuerySetStore = () => useCostQuerySetStore();
 const costQuerySetState = () => costQuerySetStore().$state;
 
-const getRefinedFilters = (consoleFilters?: ConsoleFilter[]): Record<string, string[]> => {
+const getRefinedFilters = (consoleFilters?: ConsoleFilter[]): CostAnalysisPageState['filters'] => {
     if (!consoleFilters || isEmpty(consoleFilters)) return {};
     const result: Record<string, string[]> = {};
     consoleFilters.forEach((d) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA
