### PR TITLE
fix(widget): solve widget date-range bug

### DIFF
--- a/apps/web/src/common/modules/widgets/_helpers/widget-date-helper.ts
+++ b/apps/web/src/common/modules/widgets/_helpers/widget-date-helper.ts
@@ -36,12 +36,7 @@ export const getWidgetBasedOnDate = (granularity: string, end?: string): string 
     const _dateFormat = getDateFormat(granularity);
     if (end) {
         if (granularity === 'DAILY') {
-            const now = dayjs.utc();
             const endDate = dayjs.utc(end);
-
-            if (now.isSame(endDate, 'month')) {
-                return now.format(_dateFormat);
-            }
             return endDate.endOf('month').format(_dateFormat);
         }
         return dayjs.utc(end).format(_dateFormat);

--- a/apps/web/src/common/modules/widgets/_widgets/table/Table.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/table/Table.vue
@@ -3,6 +3,7 @@ import {
     defineExpose, reactive, computed, watch, onMounted,
 } from 'vue';
 
+import dayjs from 'dayjs';
 import { flatMap, map, uniq } from 'lodash';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
@@ -97,7 +98,12 @@ const state = reactive({
         if (isDateField(state.tableDataField) || state.groupByField?.some((groupBy) => Object.values(DATE_FIELD).includes(groupBy))) {
             if (state.granularity === GRANULARITY.YEARLY) subtract = 3;
             if (state.granularity === GRANULARITY.MONTHLY) subtract = 12;
-            if (state.granularity === GRANULARITY.DAILY) subtract = 30;
+            if (state.granularity === GRANULARITY.DAILY) {
+                // if basedOnDate is end of month, need to assign date count of that month
+                const endOfMonth = dayjs.utc(state.basedOnDate).endOf('month').date();
+                if (dayjs.utc(state.basedOnDate).date() === endOfMonth) subtract = endOfMonth;
+                else subtract = 30;
+            }
         }
         const [start, end] = getWidgetDateRange(state.granularity, state.basedOnDate, subtract);
         return { start, end };


### PR DESCRIPTION
### To Reviewers
- [ ] Skip (`style`, `chore`, `ci`, minor refactoring, etc.)
- [ ] Need discussion
- [ ] Not that difficult
- [ ] Approved feature branch merge to master


### Description
- Edit date-range helper

If you select October (not current month) in date dropdown and select daily (granularity), 
date-range must be converted `2024-10-01`-`2024-10-31`, but it was not. 
It was converted to `2024-09-05`-`2024-10-04`,  as if you chose current month in date dropdown.

![image](https://github.com/user-attachments/assets/bbf23b75-7cc7-4268-bfa0-f81d44e56545)

### Things to Talk About
