### PR TITLE
refactor: separate the 'modal' from the 'verify-button'

### DIFF
--- a/apps/web/src/common/modules/button/verify-button/VerifyButton.vue
+++ b/apps/web/src/common/modules/button/verify-button/VerifyButton.vue
@@ -1,75 +1,30 @@
 <script setup lang="ts">
-import { computed, reactive, watch } from 'vue';
-
 import { PButton, PI } from '@spaceone/design-system';
 
-import { store } from '@/store';
-
 import { emailValidator } from '@/lib/helper/user-validation-helper';
-import { postValidationEmail } from '@/lib/helper/verify-email-helper';
 
-
-import ErrorHandler from '@/common/composables/error/errorHandler';
-import NotificationEmailModal from '@/common/modules/modals/notification-email-modal/NotificationEmailModal.vue';
 import { MODAL_TYPE } from '@/common/modules/modals/notification-email-modal/type';
 
 interface Props {
+    loading: boolean
     email: string
-    userId: string
-    domainId: string
     verified: boolean
     isAdministration?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
+    loading: false,
     email: '',
-    userId: '',
-    domainId: '',
     verified: false,
     isAdministration: false,
 });
 
-const emit = defineEmits<{(e: 'refresh-user', userId: string): void}>();
-
-const state = reactive({
-    loading: false,
-    isModalVisible: false,
-    modalType: '',
-    loginUserId: computed(() => store.state.user.userId),
-});
-const handleGetUserDetailEmit = () => {
-    emit('refresh-user', props.userId);
-};
+const emit = defineEmits<{(e: 'click-button', type: string): void }>();
 
 /* API */
-const handleClickVerifiedEmail = async (type: string) => {
-    state.loading = true;
-    try {
-        if (props.verified || state.modalType !== '') return;
-        await postValidationEmail({
-            user_id: props.userId,
-            domain_id: props.domainId,
-            email: props.email,
-        });
-        if (state.loginUserId === props.userId) {
-            await store.dispatch('user/setUser', { email: props.email });
-        }
-    } catch (e: any) {
-        ErrorHandler.handleError(e);
-        throw e;
-    } finally {
-        state.isModalVisible = true;
-        state.loading = false;
-        state.modalType = type;
-    }
+const handleClickVerifiedEmail = (type: string) => {
+    emit('click-button', type);
 };
-
-/* Watcher */
-watch(() => state.isModalVisible, (value) => {
-    if (!value) {
-        state.modalType = '';
-    }
-});
 </script>
 
 <template>
@@ -77,7 +32,7 @@ watch(() => state.isModalVisible, (value) => {
         <div class="verify-button">
             <p-button v-if="props.verified"
                       style-type="tertiary"
-                      :loading="state.loading"
+                      :loading="props.loading"
                       :size="props.isAdministration ? 'sm' : 'md'"
                       @click.prevent="handleClickVerifiedEmail(MODAL_TYPE.SEND)"
             >
@@ -93,21 +48,14 @@ watch(() => state.isModalVisible, (value) => {
             <p-button v-else
                       style-type="primary"
                       :disabled="!props.isAdministration && (props.email === '' || emailValidator(props.email))"
-                      :loading="state.loading"
+                      :loading="props.loading"
                       :size="props.isAdministration ? 'sm' : 'md'"
                       @click.prevent="handleClickVerifiedEmail(MODAL_TYPE.VERIFY)"
             >
                 {{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.SEND_MAIL') }}
             </p-button>
         </div>
-        <notification-email-modal
-            :domain-id="props.domainId"
-            :user-id="props.userId"
-            :email="props.email"
-            :modal-type="state.modalType"
-            :visible.sync="state.isModalVisible"
-            @refresh-user="handleGetUserDetailEmit"
-        />
+        <slot />
     </div>
 </template>
 

--- a/apps/web/src/common/modules/button/verify-button/VerifyButton.vue
+++ b/apps/web/src/common/modules/button/verify-button/VerifyButton.vue
@@ -1,42 +1,3 @@
-<template>
-    <div class="verify-button-wrapper">
-        <div class="verify-button">
-            <p-button v-if="props.verified"
-                      style-type="tertiary"
-                      :loading="state.loading"
-                      :size="props.isAdministration ? 'sm' : 'md'"
-                      @click.prevent="handleClickVerifiedEmail(MODAL_TYPE.SEND)"
-            >
-                <p-i v-if="!props.isAdministration"
-                     name="ic_edit"
-                     height="1rem"
-                     width="1rem"
-                     color="inherit"
-                     class="icon-edit"
-                />
-                {{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.CHANGE') }}
-            </p-button>
-            <p-button v-else
-                      style-type="primary"
-                      :disabled="!props.isAdministration && (props.email === '' || emailValidator(props.email))"
-                      :loading="state.loading"
-                      :size="props.isAdministration ? 'sm' : 'md'"
-                      @click.prevent="handleClickVerifiedEmail(MODAL_TYPE.VERIFY)"
-            >
-                {{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.SEND_MAIL') }}
-            </p-button>
-        </div>
-        <notification-email-modal
-            :domain-id="props.domainId"
-            :user-id="props.userId"
-            :email="props.email"
-            :modal-type="state.modalType"
-            :visible.sync="state.isModalVisible"
-            @refresh-user="handleGetUserDetailEmit"
-        />
-    </div>
-</template>
-
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
@@ -110,6 +71,45 @@ watch(() => state.isModalVisible, (value) => {
     }
 });
 </script>
+
+<template>
+    <div class="verify-button-wrapper">
+        <div class="verify-button">
+            <p-button v-if="props.verified"
+                      style-type="tertiary"
+                      :loading="state.loading"
+                      :size="props.isAdministration ? 'sm' : 'md'"
+                      @click.prevent="handleClickVerifiedEmail(MODAL_TYPE.SEND)"
+            >
+                <p-i v-if="!props.isAdministration"
+                     name="ic_edit"
+                     height="1rem"
+                     width="1rem"
+                     color="inherit"
+                     class="icon-edit"
+                />
+                {{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.CHANGE') }}
+            </p-button>
+            <p-button v-else
+                      style-type="primary"
+                      :disabled="!props.isAdministration && (props.email === '' || emailValidator(props.email))"
+                      :loading="state.loading"
+                      :size="props.isAdministration ? 'sm' : 'md'"
+                      @click.prevent="handleClickVerifiedEmail(MODAL_TYPE.VERIFY)"
+            >
+                {{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.SEND_MAIL') }}
+            </p-button>
+        </div>
+        <notification-email-modal
+            :domain-id="props.domainId"
+            :user-id="props.userId"
+            :email="props.email"
+            :modal-type="state.modalType"
+            :visible.sync="state.isModalVisible"
+            @refresh-user="handleGetUserDetailEmit"
+        />
+    </div>
+</template>
 
 <style scoped lang="postcss">
 .verify-button {

--- a/apps/web/src/services/administration/iam/user/modules/user-management-tab/UserDetail.vue
+++ b/apps/web/src/services/administration/iam/user/modules/user-management-tab/UserDetail.vue
@@ -1,76 +1,3 @@
-<template>
-    <div>
-        <p-heading heading-type="sub"
-                   :title="$t('IDENTITY.USER.ACCOUNT.BASE_INFORMATION')"
-        />
-        <p-definition-table :fields="state.fields"
-                            :data="state.data"
-                            :loading="state.loading"
-                            :skeleton-rows="7"
-                            v-on="$listeners"
-        >
-            <template #data-state="{data}">
-                <p-status v-bind="userStateFormatter(data)"
-                          class="capitalize"
-                />
-            </template>
-            <template #data-user_type="{data}">
-                <span v-if="data === 'API_USER'">API Only</span>
-                <span v-else>Console, API</span>
-            </template>
-            <template #data-email="{data}">
-                <span v-if="state.data.user_type !== 'API_USER'">
-                    <span :class="state.data.email_verified && 'verified-text'">{{ data }}</span>
-                    <span v-if="state.data.email_verified">
-                        <p-i name="ic_verified"
-                             height="1rem"
-                             width="1rem"
-                             class="verified-icon"
-                             color="#60B731"
-                        />
-                    </span>
-                    <span v-else
-                          class="not-verified"
-                    >
-                        {{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.NOT_VERIFIED') }}
-                    </span>
-                </span>
-                <span v-else>
-                    <span>N/A</span>
-                </span>
-            </template>
-            <template #data-last_accessed_at="{data}">
-                <span v-if="data === -1">
-                    No Activity
-                </span>
-                <span v-else-if="data === 0">
-                    {{ $t('IDENTITY.USER.MAIN.TODAY') }}
-                </span>
-                <span v-else-if="data === 1">
-                    {{ $t('IDENTITY.USER.MAIN.YESTERDAY') }}
-                </span>
-                <span v-else>
-                    {{ data }} {{ $t('IDENTITY.USER.MAIN.DAYS') }}
-                </span>
-            </template>
-            <template #data-created_at="{data}">
-                {{ iso8601Formatter(data, timezone) }}
-            </template>
-            <template #extra="{label}">
-                <verify-button
-                    v-if="label === $t('IDENTITY.USER.MAIN.NOTIFICATION_EMAIL') && state.data.user_type !== 'API_USER'"
-                    :email="state.data.email"
-                    :user-id="state.data.user_id"
-                    :domain-id="state.data.domain_id"
-                    :verified="state.data.email_verified"
-                    is-administration
-                    @refresh-user="getUserDetailData"
-                />
-            </template>
-        </p-definition-table>
-    </div>
-</template>
-
 <script setup lang="ts">
 import {
     computed, reactive, watch,
@@ -163,8 +90,80 @@ watch(() => userPageState.visibleUpdateModal, (value) => {
         getUserDetailData(props.userId);
     }
 });
-
 </script>
+
+<template>
+    <div>
+        <p-heading heading-type="sub"
+                   :title="$t('IDENTITY.USER.ACCOUNT.BASE_INFORMATION')"
+        />
+        <p-definition-table :fields="state.fields"
+                            :data="state.data"
+                            :loading="state.loading"
+                            :skeleton-rows="7"
+                            v-on="$listeners"
+        >
+            <template #data-state="{data}">
+                <p-status v-bind="userStateFormatter(data)"
+                          class="capitalize"
+                />
+            </template>
+            <template #data-user_type="{data}">
+                <span v-if="data === 'API_USER'">API Only</span>
+                <span v-else>Console, API</span>
+            </template>
+            <template #data-email="{data}">
+                <span v-if="state.data.user_type !== 'API_USER'">
+                    <span :class="state.data.email_verified && 'verified-text'">{{ data }}</span>
+                    <span v-if="state.data.email_verified">
+                        <p-i name="ic_verified"
+                             height="1rem"
+                             width="1rem"
+                             class="verified-icon"
+                             color="#60B731"
+                        />
+                    </span>
+                    <span v-else
+                          class="not-verified"
+                    >
+                        {{ $t('IDENTITY.USER.ACCOUNT.NOTIFICATION_EMAIL.NOT_VERIFIED') }}
+                    </span>
+                </span>
+                <span v-else>
+                    <span>N/A</span>
+                </span>
+            </template>
+            <template #data-last_accessed_at="{data}">
+                <span v-if="data === -1">
+                    No Activity
+                </span>
+                <span v-else-if="data === 0">
+                    {{ $t('IDENTITY.USER.MAIN.TODAY') }}
+                </span>
+                <span v-else-if="data === 1">
+                    {{ $t('IDENTITY.USER.MAIN.YESTERDAY') }}
+                </span>
+                <span v-else>
+                    {{ data }} {{ $t('IDENTITY.USER.MAIN.DAYS') }}
+                </span>
+            </template>
+            <template #data-created_at="{data}">
+                {{ iso8601Formatter(data, timezone) }}
+            </template>
+            <template #extra="{label}">
+                <verify-button
+                    v-if="label === $t('IDENTITY.USER.MAIN.NOTIFICATION_EMAIL') && state.data.user_type !== 'API_USER'"
+                    :email="state.data.email"
+                    :user-id="state.data.user_id"
+                    :domain-id="state.data.domain_id"
+                    :verified="state.data.email_verified"
+                    is-administration
+                    @refresh-user="getUserDetailData"
+                />
+            </template>
+        </p-definition-table>
+    </div>
+</template>
 
 <style lang="postcss" scoped>
 /* custom design-system component - p-definition */

--- a/apps/web/src/services/my-page/my-account/user-account/modules/NotificationEmail.vue
+++ b/apps/web/src/services/my-page/my-account/user-account/modules/NotificationEmail.vue
@@ -1,3 +1,54 @@
+<script setup lang="ts">
+import {
+    computed, reactive, watch,
+} from 'vue';
+
+import { PI, PTextInput, PFieldGroup } from '@spaceone/design-system';
+
+import { store } from '@/store';
+import { i18n } from '@/translations';
+
+import { emailValidator } from '@/lib/helper/user-validation-helper';
+
+import { useFormValidator } from '@/common/composables/form-validator';
+import VerifyButton from '@/common/modules/button/verify-button/VerifyButton.vue';
+
+import UserAccountModuleContainer
+    from '@/services/my-page/my-account/user-account/modules/UserAccountModuleContainer.vue';
+
+const state = reactive({
+    userType: computed(() => store.state.user.backend),
+    verified: computed(() => store.state.user.emailVerified),
+    userId: computed(() => store.state.user.userId),
+    domainId: computed(() => store.state.domain.domainId),
+});
+const {
+    forms: {
+        notificationEmail,
+    },
+    setForm,
+    invalidState,
+    invalidTexts,
+} = useFormValidator({
+    notificationEmail: '',
+}, {
+    notificationEmail(value: string) { return !emailValidator(value) ? '' : i18n.t('IDENTITY.USER.FORM.EMAIL_INVALID'); },
+});
+
+/* Watcher */
+watch(() => store.state.user.email, (value) => {
+    let result = value;
+    if (value === '') {
+        if (state.userType === 'LOCAL') {
+            result = state.userId;
+        } else {
+            result = '';
+        }
+    }
+    setForm('notificationEmail', result);
+}, { immediate: true });
+</script>
+
 <template>
     <user-account-module-container
         class="notification-email-wrapper"
@@ -58,57 +109,6 @@
         </form>
     </user-account-module-container>
 </template>
-
-<script setup lang="ts">
-import {
-    computed, reactive, watch,
-} from 'vue';
-
-import { PI, PTextInput, PFieldGroup } from '@spaceone/design-system';
-
-import { store } from '@/store';
-import { i18n } from '@/translations';
-
-import { emailValidator } from '@/lib/helper/user-validation-helper';
-
-import { useFormValidator } from '@/common/composables/form-validator';
-import VerifyButton from '@/common/modules/button/verify-button/VerifyButton.vue';
-
-import UserAccountModuleContainer
-    from '@/services/my-page/my-account/user-account/modules/UserAccountModuleContainer.vue';
-
-const state = reactive({
-    userType: computed(() => store.state.user.backend),
-    verified: computed(() => store.state.user.emailVerified),
-    userId: computed(() => store.state.user.userId),
-    domainId: computed(() => store.state.domain.domainId),
-});
-const {
-    forms: {
-        notificationEmail,
-    },
-    setForm,
-    invalidState,
-    invalidTexts,
-} = useFormValidator({
-    notificationEmail: '',
-}, {
-    notificationEmail(value: string) { return !emailValidator(value) ? '' : i18n.t('IDENTITY.USER.FORM.EMAIL_INVALID'); },
-});
-
-/* Watcher */
-watch(() => store.state.user.email, (value) => {
-    let result = value;
-    if (value === '') {
-        if (state.userType === 'LOCAL') {
-            result = state.userId;
-        } else {
-            result = '';
-        }
-    }
-    setForm('notificationEmail', result);
-}, { immediate: true });
-</script>
 
 <style lang="postcss" scoped>
 .notification-email-wrapper {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [ ] Not that difficult
- [ ] Approved feature branch merge to master

### Description
Previously, the 'verifyButton' existed solely for the 'notificationModal.'
However, with the introduction of MFA, the 'verifyButton' is now also used in this component.
To apply a broader scope, we have separated the 'modal' component from 'verifyButton' using slots.

### Things to Talk About
plz check only the last commit