### PR TITLE
fix: do not start observing before all widgets are mounted

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-customize/modules/DashboardCustomize.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/DashboardCustomize.vue
@@ -19,9 +19,7 @@
                                         refresh-disabled
             />
         </div>
-        <dashboard-widget-container edit-mode
-                                    reuse-previous-data
-        />
+        <dashboard-widget-container edit-mode />
         <dashboard-customize-sidebar :loading="props.loading"
                                      :save-button-text="props.saveButtonText"
                                      :hide-cancel-button="props.hideCancelButton"

--- a/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
+++ b/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
@@ -16,10 +16,6 @@ import type { DashboardLayoutWidgetInfo } from '@/services/dashboards/widgets/_c
 import { WIDGET_SIZE } from '@/services/dashboards/widgets/_configs/config';
 import { getWidgetConfig } from '@/services/dashboards/widgets/_helpers/widget-helper';
 
-
-interface WidgetDataMap {
-    [widgetKey: string]: any;
-}
 interface WidgetValidMap {
     [widgetKey: string]: boolean;
 }
@@ -39,7 +35,6 @@ export interface DashboardDetailInfoStoreState {
     // widget info states
     dashboardWidgetInfoList: DashboardLayoutWidgetInfo[];
     loadingWidgets: boolean;
-    widgetDataMap: WidgetDataMap;
     // validation
     isNameValid?: boolean;
     widgetValidMap: WidgetValidMap;
@@ -98,7 +93,6 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
         // widget info states
         dashboardWidgetInfoList: [],
         loadingWidgets: false,
-        widgetDataMap: {},
         // validation
         isNameValid: undefined,
         widgetValidMap: {},


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

Commit messages say it all.
Please review in order by commits.

### Things to Talk About
