### PR TITLE
fix: widget options must be updated when variable schema is updated by schema properties

### DIFF
--- a/apps/web/src/services/dashboards/shared/dashboard-widget-container/WidgetViewModeModal.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-container/WidgetViewModeModal.vue
@@ -27,7 +27,6 @@ import type {
     WidgetSize,
 } from '@/services/dashboards/widgets/_configs/config';
 import type { WidgetTheme } from '@/services/dashboards/widgets/_configs/view-config';
-import { getNonInheritedWidgetOptionsAmongUsedVariables } from '@/services/dashboards/widgets/_helpers/widget-schema-helper';
 
 
 interface WidgetViewModeModalProps {
@@ -65,14 +64,7 @@ const state = reactive({
     variableSchemaSnapshot: {} as DashboardVariablesSchema,
     settingsSnapshot: {} as DashboardSettings,
     sidebarVisible: false,
-    hasNonInheritedWidgetOptions: computed<boolean>(() => {
-        const nonInheritedWidgetOptions = getNonInheritedWidgetOptionsAmongUsedVariables(
-            dashboardDetailState.variablesSchema,
-            state.updatedWidgetInfo?.inherit_options,
-            state.updatedWidgetInfo?.widget_options,
-        );
-        return nonInheritedWidgetOptions.length > 0;
-    }),
+    hasNonInheritedWidgetOptions: false,
     updatedWidgetInfo: props.widgetInfo as Partial<DashboardLayoutWidgetInfo>|undefined,
 });
 const widgetRef = toRef(state, 'widgetRef');
@@ -96,10 +88,14 @@ const handleClickEditOption = () => {
     state.sidebarVisible = true;
 };
 const handleCloseSidebar = () => {
+    state.sidebarVisible = false;
     state.widgetRef?.refreshWidget();
 };
 const handleUpdateSidebarWidgetInfo = () => {
     state.widgetRef?.refreshWidget();
+};
+const handleUpdateHasNonInheritedWidgetOptions = (value: boolean) => {
+    state.hasNonInheritedWidgetOptions = value;
 };
 
 const handleUpdateWidgetInfo = (widgetKey: string, widgetInfo: Partial<DashboardLayoutWidgetInfo>) => {
@@ -205,12 +201,13 @@ watch(() => props.visible, async (visible) => {
                 </div>
             </div>
             <transition name="slide-left">
-                <widget-view-mode-sidebar v-if="props.widgetInfo && state.sidebarVisible"
+                <widget-view-mode-sidebar v-if="props.widgetInfo"
+                                          v-show="state.sidebarVisible"
                                           :widget-config-id="props.widgetInfo.widget_name"
                                           :widget-key="props.widgetInfo.widget_key"
-                                          :visible.sync="state.sidebarVisible"
                                           @close="handleCloseSidebar"
                                           @update:widget-info="handleUpdateSidebarWidgetInfo"
+                                          @update:has-non-inherited-widget-options="handleUpdateHasNonInheritedWidgetOptions"
                 />
             </transition>
         </div>
@@ -284,7 +281,13 @@ watch(() => props.visible, async (visible) => {
 .slide-left-enter {
     transform: translate(100%, 0);
 }
+.slide-left-leave {
+    transform: translate(0, 0);
+}
 .slide-left-leave-to {
     transform: translate(100%, 0);
+}
+.slide-left-enter-to {
+    transform: translate(0, 0);
 }
 </style>

--- a/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
+++ b/apps/web/src/services/dashboards/store/dashboard-detail-info.ts
@@ -216,6 +216,7 @@ export const useDashboardDetailInfoStore = defineStore('dashboard-detail-info', 
                 _dashboardWidgetInfoList[targetIndex] = {
                     ...this.dashboardWidgetInfoList[targetIndex],
                     ...data,
+                    widget_key: widgetKey, // widget_key should not be changed
                 };
                 this.dashboardWidgetInfoList = _dashboardWidgetInfoList;
             }

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-schema-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-schema-helper.ts
@@ -1,6 +1,6 @@
 import type { JsonSchema } from '@spaceone/design-system/types/inputs/forms/json-schema-form/type';
 import {
-    chain, get, union, isEmpty,
+    chain, get, union,
 } from 'lodash';
 
 import { REFERENCE_TYPE_INFO } from '@/lib/reference/reference-config';
@@ -105,17 +105,14 @@ export const getWidgetInheritOptionsForFilter = (...properties: WidgetFilterKey[
 export const getNonInheritedWidgetOptionsAmongUsedVariables = (
     variablesSchema: DashboardVariablesSchema,
     widgetInheritOptions: InheritOptions = {},
-    widgetOptions: WidgetOptions = {},
+    schemaProperties: string[] = [],
 ): string[] => {
     const nonInheritedOptions: string[] = [];
     const enabledInheritedOptions = Object.entries(widgetInheritOptions).filter(([, inheritOption]) => inheritOption?.enabled).map(([key, inheritOption]) => inheritOption?.variable_info?.key ?? key);
     if (variablesSchema?.properties) {
         Object.entries(variablesSchema.properties).forEach(([key, property]) => {
             const optionName = getWidgetOptionName(key);
-            if (property.use
-                && !enabledInheritedOptions.includes(optionName)
-                && !isEmpty(get(widgetOptions, optionName))
-            ) nonInheritedOptions.push(optionName);
+            if (property.use && schemaProperties.includes(optionName) && !enabledInheritedOptions.includes(key)) nonInheritedOptions.push(optionName);
         });
     }
     return nonInheritedOptions;

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget-lifecycle.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget-lifecycle.ts
@@ -5,6 +5,7 @@ import {
 } from 'vue';
 
 import {
+    debounce,
     isEqual,
 } from 'lodash';
 
@@ -47,10 +48,10 @@ export const useWidgetLifecycle = <Data = any>({
 }: UseWidgetLifecycleOptions<Data>): void => {
     const initiated = ref(false);
 
-    const refreshWidgetAndEmitEvent = () => {
+    const refreshWidgetAndEmitEvent = debounce(() => {
         const newData = refreshWidget();
         emit('refreshed', newData);
-    };
+    }, 300);
 
     const stopVariablesWatch = watch(() => props.dashboardVariables, (after, before) => {
         if (!initiated.value || props.errorMode || !widgetState.inheritOptions || props.disableRefreshOnVariableChange) return;
@@ -59,7 +60,7 @@ export const useWidgetLifecycle = <Data = any>({
     }, { deep: true });
 
     const stopVariablesSchemaWatch = watch(() => props.dashboardVariablesSchema, (after, before) => {
-        if (!initiated.value || props.loading || !props.editMode || !widgetState.inheritOptions || !widgetState.schemaProperties || !widgetState.options
+        if (!initiated.value || !props.editMode || !widgetState.inheritOptions || !widgetState.schemaProperties || !widgetState.options
             || isEqual(after, before) || props.disableRefreshOnVariableChange) return;
 
         const { isWidgetUpdated, isValid, updatedWidgetInfo } = validateWidgetByVariablesSchemaUpdate({

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-widget-frame.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-widget-frame.ts
@@ -32,7 +32,7 @@ export const useWidgetFrame = (
     });
     const nonInheritOptionsTooltipText = computed<string | undefined>(() => {
         if (!props.dashboardVariablesSchema) return undefined;
-        const nonInheritOptions = getNonInheritedWidgetOptionsAmongUsedVariables(props.dashboardVariablesSchema, widgetState.inheritOptions, widgetState.options);
+        const nonInheritOptions = getNonInheritedWidgetOptionsAmongUsedVariables(props.dashboardVariablesSchema, widgetState.inheritOptions, widgetState.schemaProperties);
         if (!nonInheritOptions.length) return undefined;
 
         // TODO: widget option name must be changed to readable name.

--- a/packages/core-lib/src/index.ts
+++ b/packages/core-lib/src/index.ts
@@ -68,7 +68,9 @@ export const isNotEmpty = (value): boolean => {
     return !isEmpty(value); // String, Object
 };
 
-export const isObjectEqual = (objValue: object, othValue: object) => {
+export const isObjectEqual = (objValue?: object, othValue?: object) => {
+    if (!objValue && !othValue) return true;
+    if (!objValue || !othValue) return false;
     const _isEqual = isEqual(objValue, othValue);
     if (_isEqual) return true;
     const keys = union(Object.keys(objValue), Object.keys(othValue));


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
Please review in order by commits.

Main bug fix:
- commit: [fix: check schemaProperties instead of widgetOptions when validating …](https://github.com/cloudforet-io/console/commit/c434878b9ebfb9e9645200d16924fa284fed42df)
  - updated `getNonInheritedWidgetOptionsAmongUsedVariables` since requirement is updated. 
    - original: if the inherit option enabled property has the value in widgetOptions -> it is non inherited option
    - updated: if the property in schemaProperties has enabled inherit option -> it will automatically inherit option


Others are minor bug fix.

### Things to Talk About
