### PR TITLE
fix: refine schema properties with getRefinedSchemaProperties

### DIFF
--- a/apps/web/src/services/dashboards/widgets/__tests__/_helpers/widget-schema-helper.test.ts
+++ b/apps/web/src/services/dashboards/widgets/__tests__/_helpers/widget-schema-helper.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 
 import type { DashboardVariablesSchema } from '@/services/dashboards/config';
 import { managedDashboardVariablesSchema } from '@/services/dashboards/managed-variables-schema';
-import type { WidgetConfig } from '@/services/dashboards/widgets/_configs/config';
+import type { WidgetConfig, WidgetOptions } from '@/services/dashboards/widgets/_configs/config';
 import {
-    getInitialSchemaProperties,
+    getInitialSchemaProperties, getRefinedSchemaProperties,
     getWidgetFilterOptionsSchema,
 } from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
@@ -53,7 +53,7 @@ describe('[Widget Schema Helper] getInitialSchemaProperties', () => {
         const refined = getInitialSchemaProperties(widgetConfigMock, variablesSchemaMock);
         expect(refined).not.toEqual(expect.arrayContaining(['filters.cost_product', 'filters.region']));
     });
-    it('should not include used variables if it is not in schema', () => {
+    it('should not include used variables if it is not in widget config schema properties', () => {
         const variablesSchema = cloneDeep(variablesSchemaMock);
         variablesSchema.properties.abc = { ...managedDashboardVariablesSchema.properties.project, use: true };
 
@@ -76,5 +76,34 @@ describe('[Widget Schema Helper] getInitialSchemaProperties', () => {
     it('should be ordered by schema.order and fixed properties', () => {
         const refined = getInitialSchemaProperties(widgetConfigMock, variablesSchemaMock);
         expect(refined).toEqual(['filters.provider', 'filters.project', 'filters.service_account']);
+    });
+});
+
+
+describe('[Widget Schema Helper] getRefinedSchemaProperties', () => {
+    it('should be the same as initial schema properties if stored properties are empty', () => {
+        const initialProperties = ['filters.provider', 'filters.project', 'filters.service_account'];
+        const storedProperties = [];
+        const widgetOptions = {};
+        const refined = getRefinedSchemaProperties(storedProperties, initialProperties, widgetOptions);
+        expect(refined).toEqual(['filters.provider', 'filters.project', 'filters.service_account']);
+    });
+    it('should be not exist if the value is not set in widget options and it is not in initial schema properties even if it is in stored properties', () => {
+        const initialProperties = ['filters.project', 'filters.service_account'];
+        const storedProperties = ['filters.provider'];
+        const widgetOptions = {};
+        const refined = getRefinedSchemaProperties(storedProperties, initialProperties, widgetOptions);
+        expect(refined).toEqual(['filters.project', 'filters.service_account']);
+    });
+    it('should be exist if the value is set in widget options, stored properties even if it is not in initial schema properties.', () => {
+        const initialProperties = ['filters.project', 'filters.service_account'];
+        const storedProperties = ['filters.provider'];
+        const widgetOptions: WidgetOptions = {
+            filters: {
+                provider: [{ k: 'provider', v: 'aws' }],
+            },
+        };
+        const refined = getRefinedSchemaProperties(storedProperties, initialProperties, widgetOptions);
+        expect(refined).toEqual(['filters.project', 'filters.service_account', 'filters.provider']);
     });
 });

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-schema-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-schema-helper.ts
@@ -1,5 +1,5 @@
 import type { JsonSchema } from '@spaceone/design-system/types/inputs/forms/json-schema-form/type';
-import { chain, get, isEmpty } from 'lodash';
+import { chain, get, union, isEmpty } from 'lodash';
 
 import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
 
@@ -140,4 +140,13 @@ export const getInitialSchemaProperties = (
             return 9999;
         }) // sort by order and fixedProperties
         .value();
+};
+
+export const getRefinedSchemaProperties = (
+    storedProperties: string[],
+    initialProperties: string[],
+    widgetOptions?: WidgetOptions,
+): string[] => {
+    const optionExistProperties = storedProperties.filter((property) => !!get(widgetOptions, property));
+    return union(initialProperties, optionExistProperties);
 };

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-schema-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-schema-helper.ts
@@ -1,5 +1,7 @@
 import type { JsonSchema } from '@spaceone/design-system/types/inputs/forms/json-schema-form/type';
-import { chain, get, union, isEmpty } from 'lodash';
+import {
+    chain, get, union, isEmpty,
+} from 'lodash';
 
 import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
 

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-merged-widget-state.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-merged-widget-state.ts
@@ -16,7 +16,7 @@ import {
     getRefinedWidgetOptions,
 } from '@/services/dashboards/widgets/_helpers/widget-options-helper';
 import {
-    getInitialSchemaProperties,
+    getInitialSchemaProperties, getRefinedSchemaProperties,
 } from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 import { getWidgetInheritOptionsErrorMap } from '@/services/dashboards/widgets/_helpers/widget-validation-helper';
 
@@ -85,7 +85,11 @@ export function useMergedWidgetState(
             };
         }),
         title: computed<string>(() => optionState.title ?? state.widgetConfig?.title ?? ''),
-        schemaProperties: computed<string[]>(() => optionState.schemaProperties ?? getInitialSchemaProperties(state.widgetConfig, optionState.dashboardVariablesSchema)),
+        schemaProperties: computed<string[]>(() => {
+            const initialSchemaProperties = getInitialSchemaProperties(state.widgetConfig, optionState.dashboardVariablesSchema);
+            if (!optionState.schemaProperties) return initialSchemaProperties;
+            return getRefinedSchemaProperties(optionState.schemaProperties, initialSchemaProperties, optionState.widgetOptions);
+        }),
     }) as UnwrapRef<MergedWidgetState>;
 
     return state;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description

1. schema properties must be always refined. (with initiated properties)
2. If widget options are set, that property must be also added to schema properties.

### Things to Talk About
