### PR TITLE
refactor: use `dataField` and `parsedDataField` rather than `groupBy` & delete `groupBy` from widgetState, widget helpers

### DIFF
--- a/apps/web/src/services/dashboards/widgets/_base/base-count-of-findings/BaseCountOfFindingsWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/_base/base-count-of-findings/BaseCountOfFindingsWidget.vue
@@ -35,7 +35,7 @@ import type { Legend } from '@/services/dashboards/widgets/type';
 
 
 interface Data extends CloudServiceStatsModel {
-    [groupBy: string]: string | null | any;
+    [parsedDataField: string]: string | null | any;
     pass_finding_count: number;
     fail_finding_count: number;
 }
@@ -58,19 +58,9 @@ const { pageSize, thisPage } = useWidgetPagination(widgetState);
 const state = reactive({
     loading: true,
     data: null as Data[]|null,
-    groupByKey: computed<string|undefined>(() => {
-        // NOTE: When a dot(".") is included in the groupBy field, the API return value will only include the portion of the field that appears after the dot.
-        // ex. additional_info.service -> service
-        if (!widgetState.groupBy) return undefined;
-        const dotIndex = widgetState.groupBy.indexOf('.');
-        if (dotIndex !== -1) {
-            return widgetState.groupBy.slice(dotIndex + 1);
-        }
-        return widgetState.groupBy;
-    }),
-    groupByReferenceMap: computed<ReferenceMap>(() => {
-        if (!state.groupByKey || !props.allReferenceTypeInfo) return {};
-        return Object.values(props.allReferenceTypeInfo).find((info) => info.key === state.groupByKey)?.referenceMap ?? {};
+    dataFieldReferenceMap: computed<ReferenceMap>(() => {
+        if (!widgetState.dataField || !props.allReferenceTypeInfo) return {};
+        return Object.values(props.allReferenceTypeInfo).find((info) => info.key === widgetState.dataField)?.referenceMap ?? {};
     }),
     legends: computed<Legend[]>(() => {
         if (state.showPassFindings) {
@@ -84,7 +74,7 @@ const state = reactive({
         ];
     }),
     noData: computed(() => !state.data?.length),
-    chartData: computed<ChartData[]>(() => refineChartData(state.data, state.groupByKey, state.groupByReferenceMap)),
+    chartData: computed<ChartData[]>(() => refineChartData(state.data, widgetState.parsedDataField, state.dataFieldReferenceMap)),
     showPassFindings: computed(() => props.widgetConfigId === countOfPassAndFailFindingsWidgetConfig.widget_config_id),
     showNextPage: computed(() => !!state.data?.more),
 });
@@ -100,7 +90,7 @@ const fetchData = async (): Promise<Data[]> => {
         if (pageSize.value) apiQueryHelper.setPage(getPageStart(thisPage.value, pageSize.value), pageSize.value);
         const { status, response } = await fetchCloudServiceAnalyze({
             query: {
-                group_by: [widgetState.groupBy],
+                group_by: [widgetState.dataField],
                 fields: {
                     pass_finding_count: {
                         key: 'data.stats.findings.pass',
@@ -128,34 +118,34 @@ const fetchData = async (): Promise<Data[]> => {
 };
 
 /* Util */
-const refineChartData = (data: Data[], groupByKey: string|undefined, referenceMap: ReferenceMap): ChartData[] => {
-    if (!data?.length || !groupByKey) return [];
+const refineChartData = (data: Data[], parsedDataField: string|undefined, referenceMap: ReferenceMap): ChartData[] => {
+    if (!data?.length || !parsedDataField) return [];
 
     const refinedChartData: ChartData[] = [];
     data.forEach((d) => {
-        const rawValue = d[groupByKey];
+        const rawValue = d[parsedDataField];
         let refinedValue: string|null|undefined;
 
         // google_cloud -> Google Cloud
-        if (groupByKey === ASSET_DATA_FIELD_MAP.REGION.name) refinedValue = referenceMap[rawValue]?.name ?? rawValue;
+        if (parsedDataField === ASSET_DATA_FIELD_MAP.REGION.name) refinedValue = referenceMap[rawValue]?.name ?? rawValue;
         else refinedValue = referenceMap[rawValue]?.label ?? rawValue;
 
         refinedChartData.push({
             ...d,
-            [groupByKey]: refinedValue ?? `no_${groupByKey}`,
+            [parsedDataField]: refinedValue ?? `no_${parsedDataField}`,
         });
     });
     return refinedChartData;
 };
 const drawChart = (chartData: ChartData[]) => {
-    if (!state.groupByKey) {
-        console.error(new Error('groupByKey is undefined'));
+    if (!widgetState.parsedDataField) {
+        console.error(new Error('parsedDataField is undefined'));
         return;
     }
 
     // create chart and axis
     const { chart, xAxis, yAxis } = chartHelper.createXYHorizontalChart();
-    yAxis.set('categoryField', state.groupByKey);
+    yAxis.set('categoryField', widgetState.parsedDataField);
     yAxis.data.setAll(cloneDeep(chartData));
 
     // create legends
@@ -172,7 +162,7 @@ const drawChart = (chartData: ChartData[]) => {
         const seriesSettings: Partial<am5xy.IXYSeriesSettings> = {
             name: legend.label as string,
             valueXField: legend.name,
-            categoryYField: state.groupByKey,
+            categoryYField: widgetState.parsedDataField,
             xAxis,
             yAxis,
             baseAxis: yAxis,

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-data-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-data-helper.ts
@@ -11,8 +11,8 @@ interface RawData {
 }
 
 interface RefineOptions<T extends RawData, S extends RawData> {
-    groupBy?: keyof S & keyof T; // if given, set the value to the groupBy property. { [groupBy]: valueData }
-    allReferenceTypeInfo?: AllReferenceTypeInfo; // if both this and groupBy are given, get groupBy label and set the value to the label property. { [groupByLabel]: valueData }
+    dataField?: keyof S & keyof T; // if given, set the value to the dataField property. { [dataField]: valueData }
+    allReferenceTypeInfo?: AllReferenceTypeInfo; // if both this and dataField are given, get dataField label and set the value to the label property. { [dataFieldLabel]: valueData }
     arrayDataKey: keyof T|(keyof T)[]; // = 'cost_sum' or ['cost_sum', 'budget_sum']
     categoryKey: keyof S; // merge by this key.  = 'date' pr ['date', 'Usage Type Details']
     valueKey: keyof S // 'value'
@@ -34,19 +34,19 @@ export const getRefinedXYChartData = <T extends RawData, S extends RawData>(
 
 
     const {
-        groupBy, allReferenceTypeInfo, categoryKey, isHorizontal,
+        dataField, allReferenceTypeInfo, categoryKey, isHorizontal,
     } = options;
 
     let chartData: S[] = [];
     rawData.forEach((data) => {
-        const dataFieldLabel = groupBy ? getGroupByLabel<T, S>(data, groupBy, allReferenceTypeInfo) : undefined;
+        const dataFieldLabel = dataField ? getDataFieldLabel<T, S>(data, dataField, allReferenceTypeInfo) : undefined;
         chartData = isHorizontal
             ? mergeRefinedHorizontalXYChartData(chartData, data, options, dataFieldLabel)
             : mergeRefinedXYChartData(chartData, data, options, dataFieldLabel);
     });
     return sortBy(chartData, categoryKey);
 };
-const mergeRefinedXYChartData = <T extends RawData, S extends RawData>(chartData: S[], data: T, options: RefineOptions<T, S>, groupByLabel: keyof S|undefined): S[] => {
+const mergeRefinedXYChartData = <T extends RawData, S extends RawData>(chartData: S[], data: T, options: RefineOptions<T, S>, dataFieldLabel: keyof S|undefined): S[] => {
     const {
         arrayDataKey, categoryKey, valueKey, useDataKeyAsRefinedValue, additionalIncludeKeys, additionalIncludeKeysFromParent,
     } = options;
@@ -54,7 +54,7 @@ const mergeRefinedXYChartData = <T extends RawData, S extends RawData>(chartData
     let mergedChartData = chartData;
     arrayDataKeys.forEach((arrDataKey) => { // [{date: '2022-11', value: 34}, ...]
         const arrayData = data[arrDataKey];
-        const valueSetKey = useDataKeyAsRefinedValue ? (arrDataKey as keyof S) : groupByLabel ?? valueKey;
+        const valueSetKey = useDataKeyAsRefinedValue ? (arrDataKey as keyof S) : dataFieldLabel ?? valueKey;
         const refinedList: S[] = arrayData?.map((valueSet) => {
             const refined = {
                 [valueSetKey]: valueSet[valueKey],
@@ -76,12 +76,12 @@ const mergeByKey = <S extends RawData>(arrA: S[], arrB: S[], key: keyof S): S[] 
     const merged = merge(keyBy(arrA, key), keyBy(arrB, key));
     return values(merged) as S[];
 };
-const mergeRefinedHorizontalXYChartData = <T extends RawData, S extends RawData>(chartData: S[], data: T, options: RefineOptions<T, S>, groupByLabel: keyof S|undefined): S[] => {
+const mergeRefinedHorizontalXYChartData = <T extends RawData, S extends RawData>(chartData: S[], data: T, options: RefineOptions<T, S>, dataFieldLabel: keyof S|undefined): S[] => {
     const {
-        groupBy, arrayDataKey, categoryKey, valueKey, additionalIncludeKeysFromParent,
+        dataField, arrayDataKey, categoryKey, valueKey, additionalIncludeKeysFromParent,
     } = options;
-    if (!groupBy) {
-        console.error(Error('groupBy is required for horizontal chart.'));
+    if (!dataField) {
+        console.error(Error('dataField is required for horizontal chart.'));
         return [];
     }
     const arrayDataKeys = Array.isArray(arrayDataKey) ? arrayDataKey : [arrayDataKey];
@@ -95,7 +95,7 @@ const mergeRefinedHorizontalXYChartData = <T extends RawData, S extends RawData>
             refinedChartItem = {
                 ...refinedChartItem,
                 [valueSet[categoryKey] as string]: valueSet[valueKey],
-                [groupBy]: groupByLabel,
+                [dataField]: dataFieldLabel,
             };
 
             if (additionalIncludeKeysFromParent) {
@@ -109,17 +109,17 @@ const mergeRefinedHorizontalXYChartData = <T extends RawData, S extends RawData>
     });
     return mergedChartData;
 };
-const getGroupByLabel = <T extends RawData, S extends RawData>(data: T, groupBy: keyof T, allReferenceTypeInfo?: AllReferenceTypeInfo): keyof S => {
-    const referenceMap = Object.values(allReferenceTypeInfo ?? {}).find((info) => info.key === groupBy)?.referenceMap;
-    const resourceValue = data[groupBy];
+const getDataFieldLabel = <T extends RawData, S extends RawData>(data: T, dataField: keyof T, allReferenceTypeInfo?: AllReferenceTypeInfo): keyof S => {
+    const referenceMap = Object.values(allReferenceTypeInfo ?? {}).find((info) => info.key === dataField)?.referenceMap;
+    const resourceValue = data[dataField];
     if (resourceValue) return referenceMap?.[resourceValue]?.label ?? resourceValue; // AmazonCloudFront
-    return `no_${groupBy as string}`;
+    return `no_${dataField as string}`;
 };
 
 
 
 type AppendedData<T> = T & {
-    [groupBy: string]: string | any;
+    [dataField: string]: string | any;
 };
 /**
  * @name getRefinedPieChartData
@@ -129,15 +129,15 @@ type AppendedData<T> = T & {
  */
 export const getRefinedPieChartData = <T extends RawData = RawData>(
     rawData: T[],
-    groupBy: CostDataField,
+    dataField: CostDataField,
     allReferenceTypeInfo: AllReferenceTypeInfo,
 ): AppendedData<T>[] => {
-    if (!rawData || !groupBy) return [];
+    if (!rawData || !dataField) return [];
 
     const chartData: AppendedData<T>[] = [];
     rawData.forEach((d) => {
-        let _name = d[groupBy];
-        const referenceTypeInfo = Object.values(allReferenceTypeInfo).find((info) => info.key === groupBy);
+        let _name = d[dataField];
+        const referenceTypeInfo = Object.values(allReferenceTypeInfo).find((info) => info.key === dataField);
         if (_name && referenceTypeInfo) {
             const referenceMap = referenceTypeInfo.referenceMap;
             _name = referenceMap[_name]?.label ?? referenceMap[_name]?.name ?? _name;
@@ -146,7 +146,7 @@ export const getRefinedPieChartData = <T extends RawData = RawData>(
         }
         chartData.push({
             ...d,
-            [groupBy]: _name,
+            [dataField]: _name,
         } as AppendedData<T>);
     });
     return chartData;

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-chart-helper.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import type { AllReferenceTypeInfo } from '@/store/reference/all-reference-store';
 
 import type { DateRange } from '@/services/dashboards/config';
-import type { CostDataField } from '@/services/dashboards/widgets/_configs/config';
+import type { DataField } from '@/services/dashboards/widgets/_configs/config';
 import { COST_DATA_FIELD_MAP } from '@/services/dashboards/widgets/_configs/config';
 import type {
     Legend,
@@ -21,25 +21,25 @@ interface RawData {
  */
 export const getXYChartLegends = <T = Record<string, any>>(
     rawData?: T[],
-    groupBy?: string,
+    dataField?: string,
     allReferenceTypeInfo?: AllReferenceTypeInfo,
     disableReferenceColor = false,
 ): Legend[] => {
-    if (!rawData || !groupBy) return [];
+    if (!rawData || !dataField) return [];
     const legends: Legend[] = [];
     rawData.forEach((d) => {
-        let _name = d[groupBy];
-        let _label = d[groupBy];
+        let _name = d[dataField];
+        let _label = d[dataField];
         let _color;
-        const referenceTypeInfo = Object.values(allReferenceTypeInfo ?? {}).find((info) => info.key === groupBy);
+        const referenceTypeInfo = Object.values(allReferenceTypeInfo ?? {}).find((info) => info.key === dataField);
         if (_name && referenceTypeInfo) {
             const referenceMap = referenceTypeInfo.referenceMap;
             _label = referenceMap[_name]?.label ?? referenceMap[_name]?.name ?? _name;
-            if (groupBy === COST_DATA_FIELD_MAP.PROVIDER.name && !disableReferenceColor) {
+            if (dataField === COST_DATA_FIELD_MAP.PROVIDER.name && !disableReferenceColor) {
                 _color = referenceMap[_name]?.color;
             }
         } else if (!_name) {
-            _name = `no_${groupBy}`;
+            _name = `no_${dataField}`;
             _label = 'Unknown';
         }
         legends.push({
@@ -52,9 +52,9 @@ export const getXYChartLegends = <T = Record<string, any>>(
     return legends;
 };
 
-export const getPieChartLegends = (rawData: RawData[], groupBy?: string): Legend[] => {
-    if (!rawData || !groupBy) return [];
-    return rawData.map((d) => ({ name: d[groupBy], disabled: false }));
+export const getPieChartLegends = (rawData: RawData[], dataField?: string): Legend[] => {
+    if (!rawData || !dataField) return [];
+    return rawData.map((d) => ({ name: d[dataField], disabled: false }));
 };
 
 export const getDateAxisSettings = (dateRange: DateRange): Partial<IDateAxisSettings<any>> => {
@@ -68,7 +68,7 @@ export const getDateAxisSettings = (dateRange: DateRange): Partial<IDateAxisSett
 
 
 type AppendedData<T> = T & {
-    [groupBy: string]: string | any;
+    [dataField: string]: string | any;
 };
 /**
  * @name getRefinedPieChartData
@@ -78,15 +78,15 @@ type AppendedData<T> = T & {
  */
 export const getRefinedPieChartData = <T extends RawData = RawData>(
     rawData: T[],
-    groupBy: CostDataField,
+    dataField: DataField,
     allReferenceTypeInfo: AllReferenceTypeInfo,
 ): AppendedData<T>[] => {
-    if (!rawData || !groupBy) return [];
+    if (!rawData || !dataField) return [];
 
     const chartData: AppendedData<T>[] = [];
     rawData.forEach((d) => {
-        let _name = d[groupBy];
-        const referenceTypeInfo = Object.values(allReferenceTypeInfo).find((info) => info.key === groupBy);
+        let _name = d[dataField];
+        const referenceTypeInfo = Object.values(allReferenceTypeInfo).find((info) => info.key === dataField);
         if (_name && referenceTypeInfo) {
             const referenceMap = referenceTypeInfo.referenceMap;
             _name = referenceMap[_name]?.label ?? referenceMap[_name]?.name ?? _name;
@@ -95,7 +95,7 @@ export const getRefinedPieChartData = <T extends RawData = RawData>(
         }
         chartData.push({
             ...d,
-            [groupBy]: _name,
+            [dataField]: _name,
         } as AppendedData<T>);
     });
     return chartData;

--- a/apps/web/src/services/dashboards/widgets/_helpers/widget-table-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/_helpers/widget-table-helper.ts
@@ -99,8 +99,8 @@ export const sortTableData = <Data extends RawData = RawData>(
     targetFieldKeys: string[] = ['cost_sum', 'usage_quantity_sum'],
 ): Data[] => sortArrayInObjectArray<Data>(rawData, sortKey, targetFieldKeys);
 
-export const getReferenceTypeOfGroupBy = (allReferenceTypeInfo: AllReferenceTypeInfo, groupBy: DataField): ReferenceType | undefined => {
-    const referenceTypeInfo = Object.values(allReferenceTypeInfo).find((info) => info.key === groupBy);
+export const getReferenceTypeOfDataField = (allReferenceTypeInfo: AllReferenceTypeInfo, dataField: DataField): ReferenceType | undefined => {
+    const referenceTypeInfo = Object.values(allReferenceTypeInfo).find((info) => info.key === dataField);
     if (referenceTypeInfo) return referenceTypeInfo.type;
     return undefined;
 };

--- a/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-widget-state.ts
+++ b/apps/web/src/services/dashboards/widgets/_hooks/use-widget/use-widget-state.ts
@@ -45,8 +45,6 @@ import type { ChartType } from '@/services/dashboards/widgets/type';
 export interface WidgetState extends MergedWidgetState {
     granularity: ComputedRef<Granularity|undefined>;
     chartType: ComputedRef<ChartType|undefined>;
-    // TODO: remove groupBy
-    groupBy: ComputedRef<CostDataField|AssetDataField|undefined>;
     dataField: ComputedRef<CostDataField|AssetDataField|undefined>;
     secondaryDataField: ComputedRef<CostDataField|AssetDataField|undefined>;
     parsedDataField: ComputedRef<string>; // remove dots from dataField e.g. additional_info.Usage Type Details -> Usage Type Details
@@ -101,9 +99,9 @@ export function useWidgetState(props: WidgetProps) {
             };
         }),
         costWidgetLocation: computed<Location|undefined>(() => {
-            const groupBy: string[] = [];
-            if (state.dataField) groupBy.push(state.dataField);
-            if (state.secondaryDataField) groupBy.push(state.secondaryDataField);
+            const dataField: string[] = [];
+            if (state.dataField) dataField.push(state.dataField);
+            if (state.secondaryDataField) dataField.push(state.secondaryDataField);
             const location: Location = {
                 name: COST_EXPLORER_ROUTE.COST_ANALYSIS.QUERY_SET._NAME,
                 params: {
@@ -112,7 +110,7 @@ export function useWidgetState(props: WidgetProps) {
                 },
                 query: {
                     granularity: primitiveToQueryString(state.granularity),
-                    group_by: arrayToQueryString(groupBy),
+                    group_by: arrayToQueryString(dataField),
                     period: objectToQueryString(state.dateRange),
                     filters: arrayToQueryString(getWidgetLocationFilters(baseState.options.filters)),
                 },
@@ -146,11 +144,6 @@ export function useWidgetState(props: WidgetProps) {
         ...toRefs(baseState) as MergedWidgetState,
         granularity: computed(() => baseState.options?.granularity),
         chartType: computed<ChartType|undefined>(() => baseState.options?.chart_type),
-        groupBy: computed(() => {
-            if (baseState.widgetConfig.labels?.includes('Cost')) return baseState.options?.cost_data_field;
-            if (baseState.widgetConfig.labels?.includes('Asset')) return baseState.options?.asset_data_field;
-            return undefined;
-        }),
         dataField: computed(() => {
             if (baseState.widgetConfig.labels?.includes('Cost')) return baseState.options?.cost_data_field;
             if (baseState.widgetConfig.labels?.includes('Asset')) return baseState.options?.asset_data_field;

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/aws-data-transfer-by-region/AWSDataTransferByRegionWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/aws-data-transfer-by-region/AWSDataTransferByRegionWidget.vue
@@ -104,7 +104,7 @@ const state = reactive({
     loading: true,
     data: null as FullData | null,
     fieldsKey: computed<'cost'|'usage_quantity'>(() => (selectedSelectorType.value === 'cost' ? 'cost' : 'usage_quantity')),
-    legends: computed<Legend[]>(() => (state.data?.results ? getPieChartLegends(state.data.results, widgetState.groupBy) : [])),
+    legends: computed<Legend[]>(() => (state.data?.results ? getPieChartLegends(state.data.results, widgetState.parsedDataField) : [])),
     chartData: computed<CircleData[]>(() => getRefinedCircleData(state.data?.results, props.allReferenceTypeInfo?.region?.referenceMap as RegionReferenceMap)),
     tableData: computed<TableData[]>(() => {
         if (!state.data?.results?.length) return [];
@@ -136,14 +136,14 @@ const state = reactive({
         });
 
         // set width of table fields
-        const groupByFieldWidth = dynamicTableFields.length > 4 ? '28%' : '34%';
+        const dataFieldTableFieldWidth = dynamicTableFields.length > 4 ? '28%' : '34%';
         const otherFieldWidth = dynamicTableFields.length > 4 ? '18%' : '22%';
 
         const fixedFields: Field[] = [{
             label: 'Region',
             name: COST_DATA_FIELD_MAP.REGION.name,
             textOptions: { type: 'reference', referenceType: 'region' },
-            width: groupByFieldWidth,
+            width: dataFieldTableFieldWidth,
         }];
         return [
             ...fixedFields,
@@ -196,16 +196,16 @@ const fetchData = async (): Promise<FullData> => {
         apiQueryHelper.setFilters(widgetState.consoleFilters);
         if (pageSize.value) apiQueryHelper.setPage(getPageStart(thisPage.value, pageSize.value), pageSize.value);
 
-        const groupBy = [COST_DATA_FIELD_MAP.REGION.name, USAGE_TYPE_QUERY_KEY];
+        const dataField = [COST_DATA_FIELD_MAP.REGION.name, USAGE_TYPE_QUERY_KEY];
         if (state.fieldsKey === 'usage_quantity') {
-            groupBy.push('usage_unit');
+            dataField.push('usage_unit');
         }
 
         const { status, response } = await fetchCostAnalyze({
             data_source_id: widgetState.options.cost_data_source,
             query: {
                 granularity: widgetState.granularity,
-                group_by: groupBy,
+                group_by: dataField,
                 start: widgetState.dateRange.start,
                 end: widgetState.dateRange.end,
                 fields: {

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/budget-status/BudgetStatusWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/budget-status/BudgetStatusWidget.vue
@@ -83,7 +83,7 @@ const fetchData = async (): Promise<Response|undefined> => {
             data_source_id: widgetState.options.cost_data_source,
             query: {
                 granularity: widgetState.granularity,
-                group_by: [widgetState.groupBy, 'name'],
+                group_by: [widgetState.dataField, 'name'],
                 start: widgetState.dateRange.start,
                 end: widgetState.dateRange.end,
                 fields: {

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/cost-by-region/CostByRegionWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/cost-by-region/CostByRegionWidget.vue
@@ -63,7 +63,7 @@ const { widgetState, widgetFrameProps, widgetFrameEventHandlers } = useWidget(pr
             },
             query: {
                 granularity: primitiveToQueryString(GRANULARITY.DAILY),
-                group_by: arrayToQueryString([widgetState.groupBy]),
+                group_by: arrayToQueryString([widgetState.dataField]),
                 period: objectToQueryString(widgetState.dateRange),
                 filters: arrayToQueryString(getWidgetLocationFilters(widgetState.options.filters)),
             },
@@ -112,7 +112,7 @@ const fetchData = async (): Promise<FullData> => {
             data_source_id: widgetState.options.cost_data_source,
             query: {
                 granularity: widgetState.granularity,
-                group_by: [widgetState.groupBy, COST_DATA_FIELD_MAP.PROVIDER.name],
+                group_by: [widgetState.dataField, COST_DATA_FIELD_MAP.PROVIDER.name],
                 start: widgetState.dateRange.start,
                 end: widgetState.dateRange.end,
                 fields: {

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/cost-by-region/cost-by-region-data-hleper.ts
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/cost-by-region/cost-by-region-data-hleper.ts
@@ -10,7 +10,7 @@ export interface Data {
     cost_sum: { date: string; value: number }[];
     _total_cost_sum: number;
     provider: string;
-    [groupBy: string]: any;
+    [dataField: string]: any;
 }
 
 export const getRefinedMapChartData = (results: Data[]|null, regions: RegionReferenceMap, providers: ProviderReferenceMap): MapChartData[] => {

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/cost-map/CostMapWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/cost-map/CostMapWidget.vue
@@ -61,7 +61,7 @@ const { widgetState, widgetFrameProps, widgetFrameEventHandlers } = useWidget(pr
             },
             query: {
                 granularity: primitiveToQueryString(GRANULARITY.DAILY),
-                group_by: arrayToQueryString([widgetState.groupBy]),
+                group_by: arrayToQueryString([widgetState.dataField]),
                 period: objectToQueryString(widgetState.dateRange),
                 filters: arrayToQueryString(getWidgetLocationFilters(widgetState.options.filters)),
             },
@@ -74,7 +74,7 @@ const state = reactive({
     data: null as AnalyzeRawData[] | null,
     chartData: computed<TreemapChartData[]>(() => {
         if (!state.data) return [];
-        return getRefinedTreemapChartData(state.data, widgetState.groupBy as CostDataField, props.allReferenceTypeInfo);
+        return getRefinedTreemapChartData(state.data, widgetState.parsedDataField as CostDataField, props.allReferenceTypeInfo);
     }),
 });
 
@@ -91,7 +91,7 @@ const fetchData = async (): Promise<AnalyzeRawData[]|null> => {
                 granularity: widgetState.granularity,
                 start: widgetState.dateRange.start,
                 end: widgetState.dateRange.end,
-                group_by: [widgetState.groupBy],
+                group_by: [widgetState.dataField],
                 fields: {
                     cost_sum: {
                         key: 'cost',

--- a/apps/web/src/services/dashboards/widgets/cost-widgets/cost-map/costmap-chart-data-helper.ts
+++ b/apps/web/src/services/dashboards/widgets/cost-widgets/cost-map/costmap-chart-data-helper.ts
@@ -7,16 +7,16 @@ import type { CostDataField } from '@/services/dashboards/widgets/_configs/confi
  * @name getRefinedTreemapChartData
  * @description Convert raw data to TreemapChart data.
  */
-export const getRefinedTreemapChartData = (rawDataList: AnalyzeRawData[], groupBy: CostDataField|undefined, allReferenceTypeInfo: AllReferenceTypeInfo) => {
+export const getRefinedTreemapChartData = (rawDataList: AnalyzeRawData[], dataField: CostDataField|undefined, allReferenceTypeInfo: AllReferenceTypeInfo) => {
     const chartData: TreemapChartData[] = [{
         children: [],
     }];
-    if (!rawDataList || !groupBy) return [];
+    if (!rawDataList || !dataField) return [];
 
-    const referenceMap = Object.values(allReferenceTypeInfo).find((info) => info.key === groupBy)?.referenceMap;
+    const referenceMap = Object.values(allReferenceTypeInfo).find((info) => info.key === dataField)?.referenceMap;
     rawDataList.forEach((rawData) => {
-        const groupByValue = rawData[groupBy];
-        const label = convertValueToLabel(groupByValue, referenceMap);
+        const dataFieldValue = rawData[dataField];
+        const label = convertValueToLabel(dataFieldValue, referenceMap);
 
         chartData[0].children.push({
             ...rawData,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [ ] Not that difficult
- [ ] Approved feature branch merge to master


### Description
`groupBy` -> `dataField` / `parsedDataField`

Please see order by commits!

### Things to Talk About
