### PR TITLE
refactor: change to setup store to use composable in widget-form-store

### DIFF
--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-add-modal/DashboardWidgetAddModal.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-add-modal/DashboardWidgetAddModal.vue
@@ -25,7 +25,9 @@ const emit = defineEmits<{(e: 'update:visible', visible: boolean): void;
     (e: 'add-widget', dashboardLayoutWidgetInfo: DashboardLayoutWidgetInfo): void;
 }>();
 const widgetFormStore = useWidgetFormStore();
-const widgetFormState = widgetFormStore.$state;
+const widgetFormState = widgetFormStore.state;
+const widgetFormGetters = widgetFormStore.getters;
+
 const state = reactive({
     proxyVisible: useProxyValue('visible', props, emit),
 });
@@ -38,14 +40,14 @@ const tabState = reactive({
 });
 
 const handleConfirm = () => {
-    if (!widgetFormState.widgetConfigId || !widgetFormState.widgetTitle) return;
+    if (!widgetFormState.widgetConfigId || !widgetFormGetters.title) return;
     const widgetConfig = getWidgetConfig(widgetFormState.widgetConfigId);
     const dashboardLayoutWidgetInfo: DashboardLayoutWidgetInfo = {
         widget_key: uuidv4(),
         widget_name: widgetFormState.widgetConfigId,
         size: widgetConfig.sizes[0],
         version: '1', // TODO: auto?
-        ...widgetFormStore.updatedWidgetInfo,
+        ...widgetFormGetters.updatedWidgetInfo,
     };
     emit('add-widget', dashboardLayoutWidgetInfo);
     state.proxyVisible = false;
@@ -58,7 +60,7 @@ const handleConfirm = () => {
                     :header-title="$t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.TITLE')"
                     size="lg"
                     class="dashboard-add-widget-modal"
-                    :disabled="!widgetFormStore.isAllValid"
+                    :disabled="!widgetFormGetters.isAllValid"
                     @confirm="handleConfirm"
     >
         <template #body>

--- a/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-add-modal/DashboardWidgetAddModal.vue
+++ b/apps/web/src/services/dashboards/dashboard-customize/modules/dashboard-widget-add-modal/DashboardWidgetAddModal.vue
@@ -58,7 +58,7 @@ const handleConfirm = () => {
                     :header-title="$t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.TITLE')"
                     size="lg"
                     class="dashboard-add-widget-modal"
-                    :disabled="!widgetFormState.isValid"
+                    :disabled="!widgetFormStore.isAllValid"
                     @confirm="handleConfirm"
     >
         <template #body>

--- a/apps/web/src/services/dashboards/shared/DashboardWidgetEditModal.vue
+++ b/apps/web/src/services/dashboards/shared/DashboardWidgetEditModal.vue
@@ -23,13 +23,14 @@ interface EmitFn {
 const emit = defineEmits<EmitFn>();
 const props = defineProps<Props>();
 const widgetFormStore = useWidgetFormStore();
-const widgetFormState = widgetFormStore.$state;
+const widgetFormState = widgetFormStore.state;
+const widgetFormGetters = widgetFormStore.getters;
 
 const handleEditModalCancel = () => {
     emit('cancel');
 };
 const handleEditModalConfirm = () => {
-    emit('confirm', widgetFormStore.updatedWidgetInfo);
+    emit('confirm', widgetFormGetters.updatedWidgetInfo);
 };
 </script>
 

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-container/WidgetViewModeSidebar.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-container/WidgetViewModeSidebar.vue
@@ -41,7 +41,9 @@ const emit = defineEmits<{(e: 'close', save: boolean): void;
 const dashboardDetailStore = useDashboardDetailInfoStore();
 const dashboardDetailState = dashboardDetailStore.$state;
 const widgetFormStore = useWidgetFormStore();
-const widgetFormState = widgetFormStore.$state;
+const widgetFormState = widgetFormStore.state;
+const widgetFormGetters = widgetFormStore.getters;
+
 const state = reactive({
     nonInheritedOptionModalVisible: false,
     hasNonInheritedWidgetOptions: computed<boolean>(() => {
@@ -58,7 +60,7 @@ const state = reactive({
 /* Util */
 const updateDashboardWidgetStore = () => {
     // update widget info in dashboard detail store
-    if (widgetFormStore.updatedWidgetInfo) dashboardDetailStore.updateWidgetInfo(props.widgetKey, widgetFormStore.updatedWidgetInfo);
+    if (widgetFormGetters.updatedWidgetInfo) dashboardDetailStore.updateWidgetInfo(props.widgetKey, widgetFormGetters.updatedWidgetInfo);
 };
 
 /* Api */
@@ -95,7 +97,7 @@ const handleCloseSidebar = () => {
     emit('close', false);
 };
 
-debouncedWatch(() => widgetFormStore.updatedWidgetInfo, (after, before) => {
+debouncedWatch(() => widgetFormGetters.updatedWidgetInfo, (after, before) => {
     if (before === undefined || isEqual(after, before)) return;
     emit('update:widget-info', after as UpdatableWidgetInfo);
 }, { debounce: 150 });
@@ -140,7 +142,7 @@ watch(() => props.visible, (value) => {
                         {{ $t('DASHBOARDS.FULL_SCREEN_VIEW.CANCEL') }}
                     </p-button>
                     <p-button style-type="primary"
-                              :disabled="!widgetFormStore.isAllValid"
+                              :disabled="!widgetFormGetters.isAllValid"
                               @click="handleClickSaveButton"
                     >
                         {{ $t('DASHBOARDS.FULL_SCREEN_VIEW.SAVE') }}

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetForm.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetForm.vue
@@ -7,9 +7,6 @@ import {
     PFieldGroup, PTextInput,
 } from '@spaceone/design-system';
 
-import {
-    useWidgetTitleInput,
-} from '@/services/dashboards/shared/dashboard-widget-input-form/composables/use-widget-title-input';
 import DashboardWidgetOptionsForm
     from '@/services/dashboards/shared/dashboard-widget-input-form/dashboard-widget-options-form/DashboardWidgetOptionsForm.vue';
 import DashboardWidgetMoreOptions
@@ -26,6 +23,7 @@ const props = defineProps<Props>();
 const dashboardDetailStore = useDashboardDetailInfoStore();
 const dashboardDetailState = dashboardDetailStore.$state;
 const widgetFormStore = useWidgetFormStore();
+const widgetFormGetters = widgetFormStore.getters;
 
 const state = reactive({
     isFocused: false,
@@ -33,26 +31,21 @@ const state = reactive({
 
 
 /* title form validation */
-const {
-    title, resetTitle, updateTitle, isTitleInvalid, titleInvalidText,
-} = useWidgetTitleInput();
-
+const handleUpdateTitle = (value: string) => {
+    if (value === widgetFormGetters.title) return;
+    widgetFormStore.updateTitle(value);
+};
 
 /* states init */
 const initSchemaAndFormData = (widgetConfigId: string, widgetKey?: string) => {
-    // init widgetInfo - refined widget info
     widgetFormStore.initWidgetForm(widgetKey, widgetConfigId);
-
-    // init title
-    updateTitle(widgetFormStore.mergedWidgetInfo?.title);
 };
 watch([() => props.widgetConfigId, () => props.widgetKey], ([widgetConfigId, widgetKey]) => {
     // do nothing if still loading
     if (!widgetConfigId) return;
 
     // reset states
-    widgetFormStore.$reset();
-    resetTitle();
+    widgetFormStore.resetAll();
 
     initSchemaAndFormData(widgetConfigId, widgetKey);
 
@@ -65,23 +58,23 @@ watch([() => props.widgetConfigId, () => props.widgetKey], ([widgetConfigId, wid
 <template>
     <div class="dashboard-widget-input-form">
         <p-field-group :label="$t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.LABEL_NAME')"
-                       :invalid="isTitleInvalid"
-                       :invalid-text="titleInvalidText"
+                       :invalid="widgetFormGetters.isTitleInvalid"
+                       :invalid-text="widgetFormGetters.titleInvalidText"
                        class="name-field"
                        required
         >
-            <p-text-input :value="title"
+            <p-text-input :value="widgetFormGetters.title"
                           :is-focused.sync="state.isFocused"
-                          :invalid="isTitleInvalid"
+                          :invalid="widgetFormGetters.isTitleInvalid"
                           :placeholder="$t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.NAME_PLACEHOLDER')"
                           class="input"
-                          @update:value="updateTitle"
+                          @update:value="handleUpdateTitle"
             />
         </p-field-group>
-        <div v-if="widgetFormStore.widgetConfig?.description?.translation_id"
+        <div v-if="widgetFormGetters.widgetConfig?.description?.translation_id"
              class="description-text"
         >
-            {{ $t(widgetFormStore.widgetConfig.description.translation_id) }}
+            {{ $t(widgetFormGetters.widgetConfig.description.translation_id) }}
         </div>
 
         <!-- TODO: update props binding after updating widget config options_schema -->

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetMoreOptions.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/DashboardWidgetMoreOptions.vue
@@ -18,11 +18,12 @@ interface MenuItem {
 }
 
 const widgetFormStore = useWidgetFormStore();
-const widgetFormState = widgetFormStore.$state;
+const widgetFormState = widgetFormStore.state;
+const widgetFormGetters = widgetFormStore.getters;
 
 const state = reactive({
     propertySchemaTuples: computed<[optionKey: string, schema: WidgetOptionsSchemaProperty][]>(() => {
-        const properties = widgetFormStore.widgetConfig?.options_schema?.properties ?? {};
+        const properties = widgetFormGetters.widgetConfig?.options_schema?.properties ?? {};
         return Object.entries(properties);
     }),
 });
@@ -54,8 +55,8 @@ const {
 });
 
 const handleUpdateSelectedOptions = (selected: MenuItem[]) => {
-    const order = widgetFormStore.widgetConfig?.options_schema?.order ?? [];
-    const schemaProperties = widgetFormStore.widgetConfig?.options_schema?.properties ?? {};
+    const order = widgetFormGetters.widgetConfig?.options_schema?.order ?? [];
+    const schemaProperties = widgetFormGetters.widgetConfig?.options_schema?.properties ?? {};
     const selectedProperties: string[] = chain(selected)
         .map((item) => item.name)
         .sortBy((optionKey) => {
@@ -79,7 +80,7 @@ watch(() => widgetFormState.schemaProperties, (selectedProperties) => {
     if (isEqual(current, selectedProperties)) return;
 
     const refined: MenuItem[] = selectedProperties.map((d) => {
-        const config = widgetFormStore.widgetConfig?.options_schema?.properties?.[d];
+        const config = widgetFormGetters.widgetConfig?.options_schema?.properties?.[d];
         return { name: d, label: config?.name ?? d };
     });
     selectedOptions.value = refined;

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/composables/use-widget-title-input.ts
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/composables/use-widget-title-input.ts
@@ -1,36 +1,27 @@
-import { toRef, watch } from 'vue';
+import { toRef } from 'vue';
 
 import { i18n } from '@/translations';
 
 import { useFormValidator } from '@/common/composables/form-validator';
 
-import { useWidgetFormStore } from '@/services/dashboards/shared/dashboard-widget-input-form/widget-form-store';
-
 export const useWidgetTitleInput = () => {
-    const widgetFormStore = useWidgetFormStore();
     const {
-        forms: { title }, setForm, invalidState, invalidTexts, isAllValid: isTitleValid, resetAll: resetTitle,
+        forms: { title }, setForm, invalidState, invalidTexts, resetAll: resetTitle,
     } = useFormValidator({
         title: '',
     }, {
-        title(value: string) { return value.trim().length ? '' : i18n.t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.VALIDATION_NAME'); },
+        title(value: string|undefined) { return value?.trim().length ? '' : i18n.t('DASHBOARDS.CUSTOMIZE.ADD_WIDGET.VALIDATION_NAME'); },
     });
     const updateTitle = (val) => {
         setForm('title', val);
-        widgetFormStore.$patch({ widgetTitle: val });
     };
     const isTitleInvalid = toRef(invalidState, 'title');
     const titleInvalidText = toRef(invalidTexts, 'title');
-
-    watch(isTitleValid, (val) => {
-        widgetFormStore.$patch({ isTitleValid: val });
-    });
 
     return {
         title,
         resetTitle,
         updateTitle,
-        isTitleValid,
         isTitleInvalid,
         titleInvalidText,
     };

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/dashboard-widget-options-form/DashboardWidgetOptionDropdown.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/dashboard-widget-options-form/DashboardWidgetOptionDropdown.vue
@@ -42,10 +42,12 @@ const emit = defineEmits<{(e: 'update:is-valid', isValid: boolean): void;
 }>();
 
 const widgetFormStore = useWidgetFormStore();
-const widgetFormState = widgetFormStore.$state;
+const widgetFormState = widgetFormStore.state;
+const widgetFormGetters = widgetFormStore.getters;
+
 const state = reactive({
     // property schema
-    schemaProperty: computed<WidgetOptionsSchemaProperty|undefined>(() => widgetFormStore.widgetConfig?.options_schema?.properties?.[props.propertyName]),
+    schemaProperty: computed<WidgetOptionsSchemaProperty|undefined>(() => widgetFormGetters.widgetConfig?.options_schema?.properties?.[props.propertyName]),
     label: computed(() => state.schemaProperty?.name ?? props.propertyName),
     selectionType: computed<WidgetOptionsSchemaProperty['selection_type']>(() => state.schemaProperty?.selection_type),
     inherit: computed<boolean>(() => !!widgetFormState.inheritOptions?.[props.propertyName]?.enabled),
@@ -137,7 +139,7 @@ const getRefinedSelectedItemByHandlers = async (
 };
 // init selected menu items on init or inherit changed
 const initSelectedMenuItems = async (): Promise<SelectDropdownMenuItem[]> => {
-    const inheritOption = widgetFormStore.inheritOptions?.[props.propertyName];
+    const inheritOption = widgetFormState.inheritOptions?.[props.propertyName];
 
     // 1) inherit case
     if (state.inherit) {
@@ -219,7 +221,7 @@ const updateWidgetOptionsBySelected = (selected?: SelectDropdownMenuItem[]) => {
     } else {
         delete widgetOptions[propertyName];
     }
-    widgetFormStore.$patch({ widgetOptions });
+    widgetFormStore.updateOptions(widgetOptions);
 };
 const updateWidgetSchemaProperties = () => {
     const schemaProperties = [...widgetFormState.schemaProperties];
@@ -227,7 +229,7 @@ const updateWidgetSchemaProperties = () => {
     if (index >= 0) {
         schemaProperties.splice(index, 1);
     }
-    widgetFormStore.$patch({ schemaProperties });
+    widgetFormStore.updateSchemaProperties(schemaProperties);
 };
 
 /* Event */

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/dashboard-widget-options-form/DashboardWidgetOptionsForm.vue
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/dashboard-widget-options-form/DashboardWidgetOptionsForm.vue
@@ -20,11 +20,11 @@ const props = defineProps<{
 }>();
 
 const widgetFormStore = useWidgetFormStore();
-const widgetFormState = widgetFormStore.$state;
-const dashboardDetailStore = useDashboardDetailInfoStore();
-const dashboardDetailState = dashboardDetailStore.$state;
+const widgetFormState = widgetFormStore.state;
+const widgetFormGetters = widgetFormStore.getters;
+
 const state = reactive({
-    properties: computed<WidgetOptionsSchema['properties']>(() => widgetFormStore.widgetConfig?.options_schema?.properties ?? {}),
+    properties: computed<WidgetOptionsSchema['properties']>(() => widgetFormGetters.widgetConfig?.options_schema?.properties ?? {}),
     optionsValidMap: {} as Record<string, boolean>,
     uuid: uuidv4(),
 });
@@ -52,15 +52,11 @@ const handleReturnToInitialSettings = () => {
 const handleDeleteProperty = (propertyName: string) => {
     widgetFormStore.updateInheritOption(propertyName, false);
     delete state.optionsValidMap[propertyName];
-    widgetFormStore.$patch({
-        isOptionsValid: Object.values(state.optionsValidMap).every((valid) => valid),
-    });
+    widgetFormStore.updateOptionsValid(Object.values(state.optionsValidMap).every((valid) => valid));
 };
 const handleUpdateIsValid = (propertyName: string, isValid: boolean) => {
     state.optionsValidMap[propertyName] = isValid;
-    widgetFormStore.$patch({
-        isOptionsValid: Object.values(state.optionsValidMap).every((valid) => valid),
-    });
+    widgetFormStore.updateOptionsValid(Object.values(state.optionsValidMap).every((valid) => valid));
 };
 </script>
 

--- a/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/widget-form-store.ts
+++ b/apps/web/src/services/dashboards/shared/dashboard-widget-input-form/widget-form-store.ts
@@ -1,8 +1,14 @@
+import type { ComputedRef, UnwrapRef } from 'vue';
+import { computed, reactive } from 'vue';
+
 import {
     cloneDeep, flattenDeep,
 } from 'lodash';
 import { defineStore } from 'pinia';
 
+import {
+    useWidgetTitleInput,
+} from '@/services/dashboards/shared/dashboard-widget-input-form/composables/use-widget-title-input';
 import { getUpdatedWidgetInfo } from '@/services/dashboards/shared/helpers/dashboard-widget-info-helper';
 import { useDashboardDetailInfoStore } from '@/services/dashboards/store/dashboard-detail-info';
 import type {
@@ -27,39 +33,53 @@ export interface PartialDashboardLayoutWidgetInfo extends DashboardLayoutWidgetI
     widget_key?: string;
 }
 
-const dashboardDetailStore = useDashboardDetailInfoStore();
-const dashboardDetailState = dashboardDetailStore.$state;
+interface Getters {
+    title: ComputedRef<string>;
+    isTitleInvalid: ComputedRef<boolean|undefined>;
+    titleInvalidText: ComputedRef<string|undefined>;
+    widgetConfig: ComputedRef<WidgetConfig|undefined>;
+    originWidgetInfo: ComputedRef<DashboardLayoutWidgetInfo|undefined>;
+    mergedWidgetInfo: ComputedRef<PartialDashboardLayoutWidgetInfo|undefined>;
+    updatedWidgetInfo: ComputedRef<UpdatableWidgetInfo|undefined>;
+    isAllValid: ComputedRef<boolean>;
+}
 
-export const useWidgetFormStore = defineStore('widget-form', {
-    state: () => ({
+export const useWidgetFormStore = defineStore('widget-form', () => {
+    const dashboardDetailStore = useDashboardDetailInfoStore();
+    const dashboardDetailState = dashboardDetailStore.$state;
+    const {
+        title, resetTitle, updateTitle, isTitleInvalid, titleInvalidText,
+    } = useWidgetTitleInput();
+
+    const initialState = {
         widgetConfigId: undefined as string|undefined, // widget config name that is used to get widget config
         widgetKey: undefined as string|undefined, // widget key to find widget in dashboard layout
         //
-        widgetTitle: '',
         inheritOptions: {} as InheritOptions,
         widgetOptions: {} as WidgetOptions,
         schemaProperties: [] as string[],
         //
         isOptionsValid: false,
-        isTitleValid: false,
-    }),
-    getters: {
-        widgetConfig(): WidgetConfig|undefined {
-            return this.widgetConfigId ? getWidgetConfig(this.widgetConfigId) : undefined;
-        },
-        originWidgetInfo(): DashboardLayoutWidgetInfo|undefined {
-            if (!this.widgetKey) return undefined;
+    };
+
+    const state = reactive(initialState);
+
+    const getters: UnwrapRef<Getters> = reactive({
+        widgetConfig: computed<WidgetConfig|undefined>(() => (state.widgetConfigId ? getWidgetConfig(state.widgetConfigId) : undefined)),
+        //
+        originWidgetInfo: computed<DashboardLayoutWidgetInfo|undefined>(() => {
+            if (!state.widgetKey) return undefined;
             const _dashboardWidgetInfoList = flattenDeep(dashboardDetailState.dashboardWidgetInfoList ?? []);
-            return _dashboardWidgetInfoList.find((w) => w.widget_key === this.widgetKey);
-        },
-        mergedWidgetInfo(): PartialDashboardLayoutWidgetInfo|undefined {
-            if (!this.widgetConfigId) return undefined;
-            const widgetInfo = this.originWidgetInfo;
+            return _dashboardWidgetInfoList.find((w) => w.widget_key === state.widgetKey);
+        }),
+        mergedWidgetInfo: computed<PartialDashboardLayoutWidgetInfo|undefined>(() => {
+            if (!state.widgetConfigId) return undefined;
+            const widgetInfo = getters.originWidgetInfo;
 
             const mergedWidgetState = mergeBaseWidgetState({
                 inheritOptions: widgetInfo?.inherit_options,
                 widgetOptions: widgetInfo?.widget_options,
-                widgetName: this.widgetConfigId,
+                widgetName: state.widgetConfigId,
                 dashboardSettings: dashboardDetailState.settings,
                 dashboardVariablesSchema: dashboardDetailState.variablesSchema,
                 dashboardVariables: dashboardDetailState.variables,
@@ -73,37 +93,54 @@ export const useWidgetFormStore = defineStore('widget-form', {
 
             return {
                 ...(widgetInfo ?? {}),
-                widget_key: this.widgetKey,
-                widget_name: this.widgetConfigId,
+                widget_key: state.widgetKey,
+                widget_name: state.widgetConfigId,
                 version: widgetInfo?.version ?? '1',
                 title: mergedWidgetState.title,
                 inherit_options: refinedInheritOptions,
                 widget_options: mergedWidgetState.options,
                 schema_properties: mergedWidgetState.schemaProperties,
             };
-        },
-        updatedWidgetInfo(): UpdatableWidgetInfo|undefined {
-            if (!this.widgetConfig || !this.widgetConfigId) {
+        }),
+        updatedWidgetInfo: computed<UpdatableWidgetInfo|undefined>(() => {
+            if (!getters.widgetConfig || !state.widgetConfigId) {
                 return undefined;
             }
 
-            return getUpdatedWidgetInfo(this.widgetConfig, {
-                title: this.widgetTitle,
-                inherit_options: this.inheritOptions,
-                widget_options: this.widgetOptions,
-                schema_properties: this.schemaProperties,
+            return getUpdatedWidgetInfo(getters.widgetConfig, {
+                title: getters.title,
+                inherit_options: state.inheritOptions,
+                widget_options: state.widgetOptions,
+                schema_properties: state.schemaProperties,
             });
+        }),
+        //
+        title,
+        isTitleInvalid,
+        titleInvalidText: titleInvalidText as ComputedRef<string|undefined>,
+        isAllValid: computed<boolean>(() => state.isOptionsValid && !getters.isTitleInvalid),
+    });
+
+    const actions = {
+        resetTitle,
+        updateTitle,
+        updateOptionsValid(isValid: boolean) {
+            state.isOptionsValid = isValid;
         },
-        isAllValid(): boolean {
-            return this.isOptionsValid && this.isTitleValid;
+        updateOptions(options: WidgetOptions) {
+            state.widgetOptions = options;
         },
-    },
-    actions: {
+        resetAll() {
+            Object.entries(initialState).forEach(([key, val]) => {
+                state[key] = val;
+            });
+            resetTitle();
+        },
         updateInheritOptionsAndWidgetOptionsByFormData(formData: any) {
-            if (!this.widgetConfig) return;
-            const _widgetOptions: WidgetOptions = cloneDeep(this.widgetConfig.options ?? {});
+            if (!getters.widgetConfig) return;
+            const _widgetOptions: WidgetOptions = cloneDeep(getters.widgetConfig.options ?? {});
             const _widgetFilters: WidgetOptions['filters'] = {};
-            const _inheritOptions = cloneDeep(this.inheritOptions);
+            const _inheritOptions = cloneDeep(state.inheritOptions);
 
             Object.entries(formData).forEach(([key, val]) => {
                 // inherit widget option case
@@ -115,7 +152,7 @@ export const useWidgetFormStore = defineStore('widget-form', {
                 // widget option filters case
                 } else if (key.startsWith('filters.')) {
                     if (val) {
-                        const variableKey = this.widgetConfig?.options_schema?.properties?.[key]?.key ?? '';
+                        const variableKey = getters.widgetConfig?.options_schema?.properties?.[key]?.key ?? '';
                         const filterDataKey = getWidgetFilterDataKey(variableKey);
                         _widgetFilters[variableKey] = [{ k: filterDataKey, v: val, o: '=' }];
                     }
@@ -126,51 +163,58 @@ export const useWidgetFormStore = defineStore('widget-form', {
             });
 
             _widgetOptions.filters = _widgetFilters;
-            this.widgetOptions = _widgetOptions;
-            this.inheritOptions = _inheritOptions;
+            state.widgetOptions = _widgetOptions;
+            state.inheritOptions = _inheritOptions;
         },
         initWidgetForm(widgetKey: string|undefined, widgetConfigId: string) {
-            this.widgetKey = widgetKey;
-            this.widgetConfigId = widgetConfigId;
-            const widgetInfo = this.mergedWidgetInfo;
+            state.widgetKey = widgetKey;
+            state.widgetConfigId = widgetConfigId;
+            const widgetInfo = getters.mergedWidgetInfo;
 
-            this.widgetTitle = widgetInfo?.title ?? '';
-            this.widgetOptions = widgetInfo?.widget_options ?? {};
-            this.inheritOptions = widgetInfo?.inherit_options ?? {};
-            this.schemaProperties = widgetInfo?.schema_properties ?? [];
+            updateTitle(widgetInfo?.title ?? '');
+            state.widgetOptions = widgetInfo?.widget_options ?? {};
+            state.inheritOptions = widgetInfo?.inherit_options ?? {};
+            state.schemaProperties = widgetInfo?.schema_properties ?? [];
         },
         updateInheritOption(propertyName: string, enabled: boolean, variableKey?: string) {
-            const inheritOptions = { ...this.inheritOptions };
+            const inheritOptions = { ...state.inheritOptions };
             if (enabled) {
                 inheritOptions[propertyName] = {
                     enabled: true,
-                    variable_key: variableKey ?? this.widgetConfig?.options_schema?.properties?.[propertyName]?.key,
+                    variable_key: variableKey ?? getters.widgetConfig?.options_schema?.properties?.[propertyName]?.key,
                 };
             } else {
                 inheritOptions[propertyName] = {
                     enabled: false,
                 };
             }
-            this.inheritOptions = inheritOptions;
+            state.inheritOptions = inheritOptions;
         },
         updateSchemaProperties(properties: string[]) {
-            this.schemaProperties = properties;
+            state.schemaProperties = properties;
 
             // update inherit options
-            const inheritOptions = { ...this.inheritOptions };
+            const inheritOptions = { ...state.inheritOptions };
             Object.keys(inheritOptions).forEach((name) => {
                 if (!properties.includes(name)) delete inheritOptions[name];
             });
-            this.inheritOptions = inheritOptions;
+            state.inheritOptions = inheritOptions;
 
             // update widget options
-            const widgetOptions = { ...this.widgetOptions };
+            const widgetOptions = { ...state.widgetOptions };
             Object.keys(widgetOptions).forEach((name) => {
                 if (!properties.includes(name)) delete widgetOptions[name];
             });
-            this.widgetOptions = widgetOptions;
+            state.widgetOptions = widgetOptions;
         },
-    },
+
+    };
+
+    return {
+        state,
+        getters,
+        ...actions,
+    };
 });
 
 const getProjectCaseInheritOptions = (inheritOptions: InheritOptions): InheritOptions => ({

--- a/apps/web/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
+++ b/apps/web/src/services/dashboards/widgets/_base/base-trend/BaseTrendWidget.vue
@@ -90,11 +90,14 @@ const { widgetState, widgetFrameProps, widgetFrameEventHandlers } = useWidget(pr
     assetWidgetLocation: undefined,
     costWidgetLocation: computed<Location|undefined>(() => {
         if (!widgetState.options.cost_data_source) return undefined;
-        const end = dayjs.utc(widgetState.settings?.date_range?.end);
+        if (!widgetState.dataField) return undefined;
+
+        const end = dayjs.utc(widgetState.dateRange.end);
         const _period = {
             start: end.subtract(5, 'month').format('YYYY-MM'),
             end: end.format('YYYY-MM'),
         };
+
         return {
             name: COST_EXPLORER_ROUTE.COST_ANALYSIS.QUERY_SET._NAME,
             params: {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [ ] Not that difficult
- [ ] Approved feature branch merge to master


### Description
This refactoring was started to fix title validation bug.


### Things to Talk About
I think setup store way is far better than option api way because it is far flexible.
We don't know that the store need another store or composable for the first time.
I suggest not to strictly use option store..!
