### PR TITLE
feat(mirinae): emit 'closed' event after modal transition ends & add backdrop feature to PSidebar component

### DIFF
--- a/packages/mirinae/src/feedbacks/modals/button-modal/PButtonModal.vue
+++ b/packages/mirinae/src/feedbacks/modals/button-modal/PButtonModal.vue
@@ -2,6 +2,7 @@
     <section class="p-button-modal">
         <transition v-if="visible"
                     name="modal"
+                    @after-leave="onModalLeave"
         >
             <div class="modal-mask"
                  :class="[{'no-backdrop':!backdrop}, {'absolute': !!absolute}]"
@@ -251,6 +252,9 @@ export default defineComponent<ButtonModalProps>({
         const onConfirmClick = () => {
             emit('confirm');
         };
+        const onModalLeave = () => {
+            emit('closed');
+        };
 
         return {
             ...toRefs(state),
@@ -262,6 +266,7 @@ export default defineComponent<ButtonModalProps>({
             onCloseClick,
             onCancelClick,
             onConfirmClick,
+            onModalLeave,
         };
     },
 });

--- a/packages/mirinae/src/feedbacks/modals/button-modal/story-helper.ts
+++ b/packages/mirinae/src/feedbacks/modals/button-modal/story-helper.ts
@@ -419,6 +419,16 @@ export const getButtonModalArgTypes = (): ArgTypes => ({
             category: 'events',
         },
     },
+    onClosed: {
+        name: 'closed',
+        description: 'Emitted when modal is closed. It waits for the transition to end.',
+        table: {
+            type: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
     onUpdateVisible: {
         name: 'update:visible',
         description: 'Emitted when update visible',

--- a/packages/mirinae/src/layouts/overlay-layout/POverlayLayout.vue
+++ b/packages/mirinae/src/layouts/overlay-layout/POverlayLayout.vue
@@ -24,6 +24,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{(e: 'update:visible', val: boolean): void;
     (e: 'close'): void;
+    (e: 'closed'): void;
 }>();
 
 const handleClose = () => {
@@ -34,7 +35,9 @@ const handleClose = () => {
 
 <template>
     <div class="p-overlay-layout">
-        <transition name="fade">
+        <transition name="fade"
+                    @after-leave="emit('closed')"
+        >
             <div v-if="props.visible"
                  class="background-overlay"
             />

--- a/packages/mirinae/src/layouts/overlay-layout/story-helper.ts
+++ b/packages/mirinae/src/layouts/overlay-layout/story-helper.ts
@@ -164,6 +164,19 @@ export const getOverlayLayoutArgTypes = (): ArgTypes => ({
             category: 'events',
         },
     },
+    closed: {
+        name: 'closed',
+        description: 'Emitted when it is closed. It waits for the transition to end.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
     // default
     'title-right-extra': { table: { disable: true } },
     default: { table: { disable: true } },

--- a/packages/mirinae/src/layouts/sidebar/PSidebar.mdx
+++ b/packages/mirinae/src/layouts/sidebar/PSidebar.mdx
@@ -76,6 +76,12 @@ import * as PSidebarStories from './PSidebar.stories';
 <br/>
 <br/>
 
+## Backdrop
+<Canvas of={PSidebarStories.Backdrop} />
+
+<br/>
+<br/>
+
 ## Footer Slot
 <Canvas of={PSidebarStories.FooterSlot} />
 

--- a/packages/mirinae/src/layouts/sidebar/PSidebar.stories.ts
+++ b/packages/mirinae/src/layouts/sidebar/PSidebar.stories.ts
@@ -245,6 +245,27 @@ export const MediumSize: Story = {
     }),
 };
 
+export const Backdrop: Story = {
+    render: () => ({
+        components: { PSidebar },
+        template: `
+            <div style="height: 500px;">
+                <p-sidebar :visible="true"
+                            title="Backdrop"
+                            :hide-close-button="true"
+                            :backdrop="true"
+                            class="mt-4"
+                >
+                    <div class="p-4 min-h-full flex justify-center items-center">
+                        Non-sidebar area
+                    </div>
+                </p-sidebar>
+            </div>
+            <!--<div>-->
+        `,
+    }),
+};
+
 export const SmallSize: Story = {
     render: () => ({
         components: { PSidebar },

--- a/packages/mirinae/src/layouts/sidebar/PSidebar.vue
+++ b/packages/mirinae/src/layouts/sidebar/PSidebar.vue
@@ -88,6 +88,10 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
+        backdrop: {
+            type: Boolean,
+            default: false,
+        },
     },
     setup(props, { emit, listeners }) {
         const state = reactive({

--- a/packages/mirinae/src/layouts/sidebar/story-helper.ts
+++ b/packages/mirinae/src/layouts/sidebar/story-helper.ts
@@ -132,6 +132,21 @@ export const getSidebarArgTypes = (): ArgTypes => ({
         },
         control: null,
     },
+    backdrop: {
+        name: 'backdrop',
+        type: { name: 'boolean' },
+        description: 'Show backdrop or not',
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: true,
+            },
+        },
+        control: 'boolean',
+    },
     // slot
     titleSlot: {
         name: 'title',


### PR DESCRIPTION
### To Reviewers
- [ ] Self-reviewed (coding conventions, bug-free, functionality verified, tests checked, documentation updated)
- [ ] Minor change, review optional (`style`, `chore`, `ci`, straightforward changes, etc.)
- [ ] Previously reviewed in feature branch, no further review needed
- [x] Need review or discussion

### Description (optional)


### Things to Talk About (optional)
