### PR TITLE
feat: init form data with reference handler at PJsonSchemaForm - added default_path to reference

### DIFF
--- a/apps/web/src/services/dashboards/widgets/_configs/widget-schema-config.ts
+++ b/apps/web/src/services/dashboards/widgets/_configs/widget-schema-config.ts
@@ -89,5 +89,6 @@ export const COST_DATA_SOURCE_SCHEMA = {
     type: 'string',
     reference: {
         resource_type: 'cost_analysis.DataSource',
+        default_path: 0,
     },
 };

--- a/packages/mirinae/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
@@ -147,6 +147,7 @@ import {
 
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
+import { isEqual } from 'lodash';
 
 import PMarkdown from '@/data-display/markdown/PMarkdown.vue';
 import PFilterableDropdown from '@/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue';
@@ -334,11 +335,15 @@ export default defineComponent<JsonSchemaFormProps>({
         })();
 
         /* Watchers */
-        watch(() => props.schema, async () => {
-            if (props.resetOnSchemaChange) await reset();
-        });
-        watch(() => props.formData, async (formData) => {
-            if (formData === state.refinedFormData) return;
+        watch([() => props.schema, () => props.formData], async ([schema, formData], [prevSchema, prevFormData]) => {
+            if (isEqual(schema, prevSchema)) {
+                if (isEqual(formData, prevFormData)) return;
+                if (isEqual(formData, state.refinedFormData)) return;
+            } else if (props.resetOnSchemaChange || state.isJsonInputMode) {
+                await reset();
+                return;
+            }
+
             await initFormData();
         });
         watch(() => state.refinedFormData, (refinedFormData) => {

--- a/packages/mirinae/src/inputs/forms/json-schema-form/helpers/form-data-refine-helper.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/helpers/form-data-refine-helper.ts
@@ -26,7 +26,7 @@ export const refineValueByProperty = (schema: JsonSchema, val?: any): any => {
     if (type === 'array') return refineArrayTypeValue(schema, val);
     if (NUMERIC_TYPES.includes(type)) return refineNumberTypeValue(val);
     if (type === 'string') {
-        // PSelectDropdown case (string, single select)
+        // PFilterableDropdown, PSelectDropdown case (string, single select)
         if (Array.isArray(val)) {
             return val[0]?.name;
         } if (typeof val === 'object') {
@@ -49,21 +49,21 @@ export const refineObjectByProperties = (schema: JsonSchema, formData: object): 
     return result;
 };
 
-export const initRefinedFormData = (schema?: JsonSchema, formData?: any, isRoot?: boolean): any => {
-    if (typeof formData !== 'object' || Array.isArray(formData)) {
+export const initRefinedFormData = (schema?: JsonSchema, rawFormData?: any, isRoot?: boolean): any => {
+    if (typeof rawFormData !== 'object' || Array.isArray(rawFormData)) {
         if (isRoot) {
             console.error(new Error('[JsonSchemaForm] Only object is available for formData prop'));
             return {};
         }
-        return formData;
+        return rawFormData;
     }
 
     const { properties } = schema ?? {};
     const result = {};
-    if (!properties) return formData;
+    if (!properties) return rawFormData;
     Object.keys(properties).forEach((key) => {
         const property = properties[key];
-        result[key] = refineValueByProperty(property, formData?.[key] ?? property.default);
+        result[key] = refineValueByProperty(property, rawFormData?.[key] ?? property.default);
     });
     return result;
 };

--- a/packages/mirinae/src/inputs/forms/json-schema-form/helpers/json-input-helper.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/helpers/json-input-helper.ts
@@ -1,10 +1,19 @@
-import { initFormDataWithSchema } from '@/inputs/forms/json-schema-form/helpers/raw-form-data-helper';
 import type { JsonSchema } from '@/inputs/forms/json-schema-form/type';
 
+const initJsonDataObjectWithSchema = (schema?: JsonSchema, formData?: object): object => {
+    const { properties } = schema ?? {};
+    if (!properties) return {};
+    const result = {};
+    Object.keys(properties).forEach((key) => {
+        const property = properties[key];
+        result[key] = formData?.[key] ?? property.default ?? undefined;
+    });
+    return result;
+};
 export const initJsonInputDataWithSchema = (schema?: JsonSchema, formData?: object): string|undefined => {
     if (formData === null || formData === undefined) return undefined;
     try {
-        return JSON.stringify(initFormDataWithSchema(schema, formData), undefined, 2);
+        return JSON.stringify(initJsonDataObjectWithSchema(schema, formData), undefined, 2);
     } catch (e) {
         return undefined;
     }

--- a/packages/mirinae/src/inputs/forms/json-schema-form/mock.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/mock.ts
@@ -180,7 +180,7 @@ export const getMenuItems = (min = 10, max = 30): FilterableDropdownMenuItem[] =
 
 export const getReferenceHandler = (pageSize = 10): ReferenceHandler => {
     const allItems: FilterableDropdownMenuItem[] = getMenuItems(pageSize * 3, pageSize * 4);
-    return async (inputText, schema, pageStart, pageLimit) => {
+    return async (inputText, { pageStart, pageSize: pageLimit }) => {
         const allResults = await new Promise<FilterableDropdownMenuItem[]>((resolve) => {
             setTimeout(() => {
                 let filtered;

--- a/packages/mirinae/src/inputs/forms/json-schema-form/type.ts
+++ b/packages/mirinae/src/inputs/forms/json-schema-form/type.ts
@@ -12,6 +12,7 @@ export type ComponentName = typeof COMPONENTS[number];
 interface Reference {
     resource_type: string; // 'identity.ServiceAccount'
     reference_key?: string; // 'service_account_id' (auto-complete/resource api, must not given) // 'project_id' (auto-complete/distinct api, must given)
+    default_path?: number // if it is given, it will be used as the path to get the default value from the result array
 }
 export interface JsonSchema {
     type?: string;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

Many things are very tightly connected, so it was impossible to split into several PRs. 
Instead, I split into several commits, so **Please review in order by commits**.


### Things to Talk About
