### PR TITLE
fix: apply qa at administration page

### DIFF
--- a/apps/web/src/services/administration/components/UserManagementFormModal.vue
+++ b/apps/web/src/services/administration/components/UserManagementFormModal.vue
@@ -64,6 +64,7 @@ const state = reactive({
     smtpEnabled: computed(() => config.get('SMTP_ENABLED')),
     mfa: computed(() => store.state.user.mfa),
     loginUserId: computed(() => store.state.user.userId),
+    isChangedToggle: false,
 });
 
 const emit = defineEmits<{(e: 'confirm', data: UserManagementData, roleId: string|null): void; }>();
@@ -83,7 +84,6 @@ const formState = reactive({
     passwordType: '',
     passwordManual: false,
     tags: {},
-    isToggled: false,
 });
 
 const validationState = reactive({
@@ -136,7 +136,6 @@ const getUserDetailData = async (userId) => {
         state.data = await SpaceConnector.clientV2.identity.user.get({
             user_id: userId,
         });
-        formState.isToggled = state.data.mfa?.state === 'ENABLED';
     } catch (e) {
         ErrorHandler.handleError(e);
     }
@@ -163,7 +162,7 @@ const confirm = async () => {
         data.reset_password = formState.passwordType === PASSWORD_TYPE.RESET;
     }
 
-    if (!formState.isToggled) {
+    if (state.isChangedToggle) {
         userPageStore.$patch({
             modalLoading: true,
         });
@@ -285,7 +284,9 @@ const initAuthTypeList = async () => {
                         @change-input="handleChangeInputs"
                         @change-verify="handleChangeVerify"
                     />
-                    <user-management-form-multi-factor-auth :is-toggled.sync="formState.isToggled" />
+                    <user-management-form-multi-factor-auth :state="state.data.mfa?.state"
+                                                            :is-changed-toggle.sync="state.isChangedToggle"
+                    />
                     <user-management-form-password-form
                         v-if="state.data.backend === USER_BACKEND_TYPE.LOCAL && state.data.user_type !== USER_TYPE.API_USER"
                         :item="state.data"

--- a/apps/web/src/services/administration/components/UserManagementFormMultiFactorAuth.vue
+++ b/apps/web/src/services/administration/components/UserManagementFormMultiFactorAuth.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive } from 'vue';
+import { reactive, watch } from 'vue';
 
 import {
     PI, PTooltip, PFieldTitle, PToggleButton,
@@ -8,23 +8,30 @@ import {
 import { useProxyValue } from '@/common/composables/proxy-state';
 
 interface Props {
-    isToggled?: boolean
+    state?: string
+    isChangedToggle?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-    isToggled: undefined,
+    state: undefined,
+    isChangedToggle: false,
 });
 
-const emit = defineEmits<{(e: 'update:isToggled', type: string): void }>();
+const emit = defineEmits<{(e: 'update:isChangedToggle', type: string): void }>();
 
 const state = reactive({
-    proxyIsToggled: useProxyValue('isToggled', props, emit),
+    isToggleActive: false,
+    proxyIsChangedToggle: useProxyValue('isChangedToggle', props, emit),
 });
 
 const handleUpdateToggle = async () => {
-    state.proxyIsToggled = false;
+    state.isToggleActive = false;
+    state.proxyIsChangedToggle = true;
 };
 
+watch(() => props.state, (value) => {
+    state.isToggleActive = value === 'ENABLED';
+});
 </script>
 
 <template>
@@ -32,8 +39,8 @@ const handleUpdateToggle = async () => {
         <p-field-title :label="$t('IDENTITY.USER.MAIN.MFA')">
             <template #left>
                 <p-toggle-button
-                    :value="state.proxyIsToggled"
-                    :disabled="!state.proxyIsToggled"
+                    :value="state.isToggleActive"
+                    :disabled="!state.isToggleActive"
                     class="toggle-button"
                     @change-toggle="handleUpdateToggle"
                 />

--- a/apps/web/src/services/administration/components/UserManagementTabDetail.vue
+++ b/apps/web/src/services/administration/components/UserManagementTabDetail.vue
@@ -57,7 +57,7 @@ const state = reactive({
             { name: 'state', label: i18n.t('IDENTITY.USER.MAIN.STATE') },
             { name: 'user_type', label: i18n.t('IDENTITY.USER.MAIN.ACCESS_CONTROL') },
             ...additionalFields,
-            { name: 'mfa', label: i18n.t('IDENTITY.USER.MAIN.MFA') },
+            { name: 'mfa', label: i18n.t('IDENTITY.USER.MAIN.MFA'), disableCopy: true },
             { name: 'last_accessed_at', label: i18n.t('IDENTITY.USER.MAIN.LAST_ACTIVITY') },
             { name: 'domain_id', label: i18n.t('IDENTITY.USER.MAIN.DOMAIN_ID') },
             { name: 'language', label: i18n.t('IDENTITY.USER.MAIN.LANGUAGE') },


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [ ] Not that difficult
- [ ] Approved feature branch merge to master

### Description
- [disabled copy button at user tab detail](https://pyengine.atlassian.net/browse/QA-937)
<img width="1158" alt="image" src="https://github.com/cloudforet-io/console/assets/83805167/9d0bbfa9-1663-4df5-95e4-79a6c2b167f4">

- [changing attribute values for detecting only toggle state changes](https://pyengine.atlassian.net/browse/QA-942)
  - Disabling MFA toggle and applying disable-MFA, then updating user information.
  - Updating user information only when there is no change in the MFA toggle state.

### Things to Talk About
Plz check by commits!