### PR TITLE
fix(monthly-cost-widget): fix amcharts xAxis label issue

### DIFF
--- a/apps/web/src/services/dashboards/widgets/cost-widgets/monthly-cost/MonthlyCostWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/monthly-cost/MonthlyCostWidget.vue
@@ -185,7 +185,11 @@ const drawChart = (chartData: ChartData[]) => {
     xAxis.get('baseInterval').timeUnit = 'month';
     const xRendered = xAxis.get('renderer');
     xRendered.grid.template.setAll({ strokeOpacity: 0.8, location: 0.5 });
-    xRendered.labels.template.setAll({ visible: true });
+    xRendered.labels.template.setAll({
+        visible: true,
+        oversizedBehavior: 'hide',
+        maxWidth: 25,
+    });
 
     // set y-axis
     const yRendered = yAxis.get('renderer');


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [x] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
[QA - 826](https://pyengine.atlassian.net/browse/QA-826)
Add `IAxisLabelSettings` options (`oversizedBehavior`, `maxWidth`), when drawing MonthlyCostWidget chart.

![image](https://github.com/cloudforet-io/console/assets/83635051/d98569cb-f87a-45fd-a862-987d463070eb)


### Things to Talk About
In each case using different `timeUnit`, label's `maxWith` might be changed...