### PR TITLE
fix: apply isObjectEqual to dashboard widget info helper

### DIFF
--- a/apps/web/src/services/dashboards/shared/helpers/dashboard-widget-info-helper.ts
+++ b/apps/web/src/services/dashboards/shared/helpers/dashboard-widget-info-helper.ts
@@ -1,6 +1,8 @@
 import { cloneDeep, isEmpty, isEqual } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
+import { isObjectEqual } from '@cloudforet/core-lib';
+
 import type {
     DashboardLayoutWidgetInfo,
     InheritOptions,
@@ -15,7 +17,7 @@ export const getUpdatedWidgetInfo = (widgetConfig: WidgetConfig, mergedWidgetInf
     const updatedWidgetOptions: WidgetOptions = cloneDeep(mergedWidgetInfo.widget_options) ?? {};
 
     Object.entries(updatedInheritOptions).forEach(([key, inheritOption]) => {
-        if (isEqual(inheritOption, configInheritOptions[key])) {
+        if (isObjectEqual(inheritOption, configInheritOptions[key])) {
             delete updatedInheritOptions[key];
         }
     });
@@ -24,7 +26,7 @@ export const getUpdatedWidgetInfo = (widgetConfig: WidgetConfig, mergedWidgetInf
         if (key.startsWith('filters.')) {
             if (!val) return;
             Object.entries(val).forEach(([filterKey, filterVal]) => {
-                if (isEqual(filterVal, configWidgetOptions.filters?.[filterKey])) {
+                if (isObjectEqual(filterVal, configWidgetOptions.filters?.[filterKey])) {
                     delete (updatedWidgetOptions.filters as WidgetFiltersMap)[filterKey];
                 }
             });

--- a/packages/core-lib/src/index.ts
+++ b/packages/core-lib/src/index.ts
@@ -2,7 +2,9 @@ import bytes from 'bytes';
 import dayjs from 'dayjs';
 import tz from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
-import { isEmpty, flatten, sortBy } from 'lodash';
+import {
+    isEmpty, flatten, sortBy, isEqualWith, isEqual, union,
+} from 'lodash';
 
 dayjs.extend(tz);
 dayjs.extend(utc);
@@ -64,6 +66,18 @@ export const isNotEmpty = (value): boolean => {
     if (['boolean', 'number'].includes(typeof value)) return true;
     if (value instanceof Array) return !!value.length;
     return !isEmpty(value); // String, Object
+};
+
+export const isObjectEqual = (objValue: object, othValue: object) => {
+    const _isEqual = isEqual(objValue, othValue);
+    if (_isEqual) return true;
+    const keys = union(Object.keys(objValue), Object.keys(othValue));
+    return isEqualWith(objValue, othValue, (a, b) => keys.every((key) => {
+        if (typeof a[key] === 'object' && typeof b[key] === 'object') {
+            return isObjectEqual(a[key], b[key]);
+        }
+        return isEqual(a[key], b[key]);
+    }));
 };
 
 export const tagsToObject = (tags: Array<{ key: string; value: string }>): Record<string, string> => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [x] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

add isObjectEqual to core-lib which considers undefined property and absent property are the same.


### Things to Talk About
