### PR TITLE
fix(cost-analysis-favorite): handle managed-cost-query-set favorite case

### DIFF
--- a/apps/web/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBFavorite.vue
+++ b/apps/web/src/common/modules/navigations/gnb/modules/gnb-recent-favorite/modules/GNBFavorite.vue
@@ -89,6 +89,8 @@ import { FAVORITE_TYPE } from '@/store/modules/favorite/type';
 import type { CloudServiceTypeReferenceMap } from '@/store/modules/reference/cloud-service-type/type';
 import type { ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceMap } from '@/store/modules/reference/project/type';
+import { useAllReferenceStore } from '@/store/reference/all-reference-store';
+import type { CostDataSourceReferenceMap } from '@/store/reference/cost-data-source-reference-store';
 
 import { isUserAccessibleToMenu } from '@/lib/access-control';
 import {
@@ -132,6 +134,9 @@ export default {
     },
     props: {},
     setup(props, { emit }: SetupContext) {
+        const allReferenceStore = useAllReferenceStore();
+
+
         const state = reactive({
             loading: true,
             showAll: false,
@@ -224,7 +229,7 @@ export default {
             )),
             favoriteCostAnalysisItems: computed<FavoriteItem[]>(() => {
                 const isUserAccessible = isUserAccessibleToMenu(MENU_ID.COST_EXPLORER_COST_ANALYSIS, store.getters['user/pagePermissionList']);
-                return isUserAccessible ? convertCostAnalysisConfigToReferenceData(store.state.favorite.costAnalysisItems, state.costQuerySets) : [];
+                return isUserAccessible ? convertCostAnalysisConfigToReferenceData(store.state.favorite.costAnalysisItems, state.costQuerySets, state.dataSourceMap) : [];
             }),
             favoriteDashboardItems: computed<FavoriteItem[]>(() => {
                 const isUserAccessibleToDashboards = isUserAccessibleToMenu(MENU_ID.DASHBOARDS, store.getters['user/pagePermissionList']);
@@ -255,6 +260,7 @@ export default {
                 const favoriteProjectGroupItems = convertProjectGroupConfigToReferenceData(store.state.favorite.projectGroupItems, state.projectGroups);
                 return [...favoriteProjectGroupItems, ...favoriteProjectItems];
             }),
+            dataSourceMap: computed<CostDataSourceReferenceMap>(() => allReferenceStore.getters.allReferenceTypeInfo.costDataSource.referenceMap),
         });
 
         /* Util */

--- a/apps/web/src/lib/helper/config-data-helper.ts
+++ b/apps/web/src/lib/helper/config-data-helper.ts
@@ -150,7 +150,7 @@ export const convertCostAnalysisConfigToReferenceData = (config: ConfigData[]|nu
             const [, dataSourceId, costQuerySetId] = d.itemId.split('_');
             results.push({
                 ...d,
-                name: costQuerySetId,
+                name: d.itemId,
                 label: costQuerySetId,
                 updatedAt: d.updatedAt,
                 icon: 'ic_service_cost-explorer',

--- a/apps/web/src/lib/helper/config-data-helper.ts
+++ b/apps/web/src/lib/helper/config-data-helper.ts
@@ -7,6 +7,7 @@ import type { RecentConfig, RecentItem } from '@/store/modules/recent/type';
 import type { CloudServiceTypeReferenceMap } from '@/store/modules/reference/cloud-service-type/type';
 import type { ProjectGroupReferenceItem, ProjectGroupReferenceMap } from '@/store/modules/reference/project-group/type';
 import type { ProjectReferenceItem, ProjectReferenceMap } from '@/store/modules/reference/project/type';
+import type { CostDataSourceReferenceMap } from '@/store/reference/cost-data-source-reference-store';
 
 import { getAllSuggestionMenuList } from '@/lib/helper/menu-suggestion-helper';
 
@@ -126,7 +127,7 @@ export const convertCloudServiceConfigToReferenceData = (config: ConfigData[]|nu
     return results;
 };
 
-export const convertCostAnalysisConfigToReferenceData = (config: ConfigData[]|null, costQuerySetList: CostQuerySetModel[]): ReferenceData[] => {
+export const convertCostAnalysisConfigToReferenceData = (config: ConfigData[]|null, costQuerySetList: CostQuerySetModel[], dataSourceMap: CostDataSourceReferenceMap): ReferenceData[] => {
     const results: ReferenceData[] = [];
     if (!config) return results;
 
@@ -140,6 +141,24 @@ export const convertCostAnalysisConfigToReferenceData = (config: ConfigData[]|nu
                 updatedAt: d.updatedAt,
                 icon: 'ic_service_cost-explorer',
                 dataSourceId: resource.data_source_id,
+                parents: [{
+                    name: resource.data_source_id,
+                    label: dataSourceMap[resource.data_source_id].label,
+                }],
+            });
+        } else if (d.itemId.startsWith('managed_')) { // managed cost query set
+            const [, dataSourceId, costQuerySetId] = d.itemId.split('_');
+            results.push({
+                ...d,
+                name: costQuerySetId,
+                label: costQuerySetId,
+                updatedAt: d.updatedAt,
+                icon: 'ic_service_cost-explorer',
+                dataSourceId,
+                parents: [{
+                    name: dataSourceId,
+                    label: dataSourceMap[dataSourceId].label,
+                }],
             });
         }
     });

--- a/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerLNB.vue
@@ -33,7 +33,6 @@ import { MENU_ITEM_TYPE } from '@/common/modules/navigations/lnb/type';
 
 import { gray } from '@/styles/colors';
 
-import { managedCostQuerySetIdList } from '@/services/cost-explorer/cost-analysis/config';
 import RelocateDashboardModal from '@/services/cost-explorer/modules/RelocateDashboardModal.vue';
 import RelocateDashboardNotification from '@/services/cost-explorer/modules/RelocateDashboardNotification.vue';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
@@ -91,7 +90,7 @@ const state = reactive({
             type: 'item',
             id: d.cost_query_set_id,
             label: d.name,
-            icon: managedCostQuerySetIdList.includes(d.cost_query_set_id) ? {
+            icon: costQuerySetStore.managedCostQuerySets.map((item) => item.cost_query_set_id).includes(d.cost_query_set_id) ? {
                 name: 'ic_main-filled',
                 color: gray[500],
             } : undefined,
@@ -200,7 +199,7 @@ const handleSelectDataSource = (selected: string) => {
         name: COST_EXPLORER_ROUTE.COST_ANALYSIS.QUERY_SET._NAME,
         params: {
             dataSourceId: selected,
-            costQuerySetId: managedCostQuerySetIdList[0],
+            costQuerySetId: costQuerySetStore.managedCostQuerySets[0].cost_query_set_id,
         },
     }).catch(() => {});
 };

--- a/apps/web/src/services/cost-explorer/cost-analysis/config.ts
+++ b/apps/web/src/services/cost-explorer/cost-analysis/config.ts
@@ -3,22 +3,16 @@ import type { CostQuerySetModel } from '@/services/cost-explorer/type';
 
 export const DYNAMIC_COST_QUERY_SET_PARAMS = 'dynamic';
 
-export const MANAGED_COST_QUERY_SET_IDS = {
+export const ORIGIN_MANAGED_COST_QUERY_SET_IDS = {
     MONTHLY_PROJECT: 'Monthly cost by project',
     MONTHLY_PRODUCT: 'Monthly cost by product',
     DAILY_PRODUCT: 'Daily cost by product',
 } as const;
 
-export const managedCostQuerySetIdList: string[] = [
-    MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
-    MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
-    MANAGED_COST_QUERY_SET_IDS.DAILY_PRODUCT,
-];
-
-export const managedCostQuerySets: CostQuerySetModel[] = [
+export const originManagedCostQuerySets: CostQuerySetModel[] = [
     {
-        cost_query_set_id: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
-        name: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
+        cost_query_set_id: ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
+        name: ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
         options: {
             group_by: [GROUP_BY.PROJECT],
             granularity: GRANULARITY.MONTHLY,
@@ -35,8 +29,8 @@ export const managedCostQuerySets: CostQuerySetModel[] = [
         },
     },
     {
-        cost_query_set_id: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
-        name: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
+        cost_query_set_id: ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
+        name: ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PRODUCT,
         options: {
             group_by: [GROUP_BY.PRODUCT],
             granularity: GRANULARITY.MONTHLY,
@@ -53,8 +47,8 @@ export const managedCostQuerySets: CostQuerySetModel[] = [
         },
     },
     {
-        cost_query_set_id: MANAGED_COST_QUERY_SET_IDS.DAILY_PRODUCT,
-        name: MANAGED_COST_QUERY_SET_IDS.DAILY_PRODUCT,
+        cost_query_set_id: ORIGIN_MANAGED_COST_QUERY_SET_IDS.DAILY_PRODUCT,
+        name: ORIGIN_MANAGED_COST_QUERY_SET_IDS.DAILY_PRODUCT,
         options: {
             group_by: [GROUP_BY.PRODUCT],
             granularity: GRANULARITY.DAILY,

--- a/apps/web/src/services/cost-explorer/cost-analysis/config.ts
+++ b/apps/web/src/services/cost-explorer/cost-analysis/config.ts
@@ -9,7 +9,8 @@ export const ORIGIN_MANAGED_COST_QUERY_SET_IDS = {
     DAILY_PRODUCT: 'Daily cost by product',
 } as const;
 
-export const originManagedCostQuerySets: CostQuerySetModel[] = [
+// This is origin managed cost query set list. For actual use, 'cost_query_set_id' must be converted with 'dataSourceId'.
+export const originManagedCostQuerySets: Omit<CostQuerySetModel, 'data_source_id'>[] = [
     {
         cost_query_set_id: ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
         name: ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisHeader.vue
@@ -23,7 +23,7 @@ import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteB
 import { gray } from '@/styles/colors';
 
 import {
-    DYNAMIC_COST_QUERY_SET_PARAMS, managedCostQuerySetIdList,
+    DYNAMIC_COST_QUERY_SET_PARAMS,
 } from '@/services/cost-explorer/cost-analysis/config';
 import { REQUEST_TYPE } from '@/services/cost-explorer/cost-analysis/lib/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
@@ -39,7 +39,10 @@ const state = reactive({
     defaultTitle: computed<TranslateResult>(() => i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.COST_ANALYSIS')),
     title: computed<string>(() => costAnalysisPageStore.selectedQuerySet?.name ?? state.defaultTitle),
     dataSourceImage: computed(() => costAnalysisPageStore.dataSourceImageUrl),
-    isManagedCostQuerySet: computed<boolean>(() => (costAnalysisPageStore.selectedQueryId ? managedCostQuerySetIdList.includes(costAnalysisPageStore.selectedQueryId) : false)),
+    managedCostQuerySetList: computed(() => costAnalysisPageStore.managedCostQuerySetList),
+    isManagedCostQuerySet: computed<boolean>(() => (costAnalysisPageStore.selectedQueryId
+        ? state.managedCostQuerySetList.some((item) => item.cost_query_set_id === costAnalysisPageStore.selectedQueryId)
+        : false)),
     itemIdForDeleteQuery: '',
     selectedQuerySetId: undefined as string|undefined,
     queryFormModalVisible: false,
@@ -87,7 +90,7 @@ const handleDeleteQueryConfirm = async () => {
                                     width="2rem"
                                     height="2rem"
                         />
-                        <p-i v-if="managedCostQuerySetIdList.includes(state.title || '')"
+                        <p-i v-if="state.managedCostQuerySetList.some((item) => item.name === (state.title || ''))"
                              name="ic_main-filled"
                              width="1rem"
                              height="1rem"

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -21,7 +21,6 @@ import ErrorHandler from '@/common/composables/error/errorHandler';
 
 import {
     DYNAMIC_COST_QUERY_SET_PARAMS,
-    managedCostQuerySetIdList,
 } from '@/services/cost-explorer/cost-analysis/config';
 import { REQUEST_TYPE } from '@/services/cost-explorer/cost-analysis/lib/config';
 import CostAnalysisFiltersPopper from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue';
@@ -71,7 +70,7 @@ const state = reactive({
         },
     ])),
     selectedQuerySetId: computed(() => costAnalysisPageStore.selectedQueryId),
-    isManagedQuerySet: computed(() => managedCostQuerySetIdList.includes(state.selectedQuerySetId)),
+    isManagedQuerySet: computed(() => costAnalysisPageStore.managedCostQuerySetList.map((d) => d.cost_query_set_id).includes(state.selectedQuerySetId)),
     isDynamicQuerySet: computed<boolean>(() => costAnalysisPageStore.selectedQueryId === DYNAMIC_COST_QUERY_SET_PARAMS),
     filtersPopoverVisible: false,
     granularity: undefined as Granularity|undefined,

--- a/apps/web/src/services/cost-explorer/routes.ts
+++ b/apps/web/src/services/cost-explorer/routes.ts
@@ -43,7 +43,7 @@ const costExplorerRoutes: RouteConfig = {
                                 name: COST_EXPLORER_ROUTE.COST_ANALYSIS.QUERY_SET._NAME,
                                 params: {
                                     dataSourceId: results[0].data_source_id,
-                                    costQuerySetId: `managed-${results[0].data_source_id}-${ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT}`,
+                                    costQuerySetId: `managed_${results[0].data_source_id}_${ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT}`,
                                 },
                             });
                         }

--- a/apps/web/src/services/cost-explorer/routes.ts
+++ b/apps/web/src/services/cost-explorer/routes.ts
@@ -8,7 +8,7 @@ import { ACCESS_LEVEL } from '@/lib/access-control/config';
 import { getRedirectRouteByPagePermission } from '@/lib/access-control/redirect-route-helper';
 import { MENU_ID } from '@/lib/menu/config';
 
-import { DYNAMIC_COST_QUERY_SET_PARAMS, MANAGED_COST_QUERY_SET_IDS, managedCostQuerySetIdList } from '@/services/cost-explorer/cost-analysis/config';
+import { DYNAMIC_COST_QUERY_SET_PARAMS, ORIGIN_MANAGED_COST_QUERY_SET_IDS } from '@/services/cost-explorer/cost-analysis/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 
 const CostExplorerContainer = () => import('@/services/cost-explorer/CostExplorerContainer.vue');
@@ -43,7 +43,7 @@ const costExplorerRoutes: RouteConfig = {
                                 name: COST_EXPLORER_ROUTE.COST_ANALYSIS.QUERY_SET._NAME,
                                 params: {
                                     dataSourceId: results[0].data_source_id,
-                                    costQuerySetId: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
+                                    costQuerySetId: `managed-${results[0].data_source_id}-${ORIGIN_MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT}`,
                                 },
                             });
                         }
@@ -55,7 +55,7 @@ const costExplorerRoutes: RouteConfig = {
                     meta: {
                         lnbVisible: true,
                         label: ({ params }) => (params.costQuerySetId === DYNAMIC_COST_QUERY_SET_PARAMS ? undefined : params.costQuerySetId),
-                        copiable: ({ params }) => ![...managedCostQuerySetIdList, DYNAMIC_COST_QUERY_SET_PARAMS].includes(params.costQuerySetId),
+                        copiable: ({ params }) => ![DYNAMIC_COST_QUERY_SET_PARAMS].includes(params.costQuerySetId),
                     },
                     props: true,
                     component: CostAnalysisPage as any,

--- a/apps/web/src/services/cost-explorer/store/cost-analysis-page-store.ts
+++ b/apps/web/src/services/cost-explorer/store/cost-analysis-page-store.ts
@@ -62,6 +62,7 @@ export const useCostAnalysisPageStore = defineStore('cost-analysis-page', {
         costQueryList: () => costQuerySetState().costQuerySetList,
         selectedQuerySet: () => costQuerySetStore().selectedQuerySet,
         selectedDataSourceId: () => costQuerySetState().selectedDataSourceId,
+        managedCostQuerySetList: () => costQuerySetStore().managedCostQuerySets,
         currency: (): Currency => {
             if (costQuerySetState().selectedDataSourceId) {
                 const targetDataSource = allReferenceStore.getters.costDataSource[costQuerySetState().selectedDataSourceId ?? ''];

--- a/apps/web/src/services/cost-explorer/store/cost-query-set-store.ts
+++ b/apps/web/src/services/cost-explorer/store/cost-query-set-store.ts
@@ -33,7 +33,7 @@ export const useCostQuerySetStore = defineStore('cost-query-set', {
             if (!state.selectedDataSourceId) return [];
             return originManagedCostQuerySets.map((item) => ({
                 ...item,
-                // manged cost query set id: managed-<data source id>-<cost query set id>
+                // manged cost query set id: managed_<data source id>_<cost query set id>
                 cost_query_set_id: `managed_${state.selectedDataSourceId}_${item.cost_query_set_id}`,
                 data_source_id: state.selectedDataSourceId,
             })) as CostQuerySetModel[];

--- a/apps/web/src/services/cost-explorer/store/cost-query-set-store.ts
+++ b/apps/web/src/services/cost-explorer/store/cost-query-set-store.ts
@@ -34,8 +34,9 @@ export const useCostQuerySetStore = defineStore('cost-query-set', {
             return originManagedCostQuerySets.map((item) => ({
                 ...item,
                 // manged cost query set id: managed-<data source id>-<cost query set id>
-                cost_query_set_id: `managed-${state.selectedDataSourceId}-${item.cost_query_set_id}`,
-            }));
+                cost_query_set_id: `managed_${state.selectedDataSourceId}_${item.cost_query_set_id}`,
+                data_source_id: state.selectedDataSourceId,
+            })) as CostQuerySetModel[];
         },
     },
     actions: {

--- a/apps/web/src/services/cost-explorer/type.ts
+++ b/apps/web/src/services/cost-explorer/type.ts
@@ -35,7 +35,7 @@ export interface CostQuerySetOptionForPeriod {
 
 export interface CostQuerySetModel {
     cost_query_set_id: string;
-    data_source_id?: string; // This isn't using in cost-analysis now. Just used in GNB favorite.
+    data_source_id: string; // This isn't using in cost-analysis now. Just used in GNB favorite.
     name: string;
     options?: CostQuerySetOption;
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
**Problem** 
- `manged-cost-query-set` didn't have unique `cost_query_set_id`. But each dataSource have `managed-cost-query-set`.
- It still works, but in favorite case, not.

**Solution**
- Every time dataSource changed, `cost-query-set-store` convert manged `cost_query_set_id` to new `cost_query_set_id` with dataSource like `managed_<data_source_id>_<cost_query_set_id>`.
- When we convert favorite config in `GNBFavorite`, we can distinguish that this is managed item by prefix `managed_`, and we can use both `<data_source_id>` and `<cost_query_set_id>`.

![image](https://github.com/cloudforet-io/console/assets/83635051/3c41709e-ba5a-4150-b0a5-59a038d025cd)


Please see order by commits. 
