### PR TITLE
fix: solve missing asset category issue in datatable-datasource popper

### DIFF
--- a/apps/web/src/common/modules/widgets/_components/WidgetFormAssetSecurityDataSourcePopper.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormAssetSecurityDataSourcePopper.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive,
 } from 'vue';
 
-import { sortBy } from 'lodash';
+import { sortBy, startCase, toLower } from 'lodash';
 
 import {
     PFieldTitle, PContextMenu,
@@ -43,6 +43,7 @@ const state = reactive({
             .map((namespace) => namespace.data.group);
         const _groupMenuItems: MenuItem[] = [];
         const _uniqueGroups = Array.from(new Set(groups));
+
         sortBy(_uniqueGroups, (group) => group !== 'common').forEach((group) => {
             if (group === 'common') {
                 _groupMenuItems.push({
@@ -51,16 +52,13 @@ const state = reactive({
                     label: i18n.t('DASHBOARDS.WIDGET.OVERLAY.STEP_1.COMMON'),
                 });
             } else {
-                // provider case
                 const providerData = storeState.providers[group];
-                if (providerData) {
-                    _groupMenuItems.push({
-                        type: 'item',
-                        name: providerData.key,
-                        label: providerData.label,
-                        imageUrl: providerData.data.icon,
-                    });
-                }
+                _groupMenuItems.push({
+                    type: 'item',
+                    name: providerData?.key || group,
+                    label: providerData?.label || customSnakeToTitleCase(group),
+                    imageUrl: providerData?.data?.icon,
+                });
             }
         });
         return _groupMenuItems.filter((d) => d.label.toLowerCase().includes(state.categorySearchText.toLowerCase()));
@@ -97,6 +95,9 @@ const state = reactive({
     }),
     metricSearchText: '',
 });
+
+const customSnakeToTitleCase = (title: string) => startCase(toLower(title.replace(/_/g, ' ')));
+
 
 /* Event */
 const handleSelectCategory = (item: MenuItem) => {


### PR DESCRIPTION
### To Reviewers
- [ ] Self-reviewed (coding conventions, bug-free, functionality verified, tests checked, documentation updated)
- [ ] Minor change, review optional (`style`, `chore`, `ci`, straightforward changes, etc.)
- [ ] Previously reviewed in feature branch, no further review needed
- [x] Need review or discussion

### Description (optional)

[Feedback](https://www.notion.so/130bfa76599680aba950d898159c2b98?pvs=4)

### Things to Talk About (optional)
