### PR TITLE
feat(cost-analysis): set alias to cost data type dropdown

### DIFF
--- a/apps/web/src/services/cost-explorer/components/CostAnalysisDataTypeDropdown.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisDataTypeDropdown.vue
@@ -40,11 +40,15 @@ const state = reactive({
             }));
         } return [];
     }),
-    headerMenuItems: computed<MenuItem[]>(() => [
-        { type: 'item', name: 'cost', label: 'Cost' },
-        { type: 'item', name: 'usage', label: 'Usage' },
-        ...state.additionalMenuItems,
-    ]),
+    headerMenuItems: computed<MenuItem[]>(() => {
+        const costAlias: string|undefined = state.targetCostDataSource.data?.plugin_info?.metadata?.alias?.cost;
+        const usageAlias: string|undefined = state.targetCostDataSource.data?.plugin_info?.metadata?.alias?.usage;
+        return [
+            { type: 'item', name: 'cost', label: costAlias ? `Cost (${costAlias})` : 'Cost' },
+            { type: 'item', name: 'usage', label: usageAlias ? `Usage (${usageAlias})` : 'Usage' },
+            ...state.additionalMenuItems,
+        ];
+    }),
 });
 
 const handleUpdateSelected = (selected: DisplayDataType) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [x] Not that difficult
- [ ] Approved feature branch merge to master


### Description
If the alias for `cost` is 'Pay as you Go', it'll be displayed as 'Cost (Pay as you go)'!

