### PR TITLE
Fix wrong sample code (#3394)

### DIFF
--- a/apps/web/public/config/development.json.sample
+++ b/apps/web/public/config/development.json.sample
@@ -1,9 +1,9 @@
 {
   "CONSOLE_API": {
-    "ENDPOINT": "https://console.api.dev.spaceone.dev"
+    "ENDPOINT": "http://127.0.0.1:8081"
   },
   "CONSOLE_API_V2": {
-    "ENDPOINT": "https://console-v2.api.dev.spaceone.dev"
+    "ENDPOINT": "http://127.0.0.1:8082"
   },
   "GTAG_ID": "DISABLED",
   "DOMAIN_NAME": "spaceone",
@@ -22,6 +22,6 @@
     "AUTH": {
         "SKIP_TOKEN_CHECK": false,
         "API_KEY": "api-key"
-    },
+    }
   }
 }


### PR DESCRIPTION
apps/web/public/config/development.sample.json has a JSON typo

- Change CONSLE_API (http://127.0.0.1:8081)
- Change CONSOLE_API_V2 (http://127.0.0.1:8082)
- Remove JSON typo error

### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [x] Not that difficult
- [ ] Approved feature branch merge to master


### Description

The developer guides has typo and hard to debugging. Fix the wrong sample.

### Things to Talk About
