### PR TITLE
fix: prevent board-item dropdown icon menu's native event in tablet mode

### DIFF
--- a/packages/mirinae/src/data-display/board-item/PBoardItem.vue
+++ b/packages/mirinae/src/data-display/board-item/PBoardItem.vue
@@ -45,6 +45,7 @@
                                        style-type="icon-button"
                                        button-icon="ic_ellipsis-horizontal"
                                        use-fixed-menu-style
+                                       @click.native="handleClickStopNativeEvent"
                     >
                         <template #menu-menu>
                             <div class="custom-button-menu">
@@ -133,8 +134,13 @@ export default defineComponent<BoardItemProps>({
             predicate: () => !!(props.selected && props.value && props.selected === props.value),
         });
 
+        const handleClickStopNativeEvent = (event) => {
+            event.stopPropagation();
+        };
+
         return {
             isSelected,
+            handleClickStopNativeEvent,
             ...toRefs(state),
         };
     },


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [x] Not that difficult
- [ ] Approved feature branch merge to master


### Description
[QA-1536](https://pyengine.atlassian.net/browse/QA-1536)

### Things to Talk About
