### PR TITLE
fix: update cost analysis chart legend based on data

### DIFF
--- a/apps/web/src/services/cost-explorer/components/CostAnalysisStackedColumnChart.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisStackedColumnChart.vue
@@ -50,7 +50,7 @@ const props = withDefaults(defineProps<Props>(), {
     legend: () => ({}),
     accumulated: false,
 });
-const emit = defineEmits<{(e: 'update:legend', value): void;
+const emit = defineEmits<{(e: 'update:legend', value: Record<string, boolean>): void;
 }>();
 
 const LIMIT = 15;
@@ -203,13 +203,10 @@ const drawChart = (rawData: AnalyzeResponse<CostAnalyzeRawData>) => {
 
     // init legend
     const _legend: Record<string, boolean> = {};
-    if (isEmpty(state.proxyLegend)) {
-        const _series = state.chartData.map((d) => d.name);
-        _series.forEach((d) => {
-            _legend[d] = true;
-        });
-        state.proxyLegend = _legend;
-    }
+    state.chartData.forEach((d) => {
+        _legend[d.name] = true;
+    });
+    state.proxyLegend = _legend;
 
     state.chart = init(chartContext.value);
     state.chart.setOption(state.chartOptions, true);

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisStackedColumnChart.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisStackedColumnChart.vue
@@ -192,7 +192,7 @@ const getTotalData = (rawData: AnalyzeResponse<CostAnalyzeRawData>, accumulated:
         data: _data,
     }];
 };
-const drawChart = (rawData: AnalyzeResponse<CostAnalyzeRawData>) => {
+const drawChart = (rawData: AnalyzeResponse<CostAnalyzeRawData>, updateLegend = false) => {
     if (isEmpty(rawData)) return;
 
     if (costAnalysisPageState.chartGroupBy) {
@@ -202,22 +202,26 @@ const drawChart = (rawData: AnalyzeResponse<CostAnalyzeRawData>) => {
     }
 
     // init legend
-    const _legend: Record<string, boolean> = {};
-    state.chartData.forEach((d) => {
-        _legend[d.name] = true;
-    });
-    state.proxyLegend = _legend;
+    if (updateLegend) {
+        const _legend: Record<string, boolean> = {};
+        state.chartData.forEach((d) => {
+            _legend[d.name] = true;
+        });
+        state.proxyLegend = _legend;
+    }
 
     state.chart = init(chartContext.value);
     state.chart.setOption(state.chartOptions, true);
-    state.chart.on('legendselectchanged', (d) => {
-        state.proxyLegend = d.selected;
-    });
+    if (updateLegend) {
+        state.chart.on('legendselectchanged', (d) => {
+            state.proxyLegend = d.selected;
+        });
+    }
 };
 
-watch([() => chartContext.value, () => props.loading, () => props.data, () => props.accumulated], async ([_chartContext, loading, data]) => {
+watch([() => chartContext.value, () => props.loading, () => props.data, () => props.accumulated], async ([_chartContext, loading, data], prev) => {
     if (_chartContext && !loading) {
-        drawChart(data);
+        drawChart(data, prev[2] !== data);
     }
 });
 watch(() => state.proxyLegend, () => {


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [x] Not that difficult
- [ ] Approved feature branch merge to master


### Description

There was an issue on the cost analysis page where the chart legend was not syncing correctly when selecting or deselecting groupBy or filter options. 

The primary cause was that the legend was only updated to match the data when it was empty. 
This has been resolved by ensuring the legend is updated on every interaction.

### Things to Talk About
