### PR TITLE
fix: apply usage_unit to AWS usage type related widgets

### DIFF
--- a/apps/web/src/common/composables/amcharts5/xy-chart-helper.ts
+++ b/apps/web/src/common/composables/amcharts5/xy-chart-helper.ts
@@ -230,15 +230,15 @@ export const createXYColumnSeries = (
 };
 
 // Tooltip
-export const setXYSharedTooltipText = (chart: am5xy.XYChart, tooltip: am5.Tooltip, currency?: Currency, currencyRate?: CurrencyRates): void => {
+export const setXYSharedTooltipText = (chart: am5xy.XYChart, tooltip: am5.Tooltip, valueFormatter?: (value: any, data?: any) => string): void => {
     tooltip.label.adapters.add('text', (text, target) => {
         let _text = `[${gray[700]}]{valueX}[/]`;
         chart.series.each((s) => {
             const fieldName = s.get('valueYField') || s.get('valueXField') || '';
             let value = target.dataItem?.dataContext?.[fieldName];
             if (value === undefined) value = '--';
-            if (currency) value = currencyMoneyFormatter(value, currency, currencyRate);
-            _text += `\n[${s.get('stroke')?.toString()}; fontSize: 10px]●[/] [fontSize: 14px;}]${s.get('name')}:[/] [bold; fontSize: 14px]${value}[/]`;
+            const formatted = valueFormatter ? valueFormatter(value, target.dataItem?.dataContext) : value;
+            _text += `\n[${s.get('stroke')?.toString()}; fontSize: 10px]●[/] [fontSize: 14px;}]${s.get('name')}:[/] [bold; fontSize: 14px]${formatted}[/]`;
         });
         return _text;
     });

--- a/apps/web/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
@@ -18,6 +18,7 @@ import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';
 
 import type { ReferenceType } from '@/store/reference/all-reference-store';
 
+import { currencyMoneyFormatter } from '@/lib/helper/currency-helper';
 import { arrayToQueryString, objectToQueryString, primitiveToQueryString } from '@/lib/router-query-string';
 
 import { useAmcharts5 } from '@/common/composables/amcharts5';
@@ -211,7 +212,7 @@ const drawChart = (chartData: ChartData[]) => {
 
     // create tooltip
     const tooltip = chartHelper.createTooltip();
-    chartHelper.setXYSharedTooltipText(chart, tooltip, widgetState.currency);
+    chartHelper.setXYSharedTooltipText(chart, tooltip, (value) => currencyMoneyFormatter(value, widgetState.currency));
 
     // set series
     state.legends.forEach((legend) => {

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-data-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-data-helper.ts
@@ -78,7 +78,7 @@ const mergeByKey = <S extends RawData>(arrA: S[], arrB: S[], key: keyof S): S[] 
 };
 const mergeRefinedHorizontalXYChartData = <T extends RawData, S extends RawData>(chartData: S[], data: T, options: RefineOptions<T, S>, groupByLabel: keyof S|undefined): S[] => {
     const {
-        groupBy, arrayDataKey, categoryKey, valueKey,
+        groupBy, arrayDataKey, categoryKey, valueKey, additionalIncludeKeysFromParent,
     } = options;
     if (!groupBy) {
         console.error(Error('groupBy is required for horizontal chart.'));
@@ -97,6 +97,12 @@ const mergeRefinedHorizontalXYChartData = <T extends RawData, S extends RawData>
                 [valueSet[categoryKey] as string]: valueSet[valueKey],
                 [groupBy]: groupByLabel,
             };
+
+            if (additionalIncludeKeysFromParent) {
+                additionalIncludeKeysFromParent.forEach((key) => {
+                    refinedChartItem[key as keyof S] = valueSet[key] as unknown as S[keyof S];
+                });
+            }
         });
 
         mergedChartData.push(refinedChartItem);

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-helper.ts
@@ -25,22 +25,24 @@ export const getXYChartLegends = <T = Record<string, any>>(
     allReferenceTypeInfo?: AllReferenceTypeInfo,
     disableReferenceColor = false,
 ): Legend[] => {
-    if (!rawData || !groupBy || !allReferenceTypeInfo) return [];
+    if (!rawData || !groupBy) return [];
     const legends: Legend[] = [];
     rawData.forEach((d) => {
         let _name = d[groupBy];
         let _label = d[groupBy];
         let _color;
-        const referenceTypeInfo = Object.values(allReferenceTypeInfo).find((info) => info.key === groupBy);
-        if (_name && referenceTypeInfo) {
-            const referenceMap = referenceTypeInfo.referenceMap;
-            _label = referenceMap[_name]?.label ?? referenceMap[_name]?.name ?? _name;
-            if (groupBy === COST_GROUP_BY.PROVIDER && !disableReferenceColor) {
-                _color = referenceMap[_name]?.color;
+        if (allReferenceTypeInfo) {
+            const referenceTypeInfo = Object.values(allReferenceTypeInfo).find((info) => info.key === groupBy);
+            if (_name && referenceTypeInfo) {
+                const referenceMap = referenceTypeInfo.referenceMap;
+                _label = referenceMap[_name]?.label ?? referenceMap[_name]?.name ?? _name;
+                if (groupBy === COST_GROUP_BY.PROVIDER && !disableReferenceColor) {
+                    _color = referenceMap[_name]?.color;
+                }
+            } else if (!_name) {
+                _name = `no_${groupBy}`;
+                _label = 'Unknown';
             }
-        } else if (!_name) {
-            _name = `no_${groupBy}`;
-            _label = 'Unknown';
         }
         legends.push({
             name: _name,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
- [ ] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
Please review in order by commits

### Things to Talk About
