### PR TITLE
fix: fix PTextInput style bug

### DIFF
--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardHeaderTitle.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardHeaderTitle.vue
@@ -104,6 +104,7 @@ const handleClickNameConfirm = async () => {
             <p-text-input :value="dataTableNameState.proxyDataTableName"
                           class="name-input"
                           size="sm"
+                          block
                           :is-focused="state.isUnsavedTransformed"
                           @update:value="handleUpdateDataTableName"
                           @keydown.enter="handleClickNameConfirm"
@@ -176,7 +177,7 @@ const handleClickNameConfirm = async () => {
 
         /* custom design-system component - p-text-input */
         :deep(.p-text-input) {
-            @apply w-full font-normal;
+            @apply font-normal;
             .tag-container {
                 padding: 0;
             }

--- a/apps/web/src/common/modules/widgets/_widget-fields/advanced-format-rules/WidgetFieldAdvancedFormatRules.vue
+++ b/apps/web/src/common/modules/widgets/_widget-fields/advanced-format-rules/WidgetFieldAdvancedFormatRules.vue
@@ -231,11 +231,6 @@ onMounted(() => {
                 width: 1.5rem;
             }
         }
-
-        /* custom design-system component - p-text-input */
-        :deep(.p-text-input) {
-            width: 100%;
-        }
     }
 }
 
@@ -244,8 +239,5 @@ onMounted(() => {
     margin-bottom: 0;
     width: 100%;
     flex-shrink: 1;
-    .p-text-input > .input-container input {
-        width: 100%;
-    }
 }
 </style>

--- a/apps/web/src/common/modules/widgets/_widget-fields/custom-table-column-width/WidgetFieldCustomTableColumnWidth.vue
+++ b/apps/web/src/common/modules/widgets/_widget-fields/custom-table-column-width/WidgetFieldCustomTableColumnWidth.vue
@@ -271,9 +271,6 @@ onMounted(() => {
 :deep(.p-text-input) {
     width: 7.5rem;
 
-    input {
-        width: 100%;
-    }
     .input-container {
         padding-right: 1.5rem;
     }

--- a/apps/web/src/common/modules/widgets/_widget-fields/format-rules/WidgetFieldFormatRules.vue
+++ b/apps/web/src/common/modules/widgets/_widget-fields/format-rules/WidgetFieldFormatRules.vue
@@ -199,11 +199,6 @@ onMounted(() => {
                 width: 1.5rem;
             }
         }
-
-        /* custom design-system component - p-text-input */
-        :deep(.p-text-input) {
-            width: 100%;
-        }
     }
 }
 

--- a/apps/web/src/common/modules/widgets/_widget-fields/max/WidgetFieldMax.vue
+++ b/apps/web/src/common/modules/widgets/_widget-fields/max/WidgetFieldMax.vue
@@ -54,13 +54,6 @@ onMounted(() => {
 </template>
 
 <style lang="postcss" scoped>
-.widget-field-max {
-    /* custom design-system component - p-text-input */
-    :deep(.p-text-input) {
-        width: 100%;
-    }
-}
-
 /* custom design-system component - p-field-group */
 :deep(.p-field-group) {
     margin-bottom: 0;

--- a/apps/web/src/common/modules/widgets/_widget-fields/min/WidgetFieldMin.vue
+++ b/apps/web/src/common/modules/widgets/_widget-fields/min/WidgetFieldMin.vue
@@ -57,13 +57,6 @@ onMounted(() => {
 </template>
 
 <style lang="postcss" scoped>
-.widget-field-max {
-    /* custom design-system component - p-text-input */
-    :deep(.p-text-input) {
-        width: 100%;
-    }
-}
-
 /* custom design-system component - p-field-group */
 :deep(.p-field-group) {
     margin-bottom: 0;

--- a/apps/web/src/common/modules/widgets/_widget-fields/table-column-width/WidgetFieldTableColumnWidth.vue
+++ b/apps/web/src/common/modules/widgets/_widget-fields/table-column-width/WidgetFieldTableColumnWidth.vue
@@ -206,12 +206,5 @@ onMounted(() => {
 /* custom design-system component - p-text-input */
 :deep(.p-text-input) {
     max-width: 7.5rem;
-
-    input {
-        width: 100%;
-    }
-    .input-container {
-        padding-right: 1.5rem;
-    }
 }
 </style>

--- a/apps/web/src/services/advanced/pages/admin/AdminDomainSettingsAutoDormancyConfigurationPage.vue
+++ b/apps/web/src/services/advanced/pages/admin/AdminDomainSettingsAutoDormancyConfigurationPage.vue
@@ -357,7 +357,6 @@ onMounted(async () => {
                     input[type="number"] {
                         -moz-appearance: textfield;
                         appearance: textfield;
-                        width: 100%;
                     }
 
                     input[type="number"]::-webkit-outer-spin-button,

--- a/apps/web/src/services/alert-manager/components/EscalationPolicyFormRulesInput.vue
+++ b/apps/web/src/services/alert-manager/components/EscalationPolicyFormRulesInput.vue
@@ -406,12 +406,6 @@ watch(() => isAllValid.value, (_isAllValid) => {
                 margin-bottom: 0;
             }
 
-            /* custom design-system component - p-text-input */
-            :deep(.p-text-input) {
-                input {
-                    width: 100%;
-                }
-            }
             .repeat-input {
                 width: 6.5rem;
             }

--- a/apps/web/src/services/alert-manager/components/EscalationPolicyFormRulesInput.vue
+++ b/apps/web/src/services/alert-manager/components/EscalationPolicyFormRulesInput.vue
@@ -371,9 +371,6 @@ watch(() => isAllValid.value, (_isAllValid) => {
             /* custom design-system component - p-text-input */
             :deep(.p-text-input) {
                 width: 6rem;
-                input {
-                    width: 100%;
-                }
             }
 
             .rule-input-wrapper {

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerQueryFormSidebar.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerQueryFormSidebar.vue
@@ -187,6 +187,7 @@ watch(() => metricExplorerPageState.showMetricQueryFormSidebar, (visible) => {
                 >
                     <p-text-input :value="name"
                                   :invalid="invalidState.name"
+                                  block
                                   @update:value="setForm('name', $event)"
                     />
                 </p-field-group>
@@ -215,6 +216,7 @@ watch(() => metricExplorerPageState.showMetricQueryFormSidebar, (visible) => {
                     <p-text-input v-if="metricExplorerPageState.metricQueryFormMode !== 'VIEW'"
                                   :value="unit"
                                   placeholder="Count"
+                                  block
                                   @update:value="setForm('unit', $event)"
                     />
                     <p v-else
@@ -278,9 +280,6 @@ watch(() => metricExplorerPageState.showMetricQueryFormSidebar, (visible) => {
         flex-direction: column;
         width: 100%;
         padding: 0 1.5rem;
-        :deep(.p-text-input) {
-            width: 100%;
-        }
 
         .query-field {
             @apply col-span-12;

--- a/apps/web/src/services/cost-explorer/components/CostReportSettingsModal.vue
+++ b/apps/web/src/services/cost-explorer/components/CostReportSettingsModal.vue
@@ -197,6 +197,7 @@ watch(() => props.visible, (visible) => {
                         <p-text-input :value="issueDay"
                                       :invalid="invalid"
                                       :disabled="state.enableLastDay"
+                                      block
                                       type="number"
                                       class="input-field"
                                       @update:value="setForm('issueDay', $event)"
@@ -231,19 +232,11 @@ watch(() => props.visible, (visible) => {
     </p-button-modal>
 </template>
 
-<style lang="scss" scoped>
+<style lang="postcss" scoped>
 .input-field {
     width: 10rem;
 }
 
-/* custom design-system component - p-text-input */
-:deep(.p-text-input) {
-    .input-container {
-        .tag-container {
-            width: 90%;
-        }
-    }
-}
 .checkbox {
     padding-left: 0.5rem;
 }

--- a/apps/web/src/services/dashboards/components/dashboard-detail/DashboardVariablesFormManual.vue
+++ b/apps/web/src/services/dashboards/components/dashboard-detail/DashboardVariablesFormManual.vue
@@ -266,7 +266,6 @@ watch(() => props.originalData, (originalData) => {
                         <p-text-input :value.sync="state.step"
                                       block
                                       type="number"
-                                      class="step-input"
                                       :invalid="!state.isStepValid"
                         />
                         <template #label-extra>
@@ -391,14 +390,6 @@ watch(() => props.originalData, (originalData) => {
     }
     .divider {
         margin: 0.75rem 0;
-    }
-    .step-input {
-        /* custom design-system component - p-text-input */
-        :deep(&.p-text-input) {
-            input {
-                width: 100%;
-            }
-        }
     }
 }
 </style>

--- a/apps/web/src/services/info/components/NoticeForm.vue
+++ b/apps/web/src/services/info/components/NoticeForm.vue
@@ -186,11 +186,14 @@ watch([() => noticeDetailState.post, () => noticeDetailState.loading], async ([n
                                required
                 >
                     <template #default="{invalid}">
-                        <p-text-input :value="writerName"
-                                      :invalid="invalid"
-                                      :placeholder="$store.state.user.name || $t('INFO.NOTICE.FORM.PLACEHOLDER_REQUIRED')"
-                                      @update:value="setForm('writerName', $event)"
-                        />
+                        <div class="name-input-wrapper">
+                            <p-text-input :value="writerName"
+                                          block
+                                          :invalid="invalid"
+                                          :placeholder="$store.state.user.name || $t('INFO.NOTICE.FORM.PLACEHOLDER_REQUIRED')"
+                                          @update:value="setForm('writerName', $event)"
+                            />
+                        </div>
                     </template>
                 </p-field-group>
                 <p-field-group class="notice-label-wrapper"
@@ -283,12 +286,8 @@ watch([() => noticeDetailState.post, () => noticeDetailState.loading], async ([n
         }
     }
     .writer-name-input {
-        /* custom design-system component - p-text-input */
-        :deep(.p-text-input) {
-            @apply w-1/2;
-            .input-container {
-                @apply w-full;
-            }
+        .name-input-wrapper {
+            width: 50%;
         }
     }
     .notice-create-options-wrapper {

--- a/apps/web/src/services/project/components/ProjectGroupMemberManagementModal.vue
+++ b/apps/web/src/services/project/components/ProjectGroupMemberManagementModal.vue
@@ -187,6 +187,7 @@ watch(() => props.visible, async (visible) => {
                             :menu="state.userMenuItems"
                             :value.sync="state.searchText"
                             :selected="[]"
+                            block
                             use-auto-complete
                             use-fixed-menu-style
                             :placeholder="$t('PROJECT.LANDING.ADD_GROUP_MEMBER')"
@@ -252,11 +253,6 @@ watch(() => props.visible, async (visible) => {
         @apply bg-white border border-primary3 rounded-md;
         min-height: 23rem;
         padding: 0.75rem;
-    }
-
-    /* custom design-system component - p-text-input */
-    :deep(.p-text-input) {
-        width: 100%;
     }
 
     .p-data-loader {

--- a/apps/web/src/services/project/components/ProjectGroupMemberManagementModal.vue
+++ b/apps/web/src/services/project/components/ProjectGroupMemberManagementModal.vue
@@ -192,6 +192,7 @@ watch(() => props.visible, async (visible) => {
                             use-fixed-menu-style
                             :placeholder="$t('PROJECT.LANDING.ADD_GROUP_MEMBER')"
                             :page-size="5"
+                            block
                             @update="handleUpdateSelected"
                         />
                     </p-field-group>

--- a/apps/web/src/services/project/components/ProjectGroupMemberManagementModal.vue
+++ b/apps/web/src/services/project/components/ProjectGroupMemberManagementModal.vue
@@ -192,7 +192,6 @@ watch(() => props.visible, async (visible) => {
                             use-fixed-menu-style
                             :placeholder="$t('PROJECT.LANDING.ADD_GROUP_MEMBER')"
                             :page-size="5"
-                            block
                             @update="handleUpdateSelected"
                         />
                     </p-field-group>

--- a/packages/mirinae/src/inputs/input/text-input/PTextInput.stories.ts
+++ b/packages/mirinae/src/inputs/input/text-input/PTextInput.stories.ts
@@ -46,6 +46,7 @@ const Template: Story = {
                         v-bind="inputAttrs"
                         :value="value"
                         :size="size"
+                        :type="type"
                         :invalid="invalid"
                         :is-focused="isFocused"
                         :disabled="disabled" :block="block"

--- a/packages/mirinae/src/inputs/input/text-input/PTextInput.vue
+++ b/packages/mirinae/src/inputs/input/text-input/PTextInput.vue
@@ -41,6 +41,7 @@
                 >
                     <input v-bind="$attrs"
                            ref="inputRef"
+                           :class="{block}"
                            :tabindex="disabled || $attrs.readonly ? -1 : 0"
                            :type="inputType"
                            :value="displayedInputValue"
@@ -583,7 +584,7 @@ export default defineComponent<TextInputProps>({
         }
 
         input {
-            @apply truncate;
+            @apply truncate w-full;
             display: inline-block;
             flex-grow: 1;
             border-width: 0;
@@ -593,6 +594,7 @@ export default defineComponent<TextInputProps>({
             font-size: inherit;
             color: inherit;
             background-color: transparent;
+
             &::placeholder {
                 @apply text-gray-300;
             }

--- a/packages/mirinae/src/inputs/input/text-input/story-helper.ts
+++ b/packages/mirinae/src/inputs/input/text-input/story-helper.ts
@@ -95,6 +95,22 @@ export const getTextInputArgTypes = (): ArgTypes => {
             control: 'select',
             options: Object.values(INPUT_SIZE),
         },
+        type: {
+            name: 'type',
+            type: { name: 'string' },
+            description: 'Input Tag type. `text`, `password`, `number`, `email`, `tel`, `url`, `search`, `date`, `time`, `datetime-local`, `month`, `week` are available.',
+            table: {
+                type: {
+                    summary: 'string',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'text',
+                },
+            },
+            control: 'select',
+            options: ['text', 'password', 'number', 'email', 'tel', 'url', 'search', 'date', 'time', 'datetime-local', 'month', 'week'],
+        },
         isFocused: {
             name: 'isFocused',
             type: { name: 'boolean' },


### PR DESCRIPTION
### To Reviewers
- [x] Self-reviewed (coding conventions, bug-free, functionality verified, tests checked, documentation updated)
- [ ] Minor change, review optional (`style`, `chore`, `ci`, straightforward changes, etc.)
- [ ] Previously reviewed in feature branch, no further review needed
- [ ] Need review or discussion

### Description (optional)
Feature update
- Added a `type` prop to allow specifying input types like text, password, etc.
- Introduced a `block` class to enable full-width styling of the input element.
- Updated story helper to include new type options for better component configurability.

Apply changes
- Removed unnecessary width styling from custom components.
- Added `block` property to improve layout consistency.

### Things to Talk About (optional)
