### PR TITLE
feat(cost-explorer): apply cost-explorer landing page

### DIFF
--- a/apps/web/src/lib/menu/config.ts
+++ b/apps/web/src/lib/menu/config.ts
@@ -13,6 +13,7 @@ export const MENU_ID = Object.freeze({
     ASSET_INVENTORY_COLLECTOR: 'asset_inventory.collector',
     ASSET_INVENTORY_SERVICE_ACCOUNT: 'asset_inventory.service_account',
     COST_EXPLORER: 'cost_explorer',
+    COST_EXPLORER_LANDING: 'cost_explorer.landing',
     COST_EXPLORER_COST_ANALYSIS: 'cost_explorer.cost_analysis',
     COST_EXPLORER_BUDGET: 'cost_explorer.budget',
     ALERT_MANAGER: 'alert_manager',

--- a/apps/web/src/services/cost-explorer/CostExplorerContainer.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerContainer.vue
@@ -126,6 +126,7 @@ export default {
         opacity: 1;
         background-position: 50% 0;
         background-size: 90rem auto;
+        background-repeat: no-repeat;
     }
 }
 </style>

--- a/apps/web/src/services/cost-explorer/CostExplorerContainer.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerContainer.vue
@@ -10,6 +10,12 @@
                 <router-view />
             </template>
         </vertical-page-layout>
+        <centered-page-layout v-else-if="$route.meta.centeredLayout"
+                              class="cost-centered-layout"
+                              has-nav-bar
+        >
+            <router-view />
+        </centered-page-layout>
         <general-page-layout v-else
                              :breadcrumbs="breadcrumbs"
         >
@@ -30,6 +36,7 @@ import { store } from '@/store';
 
 import { useBreadcrumbs } from '@/common/composables/breadcrumbs';
 import ErrorHandler from '@/common/composables/error/errorHandler';
+import CenteredPageLayout from '@/common/modules/page-layouts/CenteredPageLayout.vue';
 import GeneralPageLayout from '@/common/modules/page-layouts/GeneralPageLayout.vue';
 import VerticalPageLayout from '@/common/modules/page-layouts/VerticalPageLayout.vue';
 
@@ -42,6 +49,7 @@ import { useCostQuerySetStore } from '@/services/cost-explorer/store/cost-query-
 export default {
     name: 'CostExplorerContainer',
     components: {
+        CenteredPageLayout,
         GeneralPageLayout,
         CostExplorerLNB,
         VerticalPageLayout,
@@ -111,3 +119,13 @@ export default {
     },
 };
 </script>
+
+<style lang="postcss" scoped>
+.cost-centered-layout {
+    &::before {
+        opacity: 1;
+        background-position: 50% 0;
+        background-size: 90rem auto;
+    }
+}
+</style>

--- a/apps/web/src/services/cost-explorer/CostExplorerHome.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerHome.vue
@@ -1,3 +1,40 @@
+<script lang="ts" setup>
+import { PLink, PButton, PPaneLayout } from '@spaceone/design-system';
+import { ACTION_ICON } from '@spaceone/design-system/src/inputs/link/type';
+
+import { i18n } from '@/translations';
+
+const SERVICE_CONTENTS = {
+    service_name: i18n.t('MENU.COST_EXPLORER'),
+    topic: {
+        title: i18n.t('BILLING.COST_MANAGEMENT.HOME.TITLE'),
+        description: i18n.t('BILLING.COST_MANAGEMENT.HOME.TOPIC_DESC'),
+        button_link: 'https://spaceone.megazone.io/contact',
+        button_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.CONTACT_BUTTON'),
+        link: 'https://cloudforet.io/docs/guides/cost-explorer/',
+        link_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.MORE_INFO'),
+        thumbnail_url: 'img_landing_cost-explorer_hero.png',
+    },
+    sub_menu: [
+        {
+            name: i18n.t('MENU.COST_EXPLORER_COST_ANALYSIS'),
+            description: i18n.t('BILLING.COST_MANAGEMENT.HOME.COST_ANALYSIS_DESC'),
+            link_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.LEARN_MORE'),
+            link: 'https://cloudforet.io/docs/guides/cost-explorer/cost-analysis/',
+            thumbnail_url: 'img_landing_cost-explorer_cost-analysis.png',
+        },
+        {
+            name: i18n.t('MENU.COST_EXPLORER_BUDGET'),
+            description: i18n.t('BILLING.COST_MANAGEMENT.HOME.COST_BUDGET_DESC'),
+            link_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.LEARN_MORE'),
+            link: 'https://cloudforet.io/docs/guides/cost-explorer/budget/',
+            thumbnail_url: 'img_landing_cost-explorer_budget.png',
+        },
+    ],
+};
+
+</script>
+
 <template>
     <div class="service-home">
         <div class="service-topic">
@@ -57,56 +94,6 @@
     </div>
 </template>
 
-<script lang="ts">
-import { PLink, PButton, PPaneLayout } from '@spaceone/design-system';
-import { ACTION_ICON } from '@spaceone/design-system/src/inputs/link/type';
-
-import { i18n } from '@/translations';
-
-const SERVICE_CONTENTS = {
-    service_name: i18n.t('MENU.COST_EXPLORER'),
-    topic: {
-        title: i18n.t('BILLING.COST_MANAGEMENT.HOME.TITLE'),
-        description: i18n.t('BILLING.COST_MANAGEMENT.HOME.TOPIC_DESC'),
-        button_link: 'https://spaceone.megazone.io/contact',
-        button_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.CONTACT_BUTTON'),
-        link: 'https://cloudforet.io/docs/guides/cost-explorer/',
-        link_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.MORE_INFO'),
-        thumbnail_url: 'img_landing_cost-explorer_hero.png',
-    },
-    sub_menu: [
-        {
-            name: i18n.t('MENU.COST_EXPLORER_COST_ANALYSIS'),
-            description: i18n.t('BILLING.COST_MANAGEMENT.HOME.COST_ANALYSIS_DESC'),
-            link_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.LEARN_MORE'),
-            link: 'https://cloudforet.io/docs/guides/cost-explorer/cost-analysis/',
-            thumbnail_url: 'img_landing_cost-explorer_cost-analysis.png',
-        },
-        {
-            name: i18n.t('MENU.COST_EXPLORER_BUDGET'),
-            description: i18n.t('BILLING.COST_MANAGEMENT.HOME.COST_BUDGET_DESC'),
-            link_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.LEARN_MORE'),
-            link: 'https://cloudforet.io/docs/guides/cost-explorer/budget/',
-            thumbnail_url: 'img_landing_cost-explorer_budget.png',
-        },
-    ],
-};
-
-export default {
-    name: 'CostExplorerHome',
-    components: {
-        PPaneLayout,
-        PLink,
-        PButton,
-    },
-    setup() {
-        return {
-            SERVICE_CONTENTS,
-            ACTION_ICON,
-        };
-    },
-};
-</script>
 <style lang="postcss" scoped>
 .service-home {
     max-width: 90rem;

--- a/apps/web/src/services/cost-explorer/CostExplorerHome.vue
+++ b/apps/web/src/services/cost-explorer/CostExplorerHome.vue
@@ -68,9 +68,9 @@ const SERVICE_CONTENTS = {
     topic: {
         title: i18n.t('BILLING.COST_MANAGEMENT.HOME.TITLE'),
         description: i18n.t('BILLING.COST_MANAGEMENT.HOME.TOPIC_DESC'),
-        button_link: 'https://help.spaceone.megazone.com/hc/ko',
-        button_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.ENABLE_BUTTON'),
-        link: 'https://help.spaceone.megazone.com/hc/ko',
+        button_link: 'https://spaceone.megazone.io/contact',
+        button_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.CONTACT_BUTTON'),
+        link: 'https://cloudforet.io/docs/guides/cost-explorer/',
         link_text: i18n.t('BILLING.COST_MANAGEMENT.HOME.MORE_INFO'),
         thumbnail_url: 'img_landing_cost-explorer_hero.png',
     },
@@ -113,7 +113,6 @@ export default {
     width: 100%;
     padding: 0 1.5rem;
     margin: 0 auto;
-    background: url('@/assets/images/landing/img_landing_cost-explorer_background.png') no-repeat 50% 0 / 90rem auto;
 }
 .service-topic {
     @apply flex;
@@ -149,7 +148,7 @@ export default {
     padding: 1rem;
     .sub-menu-card {
         @apply overflow-hidden relative bg-primary-4 rounded-md;
-        flex-basis: 33.33%;
+        flex-basis: 50%;
         min-height: 21.5625rem;
         .sub-menu-contents {
             min-height: 9.5625rem;

--- a/apps/web/src/services/cost-explorer/route-config.ts
+++ b/apps/web/src/services/cost-explorer/route-config.ts
@@ -12,4 +12,7 @@ export const COST_EXPLORER_ROUTE = Object.freeze({
         CREATE: { _NAME: `${MENU_ID.COST_EXPLORER_BUDGET}.create` },
         UPDATE: { _NAME: `${MENU_ID.COST_EXPLORER_BUDGET}.update` },
     },
+    LANDING: {
+        _NAME: MENU_ID.COST_EXPLORER_LANDING,
+    },
 });

--- a/apps/web/src/services/cost-explorer/routes.ts
+++ b/apps/web/src/services/cost-explorer/routes.ts
@@ -27,27 +27,6 @@ const costExplorerRoutes: RouteConfig = {
     meta: { menuId: MENU_ID.COST_EXPLORER, accessLevel: ACCESS_LEVEL.VIEW_PERMISSION },
     redirect: () => getRedirectRouteByPagePermission(MENU_ID.COST_EXPLORER, store.getters['user/pagePermissionMap']),
     component: CostExplorerContainer,
-    beforeEnter: async (to, from, next) => {
-        try {
-            const response = await SpaceConnector.clientV2.costAnalysis.dataSource.list();
-            const results = response?.results || [];
-            if (results.length === 0) {
-                next({ name: COST_EXPLORER_ROUTE.LANDING._NAME });
-            } else if (to.name === COST_EXPLORER_ROUTE.COST_ANALYSIS._NAME && !(to.params.dataSourceId && to.params.costQuerySetId)) {
-                next({
-                    name: COST_EXPLORER_ROUTE.COST_ANALYSIS.QUERY_SET._NAME,
-                    params: {
-                        dataSourceId: results[0].data_source_id,
-                        costQuerySetId: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
-                    },
-                });
-            } else {
-                next();
-            }
-        } catch (e) {
-            ErrorHandler.handleError(e);
-        }
-    },
     children: [
         {
             path: 'landing',
@@ -59,6 +38,27 @@ const costExplorerRoutes: RouteConfig = {
             path: 'cost-analysis',
             meta: { menuId: MENU_ID.COST_EXPLORER_COST_ANALYSIS },
             component: { template: '<router-view />' },
+            beforeEnter: async (to, from, next) => {
+                try {
+                    const response = await SpaceConnector.clientV2.costAnalysis.dataSource.list();
+                    const results = response?.results || [];
+                    if (results.length === 0) { // none-data-source case
+                        next({ name: COST_EXPLORER_ROUTE.LANDING._NAME });
+                    } else if (to.params.dataSourceId && to.params.costQuerySetId) {
+                        next();
+                    } else {
+                        next({
+                            name: COST_EXPLORER_ROUTE.COST_ANALYSIS.QUERY_SET._NAME,
+                            params: {
+                                dataSourceId: results[0].data_source_id,
+                                costQuerySetId: MANAGED_COST_QUERY_SET_IDS.MONTHLY_PROJECT,
+                            },
+                        });
+                    }
+                } catch (e) {
+                    ErrorHandler.handleError(e);
+                }
+            },
             children: [
                 {
                     path: '/',
@@ -82,6 +82,19 @@ const costExplorerRoutes: RouteConfig = {
             path: 'budget',
             meta: { menuId: MENU_ID.COST_EXPLORER_BUDGET },
             component: { template: '<router-view />' },
+            beforeEnter: async (to, from, next) => {
+                try {
+                    const response = await SpaceConnector.clientV2.costAnalysis.dataSource.list();
+                    const results = response?.results || [];
+                    if (results.length === 0) { // none-data-source case
+                        next({ name: COST_EXPLORER_ROUTE.LANDING._NAME });
+                    } else {
+                        next();
+                    }
+                } catch (e) {
+                    ErrorHandler.handleError(e);
+                }
+            },
             children: [
                 {
                     path: '/',

--- a/packages/language-pack/console-translation-2.8.babel
+++ b/packages/language-pack/console-translation-2.8.babel
@@ -13729,6 +13729,27 @@
                                 <name>HOME</name>
                                 <children>
                                     <concept_node>
+                                        <name>CONTACT_BUTTON</name>
+                                        <definition_loaded>false</definition_loaded>
+                                        <description/>
+                                        <comment/>
+                                        <default_text/>
+                                        <translations>
+                                            <translation>
+                                                <language>en-US</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                            <translation>
+                                                <language>ja-JP</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                            <translation>
+                                                <language>ko-KR</language>
+                                                <approved>false</approved>
+                                            </translation>
+                                        </translations>
+                                    </concept_node>
+                                    <concept_node>
                                         <name>COST_ANALYSIS_DESC</name>
                                         <definition_loaded>false</definition_loaded>
                                         <description/>
@@ -13737,15 +13758,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>true</approved>
+                                                <approved>false</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>true</approved>
+                                                <approved>false</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>true</approved>
+                                                <approved>false</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>

--- a/packages/language-pack/console-translation-2.8.babel
+++ b/packages/language-pack/console-translation-2.8.babel
@@ -13758,15 +13758,15 @@
                                         <translations>
                                             <translation>
                                                 <language>en-US</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ja-JP</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                             <translation>
                                                 <language>ko-KR</language>
-                                                <approved>false</approved>
+                                                <approved>true</approved>
                                             </translation>
                                         </translations>
                                     </concept_node>

--- a/packages/language-pack/en.json
+++ b/packages/language-pack/en.json
@@ -763,8 +763,8 @@
 			},
 			"HOME": {
 				"CONTACT_BUTTON": "Contact Us",
-				"COST_ANALYSIS_DESC": "Visualize your costs with various widgets and allocate spend across your organization.",
-				"COST_BUDGET_DESC": "Track your costs, usage, and coverage with \n custom budgets.",
+				"COST_ANALYSIS_DESC": "Explore your usage and costs while conducting analysis using various group-by options, filters, and granularity settings.",
+				"COST_BUDGET_DESC": "Set custom budgets and automatically generate notifications through various notification channels based on thresholds.",
 				"COST_DASHBOARD": "Cost Dashboard",
 				"COST_DASHBOARD_DESC": "Visualize your costs with various widgets\nand allocate spend across your organization.",
 				"ENABLE_BUTTON": "Enable Cost Explorer",

--- a/packages/language-pack/en.json
+++ b/packages/language-pack/en.json
@@ -762,7 +762,8 @@
 				"UPDATE_DASHBOARD": "Update Dashboard"
 			},
 			"HOME": {
-				"COST_ANALYSIS_DESC": "Explore granular cost breakdowns across \nall of your cloud resources.",
+				"CONTACT_BUTTON": "Contact Us",
+				"COST_ANALYSIS_DESC": "Visualize your costs with various widgets and allocate spend across your organization.",
 				"COST_BUDGET_DESC": "Track your costs, usage, and coverage with \n custom budgets.",
 				"COST_DASHBOARD": "Cost Dashboard",
 				"COST_DASHBOARD_DESC": "Visualize your costs with various widgets\nand allocate spend across your organization.",

--- a/packages/language-pack/ja.json
+++ b/packages/language-pack/ja.json
@@ -762,9 +762,9 @@
 				"UPDATE_DASHBOARD": "ダッシュボードの更新"
 			},
 			"HOME": {
-				"CONTACT_BUTTON": "",
-				"COST_ANALYSIS_DESC": "",
-				"COST_BUDGET_DESC": "各プロジェクト別に予算を設定し、リソース使用量を体系的に管理できます。",
+				"CONTACT_BUTTON": "お問い合わ",
+				"COST_ANALYSIS_DESC": "様々なグループ分けオプション、フィルター、粒度設定を使用して、使用状況とコストを探索し、分析を行います。",
+				"COST_BUDGET_DESC": "閾値に基づいて、カスタム予算を設定し、さまざまな通知チャンネルを介して自動的に通知を生成します。",
 				"COST_DASHBOARD": " 費用ダッシュボード",
 				"COST_DASHBOARD_DESC": "様々なウィジェットを費用管理ダッシュボードに追加して、素早くクラウド費用状況を把握できます。",
 				"ENABLE_BUTTON": "コストエクスプローラーの有効化",

--- a/packages/language-pack/ja.json
+++ b/packages/language-pack/ja.json
@@ -762,7 +762,8 @@
 				"UPDATE_DASHBOARD": "ダッシュボードの更新"
 			},
 			"HOME": {
-				"COST_ANALYSIS_DESC": "複数のクラウドリソースをグループ別に細分化し、より詳細にコスト分析が可能です。",
+				"CONTACT_BUTTON": "",
+				"COST_ANALYSIS_DESC": "",
 				"COST_BUDGET_DESC": "各プロジェクト別に予算を設定し、リソース使用量を体系的に管理できます。",
 				"COST_DASHBOARD": " 費用ダッシュボード",
 				"COST_DASHBOARD_DESC": "様々なウィジェットを費用管理ダッシュボードに追加して、素早くクラウド費用状況を把握できます。",

--- a/packages/language-pack/ko.json
+++ b/packages/language-pack/ko.json
@@ -762,7 +762,8 @@
 				"UPDATE_DASHBOARD": "대시보드 이름 변경"
 			},
 			"HOME": {
-				"COST_ANALYSIS_DESC": "여러 클라우드 리소스들을 그룹별로 세분화하여 보다 세밀하게 비용 분석이 가능합니다.",
+				"CONTACT_BUTTON": "",
+				"COST_ANALYSIS_DESC": "",
 				"COST_BUDGET_DESC": "각 프로젝트별 비용 예산을 설정하고 자원 사용량을 체계적으로 관리할 수 있습니다.",
 				"COST_DASHBOARD": "비용 대시보드",
 				"COST_DASHBOARD_DESC": "다양한 위젯들을 비용 관리 대시보드에 추가하여 빠르게 클라우드 비용 상태를 파악할 수 있습니다. ",

--- a/packages/language-pack/ko.json
+++ b/packages/language-pack/ko.json
@@ -762,9 +762,9 @@
 				"UPDATE_DASHBOARD": "대시보드 이름 변경"
 			},
 			"HOME": {
-				"CONTACT_BUTTON": "",
-				"COST_ANALYSIS_DESC": "",
-				"COST_BUDGET_DESC": "각 프로젝트별 비용 예산을 설정하고 자원 사용량을 체계적으로 관리할 수 있습니다.",
+				"CONTACT_BUTTON": "문의하기",
+				"COST_ANALYSIS_DESC": "비용 및 사용량을 탐색하고 다양한 Group-by 옵션, 필터 및 세분화 설정을 활용하여 분석할 수 있습니다.",
+				"COST_BUDGET_DESC": "조직의 구성에 맞게 사용자 정의 예산을 설정하고, 사용 상태에 따라 다양한 알림 채널로 자동 알림을 생성할 수 있습니다.",
 				"COST_DASHBOARD": "비용 대시보드",
 				"COST_DASHBOARD_DESC": "다양한 위젯들을 비용 관리 대시보드에 추가하여 빠르게 클라우드 비용 상태를 파악할 수 있습니다. ",
 				"ENABLE_BUTTON": "비용 관리 서비스 활성화",


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci` etc.)
- [x] Need discussion
- [ ] Not that difficult


### Description
Commit message says it all.

![image](https://github.com/cloudforet-io/console/assets/83635051/3e3d16c0-0d5d-479e-a34e-0a6c79fdb82b)


### Things to Talk About
I handled no-data-source case by using cost-explorer routes `beforeEnter`. How do you think about it?
