### PR TITLE
feat: change to use prop & event binding way to init widget from calling initWidget directly

### DIFF
--- a/apps/web/src/services/dashboards/shared/dashboard-variables/DashboardVariablesDropdown.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-variables/DashboardVariablesDropdown.vue
@@ -188,7 +188,7 @@ const initVariable = () => {
         }
     }
     dashboardDetailStore.$patch((_state) => {
-        _state.variablesInitMap[props.propertyName] = true;
+        _state.variablesInitMap = { ..._state.variablesInitMap, [props.propertyName]: true };
     });
 };
 
@@ -200,7 +200,7 @@ watch(visibleMenu, (_visibleMenu) => {
 
 watch(() => state.variableProperty, async (property) => {
     dashboardDetailStore.$patch((_state) => {
-        _state.variablesInitMap[props.propertyName] = false;
+        _state.variablesInitMap = { ..._state.variablesInitMap, [props.propertyName]: false };
     });
     if (property.options?.type === 'SEARCH_RESOURCE') await loadSearchResourceOptions();
     initVariable();

--- a/apps/web/src/services/dashboards/shared/dashboard-variables/DashboardVariablesSelectDropdown.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-variables/DashboardVariablesSelectDropdown.vue
@@ -14,7 +14,8 @@
                 />
             </div>
         </template>
-        <dashboard-variables-more-button v-if="props.isManageable"
+        <dashboard-variables-more-button v-if="!props.disableMoreButton"
+                                         :is-manageable="props.isManageable"
                                          :disabled="state.saveLoading"
         />
         <p-text-button style-type="highlight"
@@ -73,6 +74,7 @@ interface Props {
     originVariables?: DashboardVariables;
     originVariablesSchema?: DashboardVariablesSchema;
     dashboardId?: string;
+    disableMoreButton?: boolean;
 }
 
 const props = defineProps<Props>();

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-container/WidgetViewModeModal.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-container/WidgetViewModeModal.vue
@@ -172,7 +172,8 @@ watch(() => props.visible, async (visible) => {
                 </div>
                 <div class="filter-wrapper">
                     <div class="left-part">
-                        <dashboard-variables-select-dropdown :is-manageable="false"
+                        <dashboard-variables-select-dropdown :is-manageable="state.hasManagePermission"
+                                                             disable-more-button
                                                              disable-save-button
                                                              :origin-variables="state.variablesSnapshot"
                                                              :origin-variables-schema="state.variableSchemaSnapshot"

--- a/apps/web/src/services/dashboards/widgets/_base/base-count-of-findings/BaseCountOfFindingsWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/_base/base-count-of-findings/BaseCountOfFindingsWidget.vue
@@ -277,6 +277,7 @@ const handleUpdateThisPage = (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -297,7 +298,7 @@ defineExpose<WidgetExpose<Data[]>>({
         <div class="data-container">
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.data"
                                loader-type="skeleton"
                                :loader-backdrop-opacity="1"

--- a/apps/web/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/_base/base-pie/BasePieWidget.vue
@@ -217,6 +217,7 @@ const handleUpdateThisPage = (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -244,7 +245,7 @@ defineExpose<WidgetExpose<FullData>>({
         <div class="data-container">
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.data"
                                loader-type="skeleton"
                                :loader-backdrop-opacity="1"
@@ -260,7 +261,7 @@ defineExpose<WidgetExpose<FullData>>({
                     </template>
                 </p-data-loader>
             </div>
-            <widget-data-table :loading="state.loading"
+            <widget-data-table :loading="props.loading || state.loading"
                                :fields="state.tableFields"
                                :items="state.data ? state.data.results: []"
                                :legends.sync="state.legends"

--- a/apps/web/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
@@ -283,6 +283,7 @@ const handleUpdateThisPage = (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -318,7 +319,7 @@ defineExpose<WidgetExpose<Response>>({
         <div class="data-container">
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.chartData"
                                loader-type="skeleton"
                                disable-empty-case
@@ -330,7 +331,7 @@ defineExpose<WidgetExpose<Response>>({
                     />
                 </p-data-loader>
             </div>
-            <widget-data-table :loading="state.loading"
+            <widget-data-table :loading="props.loading || state.loading"
                                :fields="state.tableFields"
                                :items="state.data ? state.data.results : []"
                                :currency="widgetState.currency"

--- a/apps/web/src/services/dashboards/widgets/_configs/config.ts
+++ b/apps/web/src/services/dashboards/widgets/_configs/config.ts
@@ -214,7 +214,7 @@ export interface CustomWidgetInfo extends DashboardLayoutWidgetInfo {
 }
 
 // TODO: replace with NewWidgetProps
-export interface WidgetProps {
+export interface WidgetProps<T = any> {
     widgetConfigId: string;
     title?: string;
     options?: WidgetOptions;
@@ -232,6 +232,8 @@ export interface WidgetProps {
     dashboardSettings?: DashboardSettings;
     dashboardVariablesSchema?: DashboardVariablesSchema;
     dashboardVariables?: DashboardVariables;
+    loading?: boolean;
+    data?: T;
 }
 
 // TODO: remove this after replacing WidgetProps with NewWidgetProps
@@ -249,6 +251,8 @@ export interface NewWidgetProps {
 }
 
 export interface WidgetEmit {
+    (e: 'mounted'): void;
+    (e: 'initiated', data: any): void;
     (e: 'refreshed', data: any): void;
     (e: 'update-widget-info', widgetInfo: Partial<DashboardLayoutWidgetInfo>): void;
     (e: 'update-widget-validation', validation: boolean): void;

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/compliance-status/ComplianceStatusWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/compliance-status/ComplianceStatusWidget.vue
@@ -286,6 +286,7 @@ const redrawChart = () => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -328,7 +329,7 @@ defineExpose<WidgetExpose<Data[]>>({
                 </div>
                 <div class="chart-wrapper">
                     <p-data-loader class="chart-loader"
-                                   :loading="state.loading"
+                                   :loading="props.loading || state.loading"
                                    :data="state.data"
                                    loader-type="skeleton"
                                    :loader-backdrop-opacity="1"

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/severity-status-by-service/SeverityStatusByServiceWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/severity-status-by-service/SeverityStatusByServiceWidget.vue
@@ -166,6 +166,7 @@ const refreshWidget = async (): Promise<Data[]> => {
 
 useWidgetLifecycle({
     disposeWidget: undefined,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -184,7 +185,7 @@ defineExpose<WidgetExpose>({
     >
         <div class="data-container">
             <p-data-loader class="chart-wrapper"
-                           :loading="state.loading"
+                           :loading="props.loading || state.loading"
                            :data="state.refinedData"
                            loader-type="skeleton"
                            :loader-backdrop-opacity="1"

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/total-fail-findings-status/TotalFailFindingsStatusWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/total-fail-findings-status/TotalFailFindingsStatusWidget.vue
@@ -265,6 +265,7 @@ const refreshWidget = async (): Promise<FullData> => {
 
 useWidgetLifecycle({
     disposeWidget: undefined,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -321,7 +322,7 @@ defineExpose<WidgetExpose>({
             </div>
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.chartData"
                                loader-type="skeleton"
                                :loader-backdrop-opacity="1"

--- a/apps/web/src/services/dashboards/widgets/asset-widgets/trend-of-pass-and-fail-findings/TrendOfPassAndFailFindingsWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/asset-widgets/trend-of-pass-and-fail-findings/TrendOfPassAndFailFindingsWidget.vue
@@ -308,6 +308,7 @@ const handleUpdateThisPage = async (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -329,7 +330,7 @@ defineExpose<WidgetExpose<FullData>>({
         <div class="data-container">
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.chartData"
                                loader-type="skeleton"
                                disable-empty-case

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/aws-cloud-front-cost/AWSCloudFrontCostWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/aws-cloud-front-cost/AWSCloudFrontCostWidget.vue
@@ -312,6 +312,7 @@ const handleUpdateThisPage = (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -346,7 +347,7 @@ defineExpose<WidgetExpose<Response>>({
         <div class="data-container">
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.data"
                                loader-type="skeleton"
                                :loader-backdrop-opacity="1"
@@ -358,7 +359,7 @@ defineExpose<WidgetExpose<Response>>({
                 </p-data-loader>
             </div>
 
-            <widget-data-table :loading="state.loading"
+            <widget-data-table :loading="props.loading || state.loading"
                                :fields="state.tableFields"
                                :items="state.tableData"
                                :currency="widgetState.currency"

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/aws-data-transfer-by-region/AWSDataTransferByRegionWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/aws-data-transfer-by-region/AWSDataTransferByRegionWidget.vue
@@ -282,6 +282,7 @@ const handleUpdateThisPage = (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -314,7 +315,7 @@ defineExpose<WidgetExpose<FullData>>({
         <div class="data-container">
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.data"
                                loader-type="skeleton"
                                disable-empty-case
@@ -326,7 +327,7 @@ defineExpose<WidgetExpose<FullData>>({
                     />
                 </p-data-loader>
             </div>
-            <widget-data-table :loading="state.loading"
+            <widget-data-table :loading="props.loading || state.loading"
                                :fields="state.tableFields"
                                :items="state.tableData"
                                :currency="widgetState.currency"

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrendWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/aws-data-transfer-cost-trend/AWSDataTransferCostTrendWidget.vue
@@ -278,7 +278,6 @@ const initWidget = async (data?: FullData): Promise<FullData> => {
 };
 
 const refreshWidget = async (_thisPage = 1): Promise<FullData> => {
-    await nextTick();
     state.loading = true;
     thisPage.value = _thisPage;
     state.data = await fetchData();
@@ -308,6 +307,7 @@ const handleUpdateThisPage = (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -343,7 +343,7 @@ defineExpose<WidgetExpose<FullData>>({
         <div class="data-container">
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.chartData"
                                loader-type="skeleton"
                                disable-empty-case
@@ -355,7 +355,7 @@ defineExpose<WidgetExpose<FullData>>({
                     />
                 </p-data-loader>
             </div>
-            <widget-data-table :loading="state.loading"
+            <widget-data-table :loading="props.loading || state.loading"
                                :fields="state.tableFields"
                                :items="state.tableData"
                                :currency="widgetState.currency"

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/budget-usage-by-target/BudgetUsageByTargetWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/budget-usage-by-target/BudgetUsageByTargetWidget.vue
@@ -174,6 +174,7 @@ const handleUpdateThisPage = (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: undefined,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -191,7 +192,7 @@ defineExpose<WidgetExpose<Response>>({
                   class="budget-usage-by-target"
                   v-on="widgetFrameEventHandlers"
     >
-        <widget-data-table :loading="state.loading"
+        <widget-data-table :loading="props.loading || state.loading"
                            :fields="state.tableFields"
                            :items="state.tableItems"
                            :currency="widgetState.currency"

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
@@ -257,6 +257,7 @@ const refreshWidget = async (): Promise<Data[]> => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -278,7 +279,7 @@ defineExpose<WidgetExpose<Data[]>>({
         <div class="budget-usage-summary">
             <div class="recent-budget-spent">
                 <p-data-loader class="data-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="!state.noData"
                                :loader-backdrop-opacity="1"
                                disable-empty-case
@@ -335,7 +336,7 @@ defineExpose<WidgetExpose<Data[]>>({
             </div>
             <div class="chart-wrapper">
                 <p-data-loader class="data-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="!state.noData"
                                :loader-backdrop-opacity="1"
                                loader-type="skeleton"

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/cost-by-region/CostByRegionWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/cost-by-region/CostByRegionWidget.vue
@@ -199,6 +199,7 @@ const handleUpdateThisPage = (_thisPage: number) => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -224,7 +225,7 @@ defineExpose<WidgetExpose<FullData>>({
     >
         <div class="content-wrapper">
             <p-data-loader class="chart-loader"
-                           :loading="state.loading"
+                           :loading="props.loading || state.loading"
                            :data="state.chartData"
                            :loader-backdrop-opacity="1"
                            loader-type="skeleton"
@@ -245,7 +246,7 @@ defineExpose<WidgetExpose<FullData>>({
                     </span>
                 </div>
             </p-data-loader>
-            <widget-data-table :loading="state.loading"
+            <widget-data-table :loading="props.loading || state.loading"
                                :fields="state.tableFields"
                                :items="state.data ? state.data.results : []"
                                :currency="widgetState.currency"

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/cost-map/CostMapWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/cost-map/CostMapWidget.vue
@@ -100,7 +100,7 @@ const fetchData = async (): Promise<AnalyzeRawData[]|null> => {
             },
         });
         if (status === 'succeed') return response.results;
-        return [];
+        return state.data;
     } catch (e) {
         ErrorHandler.handleError(e);
         return [];
@@ -134,6 +134,7 @@ const drawChart = (chartData: TreemapChartData[]) => {
 const initWidget = async (data?: AnalyzeRawData[]): Promise<AnalyzeRawData[]> => {
     state.loading = true;
     state.data = data ?? await fetchData();
+    chartHelper.refreshRoot();
     await nextTick();
     if (chartHelper.root.value) drawChart(state.chartData);
     state.loading = false;
@@ -153,6 +154,7 @@ const refreshWidget = async (): Promise<AnalyzeRawData[]> => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -179,7 +181,7 @@ defineExpose<WidgetExpose<AnalyzeRawData[]>>({
         <div class="cost-map">
             <div class="chart-wrapper">
                 <p-data-loader class="chart-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="state.data"
                                :loader-backdrop-opacity="1"
                                loader-type="skeleton"

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/monthly-cost/MonthlyCostWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/monthly-cost/MonthlyCostWidget.vue
@@ -280,6 +280,7 @@ const refreshWidget = async (): Promise<Data[]> => {
 
 useWidgetLifecycle({
     disposeWidget: chartHelper.disposeRoot,
+    initWidget,
     refreshWidget,
     props,
     emit,
@@ -309,7 +310,7 @@ defineExpose<WidgetExpose<Data[]>>({
                     <strong>({{ formattedCurrentMonth }})</strong>
                 </p>
                 <p-data-loader class="data-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="!state.noData"
                                :loader-backdrop-opacity="1"
                                disable-empty-case
@@ -354,7 +355,7 @@ defineExpose<WidgetExpose<Data[]>>({
                     <strong>({{ formattedPreviousMonth }})</strong>
                 </p>
                 <p-data-loader class="data-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="!state.noData"
                                :loader-backdrop-opacity="1"
                                disable-empty-case
@@ -376,7 +377,7 @@ defineExpose<WidgetExpose<Data[]>>({
             </div>
             <div class="chart-wrapper">
                 <p-data-loader class="data-loader"
-                               :loading="state.loading"
+                               :loading="props.loading || state.loading"
                                :data="!state.noData"
                                :loader-backdrop-opacity="1"
                                loader-type="skeleton"


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

1. change to use prop & event binding way to init widget from calling initWidget directly
2. fix bug at DashboardVariableDropdown. change to redefine new object for reactivity for variableInitMap.

### Things to Talk About
