### PR TITLE
refactor(cost-analysis): separate granularity, period dropdown component concerns 

### DIFF
--- a/apps/web/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/CostAnalysisPage.vue
@@ -2,9 +2,7 @@
 import {
     onUnmounted, watch,
 } from 'vue';
-import { useRoute } from 'vue-router/composables';
-
-import { SpaceRouter } from '@/router';
+import { useRoute, useRouter } from 'vue-router/composables';
 
 import {
     queryStringToArray,
@@ -26,6 +24,7 @@ import type {
 
 
 const route = useRoute();
+const router = useRouter();
 
 const costAnalysisPageStore = useCostAnalysisPageStore();
 
@@ -46,7 +45,7 @@ watch(() => costAnalysisPageStore.selectedQuerySet, async (selectedQuerySet) => 
     if (selectedQuerySet) {
         await costAnalysisPageStore.setQueryOptions(selectedQuerySet.options);
     } else if (route.params.costQuerySetId === DYNAMIC_COST_QUERY_SET_PARAMS) {
-        const currentQuery = SpaceRouter.router.currentRoute.query;
+        const currentQuery = router.currentRoute.query;
         const costQuerySetOptions = getQueryOptionsFromUrlQuery(currentQuery);
         await costAnalysisPageStore.setQueryOptions(costQuerySetOptions);
     } else {

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGranularityPeriodDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGranularityPeriodDropdown.vue
@@ -94,7 +94,9 @@ watch(() => costAnalysisPageStore.selectedQueryId, (after, before) => {
                            class="granularity-dropdown"
                            @select="handleSelectGranularity"
         />
-        <cost-analysis-period-select-dropdown :option-for-initial-period="state.optionForInitialPeriod" />
+        <cost-analysis-period-select-dropdown :option-for-initial-period="state.optionForInitialPeriod"
+                                              :granularity="state.granularity"
+        />
         <p-badge v-if="state.showPeriodBadge"
                  badge-type="subtle"
                  style-type="gray200"

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGranularityPeriodDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisGranularityPeriodDropdown.vue
@@ -1,0 +1,117 @@
+<script lang="ts" setup>
+
+import {
+    computed, reactive, watch,
+} from 'vue';
+import { useRoute } from 'vue-router/composables';
+
+import {
+    PSelectDropdown, PBadge,
+} from '@spaceone/design-system';
+import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
+import dayjs from 'dayjs';
+
+
+import { i18n } from '@/translations';
+
+import {
+    DYNAMIC_COST_QUERY_SET_PARAMS,
+} from '@/services/cost-explorer/cost-analysis/config';
+import CostAnalysisPeriodSelectDropdown
+    from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue';
+import { GRANULARITY } from '@/services/cost-explorer/lib/config';
+import { useCostAnalysisPageStore } from '@/services/cost-explorer/store/cost-analysis-page-store';
+import type { CostQuerySetOption, Granularity } from '@/services/cost-explorer/type';
+
+
+const costAnalysisPageStore = useCostAnalysisPageStore();
+const costAnalysisPageState = costAnalysisPageStore.$state;
+
+const route = useRoute();
+
+const state = reactive({
+    granularityItems: computed<MenuItem[]>(() => ([
+        {
+            type: 'item',
+            name: GRANULARITY.DAILY,
+            label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.DAILY'),
+        },
+        {
+            type: 'item',
+            name: GRANULARITY.MONTHLY,
+            label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.MONTHLY'),
+        },
+        {
+            type: 'item',
+            name: GRANULARITY.YEARLY,
+            label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.YEARLY'),
+        },
+    ])),
+    granularity: undefined as Granularity|undefined,
+    showPeriodBadge: computed<boolean>(() => costAnalysisPageStore.selectedQueryId === DYNAMIC_COST_QUERY_SET_PARAMS || !costAnalysisPageState.relativePeriod),
+    periodBadgeText: computed<string>(() => {
+        if (!costAnalysisPageState.period) return '';
+        let startDateFormat = 'MMM D';
+        if (costAnalysisPageState.granularity === GRANULARITY.MONTHLY) startDateFormat = 'MMM YYYY';
+        else if (costAnalysisPageState.granularity === GRANULARITY.YEARLY) startDateFormat = 'YYYY';
+        const endDateFormat = costAnalysisPageState.granularity === GRANULARITY.DAILY ? 'MMM D, YYYY' : startDateFormat;
+        //
+        const start = dayjs.utc(costAnalysisPageState.period.start);
+        let end = dayjs.utc(costAnalysisPageState.period.end);
+        if (costAnalysisPageState.granularity === GRANULARITY.DAILY) end = dayjs.utc(costAnalysisPageState.period.end).endOf('month');
+        return `${start.format(startDateFormat)} ~ ${end.format(endDateFormat)}`;
+    }),
+    optionForInitialPeriod: undefined as CostQuerySetOption|undefined,
+});
+
+/* event */
+const handleSelectGranularity = async (granularity: Granularity) => {
+    costAnalysisPageStore.$patch({ granularity });
+    state.granularity = granularity;
+};
+
+
+/* NOTE: Case for changing query set(LNB, Dynamic Link) */
+watch(() => costAnalysisPageStore.selectedQueryId, (after, before) => {
+    if (!after) return;
+    if (route.params.costQuerySetId === DYNAMIC_COST_QUERY_SET_PARAMS) {
+        state.optionForInitialPeriod = {
+            granularity: costAnalysisPageState.granularity,
+            period: costAnalysisPageState.period,
+        };
+    } else if (after !== before) {
+        state.optionForInitialPeriod = costAnalysisPageStore.selectedQuerySet?.options;
+    }
+}, { immediate: true });
+</script>
+
+<template>
+    <div class="cost-analysis-granularity-period-dropdown">
+        <p-select-dropdown :menu="state.granularityItems"
+                           :selection-label="$t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.GRANULARITY')"
+                           style-type="rounded"
+                           :selected="costAnalysisPageState.granularity"
+                           class="granularity-dropdown"
+                           @select="handleSelectGranularity"
+        />
+        <cost-analysis-period-select-dropdown :option-for-initial-period="state.optionForInitialPeriod" />
+        <p-badge v-if="state.showPeriodBadge"
+                 badge-type="subtle"
+                 style-type="gray200"
+        >
+            {{ state.periodBadgeText }}
+        </p-badge>
+    </div>
+</template>
+
+<style lang="postcss" scoped>
+.cost-analysis-granularity-period-dropdown {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    .granularity-dropdown {
+        min-width: unset;
+    }
+}
+
+</style>

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
@@ -35,6 +35,7 @@ interface PeriodItem extends SelectDropdownMenuItem {
 
 const props = defineProps<{
     optionForInitialPeriod?: CostQuerySetOption;
+    granularity?: Granularity;
 }>();
 
 const costAnalysisPageStore = useCostAnalysisPageStore();
@@ -187,11 +188,11 @@ const handleCustomRangeModalConfirm = (period: Period) => {
 };
 
 
-watch([() => props.optionForInitialPeriod, () => costAnalysisPageState.granularity], ([option, _granularity], [prevOption]) => {
+watch([() => props.optionForInitialPeriod, () => props.granularity], ([option, _granularity], [prevOption]) => {
     if (option !== prevOption && option) {
         const { relative_period, period, granularity } = option;
         setSelectedItemByQuerySet({ relativePeriod: relative_period, period, granularity });
-    } else {
+    } else if (_granularity) {
         setSelectedItemByGranularity(_granularity);
     }
 }, { immediate: true });

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
@@ -20,7 +20,7 @@ import {
 import type { RelativePeriod } from '@/services/cost-explorer/cost-analysis/type';
 import { GRANULARITY } from '@/services/cost-explorer/lib/config';
 import { useCostAnalysisPageStore } from '@/services/cost-explorer/store/cost-analysis-page-store';
-import type { Granularity, Period } from '@/services/cost-explorer/type';
+import type { Granularity, Period, CostQuerySetOption } from '@/services/cost-explorer/type';
 import CustomDateRangeModal from '@/services/dashboards/shared/CustomDateRangeModal.vue';
 
 
@@ -34,7 +34,7 @@ interface PeriodItem extends SelectDropdownMenuItem {
 }
 
 const props = defineProps<{
-    localGranularity?: Granularity;
+    optionForInitialPeriod?: CostQuerySetOption;
 }>();
 
 const costAnalysisPageStore = useCostAnalysisPageStore();
@@ -186,21 +186,15 @@ const handleCustomRangeModalConfirm = (period: Period) => {
     state.customRangeModalVisible = false;
 };
 
-/* NOTE: Case for changing granularity dropdown */
-watch(() => props.localGranularity, (granularity) => {
-    if (granularity) setSelectedItemByGranularity(granularity);
-});
 
-/* NOTE: Case for changing query set(LNB, Dynamic Link) */
-watch(() => costAnalysisPageStore.selectedQuerySet, async (selectedQuerySet) => {
-    setSelectedItemByQuerySet({
-        relativePeriod: selectedQuerySet?.options?.relative_period,
-        period: selectedQuerySet?.options?.period,
-        granularity: selectedQuerySet?.options?.granularity,
-    });
-}, {
-    immediate: true,
-});
+watch([() => props.optionForInitialPeriod, () => costAnalysisPageState.granularity], ([option, _granularity], [prevOption]) => {
+    if (option !== prevOption && option) {
+        const { relative_period, period, granularity } = option;
+        setSelectedItemByQuerySet({ relativePeriod: relative_period, period, granularity });
+    } else {
+        setSelectedItemByGranularity(_granularity);
+    }
+}, { immediate: true });
 </script>
 
 <template>

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue
@@ -213,15 +213,3 @@ watch([() => props.optionForInitialPeriod, () => props.granularity], ([option, _
         />
     </div>
 </template>
-
-<style lang="postcss" scoped>
-.cost-analysis-period-select-dropdown {
-    .p-badge {
-        margin-right: 0.5rem;
-        .text {
-            white-space: nowrap;
-        }
-    }
-}
-
-</style>

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -7,7 +7,7 @@ import {
 } from 'vue';
 
 import {
-    PSelectDropdown, PButton, PContextMenu, PIconButton, PPopover, PBadge,
+    PButton, PContextMenu, PIconButton, PPopover, PBadge,
     useContextMenuController,
 } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
@@ -28,8 +28,8 @@ import {
 } from '@/services/cost-explorer/cost-analysis/config';
 import { REQUEST_TYPE } from '@/services/cost-explorer/cost-analysis/lib/config';
 import CostAnalysisFiltersPopper from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue';
-import CostAnalysisPeriodSelectDropdown
-    from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisPeriodSelectDropdown.vue';
+import CostAnalysisGranularityPeriodDropdown
+    from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisGranularityPeriodDropdown.vue';
 import { GRANULARITY } from '@/services/cost-explorer/lib/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 import { useCostAnalysisPageStore } from '@/services/cost-explorer/store/cost-analysis-page-store';
@@ -118,10 +118,6 @@ const {
 onClickOutside(rightPartRef, hideContextMenu);
 
 /* event */
-const handleSelectGranularity = async (granularity: Granularity) => {
-    costAnalysisPageStore.$patch({ granularity });
-    state.granularity = granularity;
-};
 const handleSaveQuerySet = async () => {
     try {
         await SpaceConnector.client.costAnalysis.costQuerySet.update({
@@ -175,20 +171,7 @@ watch(() => costAnalysisPageStore.selectedQueryId, (updatedQueryId) => {
              :style="{ 'margin-bottom': `${filtersPopperHeight ? filtersPopperHeight+40: 0}px` }"
         >
             <div class="left-part">
-                <p-select-dropdown :menu="state.granularityItems"
-                                   :selection-label="$t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.GRANULARITY')"
-                                   style-type="rounded"
-                                   :selected="costAnalysisPageState.granularity"
-                                   class="granularity-dropdown"
-                                   @select="handleSelectGranularity"
-                />
-                <cost-analysis-period-select-dropdown :local-granularity="state.granularity" />
-                <p-badge v-if="state.showPeriodBadge"
-                         badge-type="subtle"
-                         style-type="gray200"
-                >
-                    {{ state.periodBadgeText }}
-                </p-badge>
+                <cost-analysis-granularity-period-dropdown />
                 <p-popover :is-visible.sync="state.filtersPopoverVisible"
                            :class="{ 'open': state.filtersPopoverVisible }"
                            ignore-outside-click

--- a/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
+++ b/apps/web/src/services/cost-explorer/cost-analysis/modules/CostAnalysisQueryFilter.vue
@@ -11,7 +11,6 @@ import {
     useContextMenuController,
 } from '@spaceone/design-system';
 import type { MenuItem } from '@spaceone/design-system/types/inputs/context-menu/type';
-import dayjs from 'dayjs';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 
@@ -30,7 +29,6 @@ import { REQUEST_TYPE } from '@/services/cost-explorer/cost-analysis/lib/config'
 import CostAnalysisFiltersPopper from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisFiltersPopper.vue';
 import CostAnalysisGranularityPeriodDropdown
     from '@/services/cost-explorer/cost-analysis/modules/CostAnalysisGranularityPeriodDropdown.vue';
-import { GRANULARITY } from '@/services/cost-explorer/lib/config';
 import { COST_EXPLORER_ROUTE } from '@/services/cost-explorer/route-config';
 import { useCostAnalysisPageStore } from '@/services/cost-explorer/store/cost-analysis-page-store';
 import type { Granularity } from '@/services/cost-explorer/type';
@@ -50,23 +48,6 @@ const { height: filtersPopperHeight } = useElementSize(filtersPopperRef);
 const state = reactive({
     hasManagePermission: useManagePermissionState(),
     queryFormModalVisible: false,
-    granularityItems: computed<MenuItem[]>(() => ([
-        {
-            type: 'item',
-            name: GRANULARITY.DAILY,
-            label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.DAILY'),
-        },
-        {
-            type: 'item',
-            name: GRANULARITY.MONTHLY,
-            label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.MONTHLY'),
-        },
-        {
-            type: 'item',
-            name: GRANULARITY.YEARLY,
-            label: i18n.t('BILLING.COST_MANAGEMENT.COST_ANALYSIS.YEARLY'),
-        },
-    ])),
     saveDropdownMenuItems: computed<MenuItem[]>(() => ([
         {
             type: 'item',
@@ -88,19 +69,6 @@ const state = reactive({
             count += filterItems.length;
         });
         return count;
-    }),
-    showPeriodBadge: computed<boolean>(() => costAnalysisPageStore.selectedQueryId === DYNAMIC_COST_QUERY_SET_PARAMS || !costAnalysisPageState.relativePeriod),
-    periodBadgeText: computed<string>(() => {
-        if (!costAnalysisPageState.period) return '';
-        let startDateFormat = 'MMM D';
-        if (costAnalysisPageState.granularity === GRANULARITY.MONTHLY) startDateFormat = 'MMM YYYY';
-        else if (costAnalysisPageState.granularity === GRANULARITY.YEARLY) startDateFormat = 'YYYY';
-        const endDateFormat = costAnalysisPageState.granularity === GRANULARITY.DAILY ? 'MMM D, YYYY' : startDateFormat;
-        //
-        const start = dayjs.utc(costAnalysisPageState.period.start);
-        let end = dayjs.utc(costAnalysisPageState.period.end);
-        if (costAnalysisPageState.granularity === GRANULARITY.DAILY) end = dayjs.utc(costAnalysisPageState.period.end).endOf('month');
-        return `${start.format(startDateFormat)} ~ ${end.format(endDateFormat)}`;
     }),
 });
 

--- a/apps/web/src/services/cost-explorer/type.ts
+++ b/apps/web/src/services/cost-explorer/type.ts
@@ -14,7 +14,7 @@ export type GroupBy = typeof GROUP_BY[keyof typeof GROUP_BY];
 export type Filter = typeof FILTER[keyof typeof FILTER];
 
 
-interface CostQuerySetOption {
+export interface CostQuerySetOption {
     group_by?: Array<string|GroupBy>;
     granularity: Granularity;
     period?: Period;


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
- [x] Refactor
- [ ] Others (performance improvement, CI/CD, etc.)

### Affects to
- [ ] Packages
  - [ ] core-lib
  - [ ] mirinae
  - [ ] etc 

- [ ] Apps
  - [ ] storybook
  - [x] web

### Checklist
- Did you check the `lint` and `type`?
- Did you document the changes?
  - Changes in `mirinae` should be reflected in `storybook`.
- Did you test the app after the package changes?


### Description
I have removed unexpected logic from the CostAnalysisPeriodSelectDropdown and separated the dependent components(Granularity dropdown, PeriodDropdown).

### Things to Talk About
I think it's hard to understand. Let's get together and have a chat.