### PR TITLE
fix: prevent setting loading to false on api cancellation in CostAnalysisChart

### DIFF
--- a/apps/web/src/services/cost-explorer/components/CostAnalysisChart.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisChart.vue
@@ -72,6 +72,7 @@ const fetchCostAnalyze = getCancellableFetcher<object, AnalyzeResponse<CostAnaly
 const analyzeApiQueryHelper = new ApiQueryHelper();
 const listCostAnalysisData = async (period:Period): Promise<AnalyzeResponse<CostAnalyzeRawData>> => {
     try {
+        state.loading = true;
         analyzeApiQueryHelper.setFilters(costAnalysisPageGetters.consoleFilters);
         let dateFormat = 'YYYY-MM';
         if (costAnalysisPageState.granularity === GRANULARITY.YEARLY) dateFormat = 'YYYY';
@@ -93,17 +94,19 @@ const listCostAnalysisData = async (period:Period): Promise<AnalyzeResponse<Cost
                 ...analyzeApiQueryHelper.data,
             },
         });
-        if (status === 'succeed') return response;
+        if (status === 'succeed') {
+            state.loading = false;
+            return response;
+        }
         return { more: false, results: [] };
     } catch (e) {
         ErrorHandler.handleError(e);
+        state.loading = false;
         return { more: false, results: [] };
     }
 };
 const setChartData = debounce(async (period:Period) => {
-    state.loading = true;
     state.data = await listCostAnalysisData(period);
-    state.loading = false;
 }, 300);
 
 /* Event */

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisStackedColumnChart.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisStackedColumnChart.vue
@@ -234,7 +234,7 @@ useResizeObserver(chartContext, throttle(() => {
 
 <template>
     <p-data-loader :loading="props.loading"
-                   :data="props.data?.results"
+                   :data="state.chartData"
                    class="cost-analysis-stacked-column-chart"
     >
         <template #loader>


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [x] Not that difficult
- [ ] Approved feature branch merge to master


### Description
There was an issue where the loading screen appeared during chart rendering, but intermittently showed 'No Data Available' during data loading. 
This issue occurred because multiple API calls were made, and when an earlier API call was canceled, the loading state would incorrectly switch to false. 
The issue was resolved by ensuring the loading state is only set to false when the API call returns a success or an error.

### Things to Talk About
