### PR TITLE
fix(core-lib): fix error response format of spaceConnector

### DIFF
--- a/packages/core-lib/src/space-connector/error.ts
+++ b/packages/core-lib/src/space-connector/error.ts
@@ -21,9 +21,9 @@ export class APIError extends Error {
 	    if (axiosError.response) {
 	        this.status = axiosError.response.status;
 
-	        if (axiosError.response.data.error) {
-	            this.message = axiosError.response.data.error.message;
-	            this.code = axiosError.response.data.error.code;
+	        if (axiosError.response.data.detail) {
+	            this.message = axiosError.response.data.detail.message;
+	            this.code = axiosError.response.data.detail.code;
 	        } else {
 	            this.message = axiosError.response.statusText;
 	        }


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [x] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
We can see that the format of the error response object has changed [here](https://github.com/cloudforet-io/python-core/blob/master/src/spaceone/core/fastapi/api.py#L53).

 **+ additional info)**
Our API version 1 uses the "error" attribute name, while version 2 is currently using the "detail" attribute name. It appears that this change aligns with the FastAPI specification. 
Currently, we are not using error codes in version 1, and our backend developers are in the process of aligning version 1's specification with that of version 2.

### Things to Talk About
