### PR TITLE
fix: fixing the checkId bug when adding a user

### DIFF
--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
@@ -5,7 +5,7 @@
                     :fade="true"
                     :backdrop="true"
                     :visible="userPageState.visibleUpdateModal || userPageState.visibleCreateModal"
-                    :disabled="formState.userId === '' || (formState.passwordManual && formState.password === '')"
+                    :disabled="formState.userId === '' || (formState.passwordManual && formState.password === '') || !validationState.isUserIdValid"
                     :loading="userPageState.modalLoading"
                     @confirm="confirm"
                     @cancel="handleClose"
@@ -20,6 +20,7 @@
             >
                 <div class="input-form-wrapper">
                     <user-info-form
+                        :is-user-id-valid.sync="validationState.isUserIdValid"
                         :active-tab="formState.activeTab"
                         @change-input="handleChangeInputs"
                     />
@@ -44,6 +45,7 @@
             <div v-else>
                 <div class="input-form-wrapper">
                     <user-info-form
+                        :is-user-id-valid.sync="validationState.isUserIdValid"
                         :active-tab="formState.activeTab"
                         :item="item"
                         @change-input="handleChangeInputs"
@@ -151,6 +153,10 @@ export default {
             tags: {},
         });
 
+        const validationState = reactive({
+            isUserIdValid: undefined as undefined | boolean,
+        });
+
         /* Components */
         const handleChangeInputs = (value) => {
             if (value.userId) {
@@ -255,6 +261,7 @@ export default {
             userPageState,
             state,
             formState,
+            validationState,
             confirm,
             handleClose,
             handleChangeInputs,

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
@@ -168,7 +168,9 @@ const initAuthTypeList = async () => {
                     :fade="true"
                     :backdrop="true"
                     :visible="userPageState.visibleUpdateModal || userPageState.visibleCreateModal"
-                    :disabled="formState.userId === '' || (formState.passwordManual && formState.password === '') || !validationState.isUserIdValid"
+                    :disabled="formState.userId === ''
+                        || (formState.passwordManual && formState.password === '')
+                        || (userPageState.visibleCreateModal && !validationState.isUserIdValid)"
                     :loading="userPageState.modalLoading"
                     @confirm="confirm"
                     @cancel="handleClose"

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/UserManagementModal.vue
@@ -1,3 +1,166 @@
+<script setup lang="ts">
+import { computed, reactive } from 'vue';
+
+import { PButtonModal, PBoxTab } from '@spaceone/design-system';
+
+import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+
+import { store } from '@/store';
+
+import ErrorHandler from '@/common/composables/error/errorHandler';
+
+import AdminRole from '@/services/administration/iam/user/modules/user-management-modal/modules/AdminRole.vue';
+import NotificationEmailForm
+    from '@/services/administration/iam/user/modules/user-management-modal/modules/NotificationEmailForm.vue';
+import PasswordForm from '@/services/administration/iam/user/modules/user-management-modal/modules/PasswordForm.vue';
+import Tags from '@/services/administration/iam/user/modules/user-management-modal/modules/Tags.vue';
+import UserInfoForm from '@/services/administration/iam/user/modules/user-management-modal/modules/UserInfoForm.vue';
+import type { User, UserManagementData } from '@/services/administration/iam/user/type';
+import { PASSWORD_TYPE, USER_BACKEND_TYPE, USER_TYPE } from '@/services/administration/iam/user/type';
+import { useUserPageStore } from '@/services/administration/store/user-page-store';
+
+interface Props {
+    headerTitle: string;
+    item?: User;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    headerTitle: '',
+    item: undefined,
+});
+
+const userPageStore = useUserPageStore();
+const userPageState = userPageStore.$state;
+
+const state = reactive({
+    data: {} as User,
+    selectedId: computed(() => props.item?.user_id),
+});
+
+const emit = defineEmits<{(e: 'confirm', data: UserManagementData, roleId: string|null): void; }>();
+
+const formState = reactive({
+    tabs: [
+        { name: 'local', label: 'Local' },
+        { name: 'apiOnly', label: 'API Only' },
+    ],
+    activeTab: '',
+    userId: '',
+    name: '',
+    email: '',
+    domainRole: '',
+    roleId: '',
+    password: '',
+    passwordType: '',
+    passwordManual: false,
+    tags: {},
+});
+
+const validationState = reactive({
+    isUserIdValid: undefined as undefined | boolean,
+});
+
+/* Components */
+const handleChangeInputs = (value) => {
+    if (value.userId) {
+        formState.userId = value.userId;
+        formState.email = value.userId;
+    }
+    if (value.tags) formState.tags = value.tags;
+    if (value.name) formState.name = value.name;
+    if (value.email) formState.email = value.email;
+    if (value.domainRoleList) {
+        formState.domainRole = value.domainRole;
+        formState.roleId = value.roleId;
+    }
+    if (value.password) {
+        formState.password = value.password || '';
+    }
+    if (value.passwordType) {
+        formState.passwordType = value.passwordType;
+    }
+};
+const handleClose = () => {
+    userPageStore.$patch({ visibleCreateModal: false, visibleUpdateModal: false });
+};
+const setForm = () => {
+    formState.userId = state.data.user_id;
+    formState.name = state.data.name;
+    formState.email = state.data.email || '';
+    formState.domainRole = props.item.domain_role || '';
+    formState.password = props.item.password || '';
+    formState.passwordManual = false;
+    formState.tags = state.data.tags || {};
+};
+const handleChangeVerify = (status) => {
+    state.data.email_verified = status;
+};
+
+/* API */
+const getUserDetailData = async (userId) => {
+    if (userId === undefined) return;
+    try {
+        state.data = await SpaceConnector.client.identity.user.get({
+            user_id: userId,
+        });
+    } catch (e) {
+        ErrorHandler.handleError(e);
+    }
+};
+const confirm = async () => {
+    const data: UserManagementData = {
+        user_id: formState.userId,
+        name: formState.name,
+        email: formState.email || formState.userId,
+        tags: formState.tags || {},
+        password: formState.password || '',
+    };
+    if (userPageState.visibleCreateModal) {
+        if (formState.activeTab === 'local') {
+            data.backend = USER_BACKEND_TYPE.LOCAL;
+        } else if (formState.activeTab === 'apiOnly') {
+            data.backend = USER_BACKEND_TYPE.LOCAL;
+            data.user_type = USER_TYPE.API_USER;
+        } else {
+            data.backend = USER_BACKEND_TYPE.EXTERNAL;
+        }
+    }
+    if (formState.activeTab === 'local' || userPageState.visibleUpdateModal) {
+        data.reset_password = formState.passwordType === PASSWORD_TYPE.RESET;
+    }
+
+    if (formState.domainRole !== undefined) {
+        emit('confirm', data, formState.roleId);
+    } else {
+        emit('confirm', data, null);
+    }
+};
+
+/* init */
+const initAuthTypeList = async () => {
+    if (store.state.domain.extendedAuthType !== undefined) {
+        formState.tabs = [
+            { name: 'external', label: store.getters['domain/extendedAuthTypeLabel'] },
+            ...formState.tabs,
+        ];
+        formState.activeTab = 'external';
+    } else {
+        formState.activeTab = 'local';
+    }
+};
+(async () => {
+    await Promise.allSettled([
+        initAuthTypeList(),
+        getUserDetailData(state.selectedId),
+        // LOAD REFERENCE STORE
+        store.dispatch('reference/user/load'),
+    ]);
+    if (userPageState.visibleUpdateModal) {
+        await setForm();
+    }
+})();
+</script>
+
 <template>
     <p-button-modal class="user-management-modal"
                     :header-title="headerTitle"
@@ -77,206 +240,6 @@
         </template>
     </p-button-modal>
 </template>
-
-<script lang="ts">
-import { computed, reactive } from 'vue';
-
-import { PButtonModal, PBoxTab } from '@spaceone/design-system';
-
-import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
-
-import { store } from '@/store';
-
-import ErrorHandler from '@/common/composables/error/errorHandler';
-
-import AdminRole from '@/services/administration/iam/user/modules/user-management-modal/modules/AdminRole.vue';
-import NotificationEmailForm
-    from '@/services/administration/iam/user/modules/user-management-modal/modules/NotificationEmailForm.vue';
-import PasswordForm from '@/services/administration/iam/user/modules/user-management-modal/modules/PasswordForm.vue';
-import Tags from '@/services/administration/iam/user/modules/user-management-modal/modules/Tags.vue';
-import UserInfoForm from '@/services/administration/iam/user/modules/user-management-modal/modules/UserInfoForm.vue';
-import type { User, UserManagementData } from '@/services/administration/iam/user/type';
-import { PASSWORD_TYPE, USER_BACKEND_TYPE, USER_TYPE } from '@/services/administration/iam/user/type';
-import { useUserPageStore } from '@/services/administration/store/user-page-store';
-
-export default {
-    name: 'UserCreateModal',
-    components: {
-        Tags,
-        AdminRole,
-        PasswordForm,
-        NotificationEmailForm,
-        UserInfoForm,
-        PButtonModal,
-        PBoxTab,
-    },
-    directives: {
-        focus: {
-            inserted(el) {
-                el.focus();
-            },
-        },
-    },
-    props: {
-        headerTitle: {
-            type: String,
-            required: true,
-        },
-        item: {
-            type: undefined as undefined | User,
-            default: undefined,
-        },
-    },
-    setup(props, { emit }) {
-        const userPageStore = useUserPageStore();
-        const userPageState = userPageStore.$state;
-
-        const state = reactive({
-            data: {} as User,
-            selectedId: computed(() => props.item?.user_id),
-        });
-
-        const formState = reactive({
-            tabs: [
-                { name: 'local', label: 'Local' },
-                { name: 'apiOnly', label: 'API Only' },
-            ],
-            activeTab: '',
-            userId: '',
-            name: '',
-            email: '',
-            domainRole: '' || undefined,
-            roleId: '',
-            password: '',
-            passwordType: '',
-            passwordManual: false,
-            tags: {},
-        });
-
-        const validationState = reactive({
-            isUserIdValid: undefined as undefined | boolean,
-        });
-
-        /* Components */
-        const handleChangeInputs = (value) => {
-            if (value.userId) {
-                formState.userId = value.userId;
-                formState.email = value.userId;
-            }
-            if (value.tags) formState.tags = value.tags;
-            if (value.name) formState.name = value.name;
-            if (value.email) formState.email = value.email;
-            if (value.domainRoleList) {
-                formState.domainRole = value.domainRole;
-                formState.roleId = value.roleId;
-            }
-            if (value.password) {
-                formState.password = value.password || '';
-            }
-            if (value.passwordType) {
-                formState.passwordType = value.passwordType;
-            }
-        };
-        const handleClose = () => {
-            userPageStore.$patch({ visibleCreateModal: false, visibleUpdateModal: false });
-        };
-        const setForm = () => {
-            formState.userId = state.data.user_id;
-            formState.name = state.data.name;
-            formState.email = state.data.email || '';
-            formState.domainRole = props.item.domain_role;
-            formState.password = props.item.password;
-            formState.passwordManual = false;
-            formState.tags = state.data.tags || {};
-        };
-        const handleChangeVerify = (status) => {
-            state.data.email_verified = status;
-        };
-
-        /* API */
-        const getUserDetailData = async (userId) => {
-            if (userId === undefined) return;
-            try {
-                state.data = await SpaceConnector.client.identity.user.get({
-                    user_id: userId,
-                });
-            } catch (e) {
-                ErrorHandler.handleError(e);
-            }
-        };
-        const confirm = async () => {
-            const data: UserManagementData = {
-                user_id: formState.userId,
-                name: formState.name,
-                email: formState.email || formState.userId,
-                tags: formState.tags || {},
-                password: formState.password || '',
-            };
-            if (userPageState.visibleCreateModal) {
-                if (formState.activeTab === 'local') {
-                    data.backend = USER_BACKEND_TYPE.LOCAL;
-                } else if (formState.activeTab === 'apiOnly') {
-                    data.backend = USER_BACKEND_TYPE.LOCAL;
-                    data.user_type = USER_TYPE.API_USER;
-                } else {
-                    data.backend = USER_BACKEND_TYPE.EXTERNAL;
-                }
-            }
-            if (formState.activeTab === 'local' || userPageState.visibleUpdateModal) {
-                data.reset_password = formState.passwordType === PASSWORD_TYPE.RESET;
-            }
-
-            if (formState.domainRole !== undefined) {
-                emit('confirm', data, formState.roleId);
-            } else {
-                emit('confirm', data, null);
-            }
-        };
-
-        /* init */
-        const initAuthTypeList = async () => {
-            if (store.state.domain.extendedAuthType !== undefined) {
-                formState.tabs = [
-                    { name: 'external', label: store.getters['domain/extendedAuthTypeLabel'] },
-                    ...formState.tabs,
-                ];
-                formState.activeTab = 'external';
-            } else {
-                formState.activeTab = 'local';
-            }
-        };
-        (async () => {
-            await Promise.allSettled([
-                initAuthTypeList(),
-                getUserDetailData(state.selectedId),
-                // LOAD REFERENCE STORE
-                store.dispatch('reference/user/load'),
-            ]);
-            if (userPageState.visibleUpdateModal) {
-                await setForm();
-            }
-        })();
-
-        return {
-            userPageState,
-            state,
-            formState,
-            validationState,
-            confirm,
-            handleClose,
-            handleChangeInputs,
-            handleChangeVerify,
-            USER_BACKEND_TYPE,
-            USER_TYPE,
-        };
-    },
-    computed: {
-        store() {
-            return store;
-        },
-    },
-};
-</script>
 
 <style lang="postcss">
 .user-management-modal {

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/UserInfoForm.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/UserInfoForm.vue
@@ -183,10 +183,12 @@ const handleClickCheckId = async () => {
 watch(() => props.activeTab, (after) => {
     if (after) {
         state.selectedItems = [];
-        formState.userId = '';
-        formState.name = '';
-        validationState.proxyIsUserIdValid = undefined;
-        emit('change-input', { ...formState });
+        if (userPageState.visibleCreateModal) {
+            formState.userId = '';
+            formState.name = '';
+            validationState.proxyIsUserIdValid = undefined;
+            emit('change-input', { ...formState });
+        }
     }
 }, { immediate: true });
 watch(() => state.searchText, (searchText) => {

--- a/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/UserInfoForm.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-modal/modules/UserInfoForm.vue
@@ -17,6 +17,7 @@ import { i18n } from '@/translations';
 import type { UserReferenceMap } from '@/store/modules/reference/user/type';
 
 import ErrorHandler from '@/common/composables/error/errorHandler';
+import { useProxyValue } from '@/common/composables/proxy-state';
 
 import type {
     Validation,
@@ -34,16 +35,20 @@ import type { ExternalMenuType } from '@/services/administration/type';
 interface Props {
     activeTab?: string;
     item?: User;
+    isUserIdValid?: boolean;
 }
 const props = withDefaults(defineProps<Props>(), {
     activeTab: '',
     item: undefined,
+    isUserIdValid: undefined,
 });
 
 const userPageStore = useUserPageStore();
 const userPageState = userPageStore.$state;
 
-const emit = defineEmits<{(e: 'change-input', formState): void}>();
+const emit = defineEmits<{(e: 'change-input', formState): void,
+    (e: 'update:is-user-id-valid', isUserIdValid: boolean): void,
+}>();
 
 const state = reactive({
     loading: false,
@@ -58,7 +63,7 @@ const formState = reactive({
     name: '',
 });
 const validationState = reactive({
-    isUserIdValid: undefined as undefined | boolean,
+    proxyIsUserIdValid: useProxyValue('isUserIdValid', props, emit),
     userIdInvalidText: '' as TranslateResult,
     userIdValidText: '' as TranslateResult,
 });
@@ -83,15 +88,21 @@ const setExternalMenuItems = (users) => {
 const handleDeleteSelectedExternalUser = () => {
     formState.userId = '';
     formState.name = '';
-    validationState.isUserIdValid = undefined;
+    validationState.proxyIsUserIdValid = undefined;
     validationState.userIdInvalidText = '';
 };
 const handleSelectExternalUser = async (userItem) => {
     await getExternalUser(userItem.name);
     await handleClickCheckId();
 };
-const handleChangeInput = () => {
+const handleChangeName = () => {
     emit('change-input', { ...formState, name: formState.name });
+};
+const handleChangeUserId = () => {
+    if (validationState.proxyIsUserIdValid) {
+        validationState.proxyIsUserIdValid = undefined;
+        validationState.userIdInvalidText = '';
+    }
 };
 const setForm = () => {
     formState.userId = props.item.user_id;
@@ -153,11 +164,11 @@ const handleClickCheckId = async () => {
         executeSpecificIDValidation()]);
     const invalidObj = validation.find((item) => item.invalidText.length > 0);
     if (!invalidObj) {
-        validationState.isUserIdValid = true;
+        validationState.proxyIsUserIdValid = true;
         validationState.userIdValidText = i18n.t('IDENTITY.USER.FORM.NAME_VALID');
         emit('change-input', { ...formState, userId: formState.userId });
     } else {
-        validationState.isUserIdValid = invalidObj.isValid;
+        validationState.proxyIsUserIdValid = invalidObj.isValid;
         validationState.userIdInvalidText = invalidObj.invalidText;
     }
 };
@@ -172,6 +183,10 @@ const handleClickCheckId = async () => {
 watch(() => props.activeTab, (after) => {
     if (after) {
         state.selectedItems = [];
+        formState.userId = '';
+        formState.name = '';
+        validationState.proxyIsUserIdValid = undefined;
+        emit('change-input', { ...formState });
     }
 }, { immediate: true });
 watch(() => state.searchText, (searchText) => {
@@ -187,9 +202,9 @@ watch(() => state.searchText, (searchText) => {
     <div class="user-info-form-wrapper">
         <p-field-group :label="$t('IDENTITY.USER.FORM.USER_ID')"
                        :required="true"
-                       :invalid="validationState.isUserIdValid === false"
+                       :invalid="validationState.proxyIsUserIdValid === false"
                        :invalid-text="validationState.userIdInvalidText"
-                       :valid="validationState.isUserIdValid"
+                       :valid="validationState.proxyIsUserIdValid"
                        :valid-text="validationState.userIdValidText"
         >
             <template v-if="props.activeTab === 'external'
@@ -227,8 +242,9 @@ watch(() => state.searchText, (searchText) => {
                                   v-focus
                                   placeholder="user@spaceone.io"
                                   :invalid="invalid"
-                                  :valid="validationState.isUserIdValid"
+                                  :valid="validationState.proxyIsUserIdValid"
                                   :disabled="userPageState.visibleUpdateModal"
+                                  @update:value="handleChangeUserId"
                     />
                     <p-button v-if="!userPageState.visibleUpdateModal"
                               style-type="secondary"
@@ -245,7 +261,7 @@ watch(() => state.searchText, (searchText) => {
         >
             <p-text-input v-model="formState.name"
                           class="text-input"
-                          @update:value="handleChangeInput"
+                          @update:value="handleChangeName"
             />
         </p-field-group>
     </div>

--- a/apps/web/src/services/administration/iam/user/type.ts
+++ b/apps/web/src/services/administration/iam/user/type.ts
@@ -50,6 +50,8 @@ export interface User extends UserData {
 	api_key_count?: number;
 	roles?: string[];
 	user_type?: UserType;
+	domain_role?: string;
+	password?: string;
 }
 
 export const USER_TYPE_LABEL = Object.freeze({


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [ ] Not that difficult
- [ ] Approved feature branch merge to master

### Description
A bug occurs when adding a user in 'Administration', where if the userID is checked and subsequently modified, the updated userID is not applied. To address this issue, I have modified it so that when the userID is changed, a recheck is required, and the confirm button remains disabled until the recheck is completed.

1. Enter userID and check.
<img width="819" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/a289b2e3-cd6f-4b2e-8f47-dcc86b8787df">

2. Edit userID after checking.
<img width="826" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/2aa345fc-440e-49be-a49c-8d624dc49b63">

### Things to Talk About
Plz check by commits!!