### PR TITLE
fix(mirinae): do not use primitive type for selected with handler prop at PSelectDropdown

### DIFF
--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
@@ -577,6 +577,8 @@ So with custom handler, there is no need to give menu prop. <br/>
 You can control loading manually by loading prop. <br/>
 If you don't give loading prop, loading UI will be displayed automatically when handler is running. <br/>
 
+With handler, selected prop only accepts ```MenuItem[]``` type. <br/>
+
 Handler type:
 
 ```typescript

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -102,6 +102,9 @@ const state = reactive({
     selectedIndex: typeof props.selected === 'number' ? props.selected : undefined,
     selectedItems: computed<SelectDropdownMenuItem[]>(() => {
         if (state.proxySelectedItem === undefined) return [];
+        if (props.handler) {
+            return state.proxySelectedItem as SelectDropdownMenuItem[];
+        }
         if (props.indexMode) return [props.menu[state.selectedIndex || 0]];
         if (Array.isArray(state.proxySelectedItem)) return state.proxySelectedItem;
         return props.menu.filter((m) => m.name === state.proxySelectedItem);
@@ -217,6 +220,8 @@ const handleEnterKey = () => {
 };
 const updateSelected = (selected: SelectDropdownMenuItem[]) => {
     if (props.multiSelectable) {
+        state.proxySelectedItem = selected;
+    } else if (props.handler) {
         state.proxySelectedItem = selected;
     } else {
         state.selectedIndex = props.menu.findIndex((data) => data.name === selected[0]?.name);

--- a/packages/mirinae/src/inputs/dropdown/select-dropdown/story-helper.ts
+++ b/packages/mirinae/src/inputs/dropdown/select-dropdown/story-helper.ts
@@ -304,7 +304,8 @@ const extraArgTypes: ArgTypes = {
     handler: {
         name: 'handler',
         type: { name: 'function' },
-        description: 'Handler that returns auto-completion menu according to input value. If no value is given, the default handler is executed.',
+        description: 'Handler that returns auto-completion menu according to input value. If no value is given, the default handler is executed. '
+            + 'With handler, selected prop only accepts MenuItem[] type.',
         defaultValue: undefined,
         table: {
             type: {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [x] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [ ] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
SSIA

### Things to Talk About
