### PR TITLE
fix(custom-field-modal): fix key_depth calculation logic

### DIFF
--- a/apps/web/src/common/modules/custom-table/custom-field-modal/CustomFieldModal.vue
+++ b/apps/web/src/common/modules/custom-table/custom-field-modal/CustomFieldModal.vue
@@ -79,7 +79,7 @@
                             </p-button>
                         </h3>
                         <keep-alive>
-                            <select-cloud-service-tag-columns v-if="resourceType === 'inventory.CloudService'"
+                            <select-cloud-service-tag-columns v-if="isResourceTypeCloudService"
                                                               :options="options"
                                                               :is-server-page="isServerPage"
                                                               :selected-tag-keys="selectedTagKeys"
@@ -228,6 +228,7 @@ export default defineComponent<Props>({
                 return orderMap;
             }),
             isValid: computed(() => state.loading || state.selectedColumns.length > 0),
+            isResourceTypeCloudService: computed(() => props.resourceType === 'inventory.CloudService'),
         });
 
         const sortByRecommendation = () => {
@@ -326,7 +327,17 @@ export default defineComponent<Props>({
 
         const updateSelectedKeys = (keys: string[]) => {
             state.selectedColumns = keys.map((key) => {
-                if (key.startsWith(TAGS_PREFIX)) return { key, name: key.slice(TAGS_PREFIX.length), options: TAGS_OPTIONS } as DynamicField;
+                if (key.startsWith(TAGS_PREFIX)) {
+                    const name = key.slice(TAGS_PREFIX.length);
+                    return {
+                        key,
+                        name,
+                        options: {
+                            ...TAGS_OPTIONS,
+                            ...(!state.isResourceTypeCloudService && { key_depth: name.split('.').length }),
+                        },
+                    } as DynamicField;
+                }
                 return state.availableColumns.find((col) => col.key === key) ?? { key, name: key } as DynamicField;
             });
         };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [ ] Not that difficult
- [ ] Approved feature branch merge to master


### Description
[issue](https://pyengine.atlassian.net/browse/QUEST-814)

When customizing table fields, the depth option for keys was fixed. I have now modified it to align with the functionality.

### Things to Talk About
