### PR TITLE
fix(variable): handle exception case that default variable value already exists

### DIFF
--- a/apps/web/src/services/dashboards/shared/dashboard-variables/DashboardVariablesDropdown.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-variables/DashboardVariablesDropdown.vue
@@ -180,7 +180,8 @@ const loadSearchResourceOptions = async () => {
 
 const initVariable = () => {
     const variableSchema = dashboardDetailState.variablesSchema.properties[props.propertyName];
-    if ((variableSchema.options as SearchResourceOptions)?.type === 'SEARCH_RESOURCE') {
+    const existingVariableInfoValue = dashboardDetailState.dashboardInfo?.variables[props.propertyName];
+    if ((variableSchema.options as SearchResourceOptions)?.type === 'SEARCH_RESOURCE' && !existingVariableInfoValue) {
         const path = (variableSchema.options as SearchResourceOptions).default_path;
         if (path !== undefined) {
             const found = get(state.searchResourceOptions, path, undefined);

--- a/apps/web/src/services/dashboards/shared/dashboard-variables/DashboardVariablesDropdown.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-variables/DashboardVariablesDropdown.vue
@@ -181,7 +181,7 @@ const loadSearchResourceOptions = async () => {
 const initVariable = () => {
     const variableSchema = dashboardDetailState.variablesSchema.properties[props.propertyName];
     const existingVariableInfoValue = dashboardDetailState.dashboardInfo?.variables[props.propertyName];
-    if ((variableSchema.options as SearchResourceOptions)?.type === 'SEARCH_RESOURCE' && !existingVariableInfoValue) {
+    if ((variableSchema.options as SearchResourceOptions)?.type === 'SEARCH_RESOURCE' && existingVariableInfoValue !== undefined) {
         const path = (variableSchema.options as SearchResourceOptions).default_path;
         if (path !== undefined) {
             const found = get(state.searchResourceOptions, path, undefined);


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
[QA - 830](https://pyengine.atlassian.net/browse/QA-830)

At the time of dashboard variable initializing, variable (that has `default_path` and `SEARCH_RESOURCE` type) always reset to `default_path`. Even when they have a selected value.

So, I handled that case, if that variable has existing selected value.

### Things to Talk About
Do you understand the name `existingVariableInfoValue`?