### PR TITLE
fix(cost-filter): fix filterable-dropdown keyword issue

### DIFF
--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
@@ -84,9 +84,9 @@ const menuHandler = (groupBy: string): AutocompleteHandler => async (inputValue:
     const refinedMenuItems = getRefinedMenuItems(groupBy, inputValue, results?.map((d) => ({ name: d.key, label: d.name })));
     return { results: refinedMenuItems };
 };
-const getRefinedMenuItems = (groupBy: string, inputValue: string, results?: Array<{name: string; label: string}>): MenuItem[] => {
+const getRefinedMenuItems = (groupBy: string, inputValue?: string, results?: Array<{name: string; label: string}>): MenuItem[] => {
     if (!results) return [];
-    return results.map((d) => {
+    const refinedResults = results.map((d) => {
         if (groupBy === GROUP_BY.PROJECT) {
             return { name: d.name, label: storeState.projects[d.name].label };
         } if (groupBy === GROUP_BY.PROJECT_GROUP) {
@@ -97,7 +97,9 @@ const getRefinedMenuItems = (groupBy: string, inputValue: string, results?: Arra
             return { name: d.name, label: storeState.serviceAccounts[d.name].label };
         }
         return { name: d.name, label: d.label };
-    }).filter((d) => d.label.toLowerCase().includes(inputValue.toLowerCase()));
+    });
+    if (!inputValue) return refinedResults;
+    return refinedResults.filter((d) => d.label.toLowerCase().includes(inputValue.toLowerCase()));
 };
 
 const handleUpdateFiltersDropdown = (groupBy: string, selectedItems: FilterableDropdownMenuItem[]) => {

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
@@ -78,10 +78,11 @@ const menuHandler = (groupBy: string): AutocompleteHandler => async (inputValue:
     if (!groupBy) return { results: [] };
 
     state.loading = true;
-    const results = await getResources('', groupBy);
+    const results = await getResources('', groupBy); // Get all resources without inputValue.
     state.loading = false;
 
     const refinedMenuItems = getRefinedMenuItems(groupBy, results?.map((d) => ({ name: d.key, label: d.name })));
+    // filter by inputValue here.
     const refinedMenuItemsFilteredByInputValue = refinedMenuItems.filter((d) => (d.label as string).toLowerCase().includes(inputValue.toLowerCase()));
     return { results: refinedMenuItemsFilteredByInputValue };
 };

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
@@ -78,7 +78,9 @@ const menuHandler = (groupBy: string): AutocompleteHandler => async (inputValue:
     if (!groupBy) return { results: [] };
 
     state.loading = true;
-    const results = await getResources('', groupBy); // Get all resources without inputValue.
+    const results = await getResources('', groupBy);
+    /* Get all resources without inputValue.
+    * Because, results has no label to be filtered by inputValue. */
     state.loading = false;
 
     const refinedMenuItems = getRefinedMenuItems(groupBy, results?.map((d) => ({ name: d.key, label: d.name })));

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
@@ -81,12 +81,13 @@ const menuHandler = (groupBy: string): AutocompleteHandler => async (inputValue:
     const results = await getResources('', groupBy);
     state.loading = false;
 
-    const refinedMenuItems = getRefinedMenuItems(groupBy, inputValue, results?.map((d) => ({ name: d.key, label: d.name })));
-    return { results: refinedMenuItems };
+    const refinedMenuItems = getRefinedMenuItems(groupBy, results?.map((d) => ({ name: d.key, label: d.name })));
+    const refinedMenuItemsFilteredByInputValue = refinedMenuItems.filter((d) => (d.label as string).toLowerCase().includes(inputValue.toLowerCase()));
+    return { results: refinedMenuItemsFilteredByInputValue };
 };
-const getRefinedMenuItems = (groupBy: string, inputValue?: string, results?: Array<{name: string; label: string}>): MenuItem[] => {
+const getRefinedMenuItems = (groupBy: string, results?: Array<{name: string; label: string}>): MenuItem[] => {
     if (!results) return [];
-    const refinedResults = results.map((d) => {
+    return results.map((d) => {
         if (groupBy === GROUP_BY.PROJECT) {
             return { name: d.name, label: storeState.projects[d.name].label };
         } if (groupBy === GROUP_BY.PROJECT_GROUP) {
@@ -98,8 +99,6 @@ const getRefinedMenuItems = (groupBy: string, inputValue?: string, results?: Arr
         }
         return { name: d.name, label: d.label };
     });
-    if (!inputValue) return refinedResults;
-    return refinedResults.filter((d) => d.label.toLowerCase().includes(inputValue.toLowerCase()));
 };
 
 const handleUpdateFiltersDropdown = (groupBy: string, selectedItems: FilterableDropdownMenuItem[]) => {

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue
@@ -74,17 +74,17 @@ const getResources = async (inputText: string, distinctKey: string): Promise<{na
         return undefined;
     }
 };
-const menuHandler = (groupBy: string): AutocompleteHandler => async (value: string) => {
+const menuHandler = (groupBy: string): AutocompleteHandler => async (inputValue: string) => {
     if (!groupBy) return { results: [] };
 
     state.loading = true;
-    const results = await getResources(value, groupBy);
+    const results = await getResources('', groupBy);
     state.loading = false;
 
-    const refinedMenuItems = getRefinedMenuItems(groupBy, results?.map((d) => ({ name: d.key, label: d.name })));
+    const refinedMenuItems = getRefinedMenuItems(groupBy, inputValue, results?.map((d) => ({ name: d.key, label: d.name })));
     return { results: refinedMenuItems };
 };
-const getRefinedMenuItems = (groupBy: string, results?: Array<{name: string; label: string}>): MenuItem[] => {
+const getRefinedMenuItems = (groupBy: string, inputValue: string, results?: Array<{name: string; label: string}>): MenuItem[] => {
     if (!results) return [];
     return results.map((d) => {
         if (groupBy === GROUP_BY.PROJECT) {
@@ -97,7 +97,7 @@ const getRefinedMenuItems = (groupBy: string, results?: Array<{name: string; lab
             return { name: d.name, label: storeState.serviceAccounts[d.name].label };
         }
         return { name: d.name, label: d.label };
-    });
+    }).filter((d) => d.label.toLowerCase().includes(inputValue.toLowerCase()));
 };
 
 const handleUpdateFiltersDropdown = (groupBy: string, selectedItems: FilterableDropdownMenuItem[]) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
[QA - 804](https://pyengine.atlassian.net/browse/QA-804)

In `PFilterableDropdown.vue`, handler call autocomplete api with inputValue. But, in this case, **It was not working**.
The cause was that autocomplete api's response. **Response was like `{ name: 'no label key...blah blah', label: 'same as name'}`.** 

Originally that api filtered results with `inputValue` and `label`, But **results had no `label`** to be filtered by `inputValue`.

Thus, I added logic to filter results by using `inputValue` outside api. Handler no longer directly uses inputValue in the process of requesting autocomplete api.


**Please see Files changed..**


https://github.com/cloudforet-io/console/assets/83635051/9a851b03-06ac-4f09-82fb-0fc60115ca71

