### PR TITLE
feat: add new LSB navigation components and router item state management

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -62,13 +62,14 @@
     "keycloak-js": "^10.0.2",
     "lodash": "^4.17.21",
     "numeral": "^2.0.6",
-    "pinia": "^2.0.28",
+    "pinia": "^2.2.7",
     "portal-vue": "^2.1.7",
     "process": "^0.11.10",
     "prosemirror-model": "^1.19.2",
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.7.3",
     "prosemirror-view": "^1.31.5",
+    "qrcode": "^1.5.4",
     "uuid": "^8.3.2",
     "v-click-outside": "^3.0.1",
     "v-tooltip": "^2.0.3",
@@ -81,8 +82,7 @@
     "vue-selecto": "^1.6.4",
     "vuedraggable": "^2.24.3",
     "vuex": "^3.6.2",
-    "webfontloader": "^1.6.28",
-    "qrcode": "^1.5.4"
+    "webfontloader": "^1.6.28"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.4",

--- a/apps/web/src/common/modules/navigations/new-lsb/LSBContainer.vue
+++ b/apps/web/src/common/modules/navigations/new-lsb/LSBContainer.vue
@@ -1,0 +1,8 @@
+<template>
+    <aside>
+        <div class="pt-4 pb-8 px-2">
+            <slot />
+        </div>
+    </aside>
+</template>
+

--- a/apps/web/src/common/modules/navigations/new-lsb/LSBDivider.vue
+++ b/apps/web/src/common/modules/navigations/new-lsb/LSBDivider.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { PDivider } from '@cloudforet/mirinae';
+</script>
+
+<template>
+    <div class="pt-1 pb-3 px-2 my-2">
+        <p-divider />
+    </div>
+</template>

--- a/apps/web/src/common/modules/navigations/new-lsb/LSBRouterButton.vue
+++ b/apps/web/src/common/modules/navigations/new-lsb/LSBRouterButton.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { TranslateResult } from 'vue-i18n';
+import type { Location } from 'vue-router';
+
+import { PLazyImg, PI } from '@cloudforet/mirinae';
+
+import { useLsbRouterItemState } from '@/common/modules/navigations/new-lsb/composables/use-lsb-router-item-state';
+import type { LSBIcon } from '@/common/modules/navigations/new-lsb/type';
+
+const props = defineProps<{
+    label?: TranslateResult;
+    icon?: LSBIcon;
+    imgIcon?: string;
+    to?: Location;
+    currentPath?: string;
+    openNewTab?: boolean;
+}>();
+
+const {
+    isSelected,
+    iconName,
+    iconColor,
+    imgIconUrl,
+} = useLsbRouterItemState(props);
+</script>
+
+<template>
+    <router-link ref="itemEl"
+                 class="lsb-router-button inline-flex items-center w-full h-8 justify-between px-2 border border-transparent outline-none rounded-md text-gray-800"
+                 :class="[{'selected': isSelected}]"
+                 :target="props.openNewTab ? '_blank' : '_self'"
+                 :to="props.to ? props.to : {}"
+                 @click.native="$event.stopImmediatePropagation()"
+    >
+        <slot name="before-text"
+              v-bind="props"
+        />
+        <div ref="textEl"
+             class="inline-flex items-center gap-1 overflow-hidden whitespace-no-wrap"
+        >
+            <p-i v-if="props.icon"
+                 :name="iconName"
+                 :color="iconColor"
+                 width="1rem"
+                 height="1rem"
+                 class="flex-shrink-0"
+            />
+            <p-lazy-img
+                v-if="props.imgIcon"
+                :src="imgIconUrl"
+                width="1rem"
+                height="1rem"
+                class="flex-shrink-0"
+            />
+            <span class="text-label-md">
+                <slot>
+                    {{ props.label }}
+                </slot>
+            </span>
+            <slot name="after-text"
+                  v-bind="props"
+            />
+        </div>
+        <slot name="right-extra"
+              v-bind="props"
+        />
+    </router-link>
+</template>
+
+<style scoped lang="postcss">
+.lsb-router-button {
+    &:focus, &:focus-within, &:active {
+        @apply bg-white border-secondary1;
+        box-shadow: 0 0 0 2px rgba(theme('colors.secondary1'), 0.2);
+    }
+    &.selected {
+        @apply bg-blue-200;
+    }
+    &:hover {
+        @apply bg-blue-100 cursor-pointer;
+    }
+}
+</style>

--- a/apps/web/src/common/modules/navigations/new-lsb/LSBRouterItem.vue
+++ b/apps/web/src/common/modules/navigations/new-lsb/LSBRouterItem.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { useElementSize } from '@vueuse/core';
+import type { Ref } from 'vue';
+import {
+    computed, reactive, ref,
+} from 'vue';
+import type { TranslateResult } from 'vue-i18n';
+import type { Location } from 'vue-router';
+
+import { PI, PLazyImg, PTooltip } from '@cloudforet/mirinae';
+
+import type { MenuId } from '@/lib/menu/config';
+
+import BetaMark from '@/common/components/marks/BetaMark.vue';
+import NewMark from '@/common/components/marks/NewMark.vue';
+import UpdateMark from '@/common/components/marks/UpdateMark.vue';
+import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteButton.vue';
+import { FAVORITE_TYPE, type FavoriteOptions } from '@/common/modules/favorites/favorite-button/type';
+import { useLsbRouterItemState } from '@/common/modules/navigations/new-lsb/composables/use-lsb-router-item-state';
+import type { HighlightTagType, LSBIcon } from '@/common/modules/navigations/new-lsb/type';
+
+interface Props {
+    id: string;
+    label?: TranslateResult;
+    icon?: LSBIcon;
+    imgIcon?: string;
+    to?: Location;
+    currentPath?: string;
+    openNewTab?: boolean;
+    highlightTag?: HighlightTagType;
+    favoriteOptions?: FavoriteOptions;
+    hideFavorite?: boolean;
+    isAdminMode?: boolean;
+    index?: number | string;
+}
+
+const props = defineProps<Props>();
+
+const itemEl = ref<HTMLElement | null>(null);
+const textEl = ref<HTMLElement | null>(null);
+
+const state = reactive({
+    itemWidth: computed<Ref<number>>(() => useElementSize(itemEl.value).width),
+    textWidth: computed<Ref<number>>(() => useElementSize(textEl.value).width),
+    hoveredItem: '' as MenuId | string,
+    isEllipsis: computed<boolean>(() => state.hoveredItem === props.id && (state.itemWidth.value - 20 === state.textWidth.value)),
+});
+
+const getIsHovered = (itemId?: MenuId | string) => state.hoveredItem && state.hoveredItem === itemId;
+const {
+    isSelected,
+    iconName,
+    iconColor,
+    imgIconUrl,
+} = useLsbRouterItemState(props);
+</script>
+
+<template>
+    <router-link ref="itemEl"
+                 class="lsb-router-item inline-flex items-center w-full h-8 justify-between px-2 border border-transparent outline-none rounded-md text-label-md text-gray-800"
+                 :class="[{'selected': isSelected, 'is-hide-favorite': props.hideFavorite}]"
+                 :target="props.openNewTab ? '_blank' : '_self'"
+                 :to="props.to ? props.to : {}"
+                 @click.native="$event.stopImmediatePropagation()"
+                 @mouseenter.native="state.hoveredItem = props.id"
+                 @mouseleave.native="state.hoveredItem = ''"
+    >
+        <slot name="before-text"
+              v-bind="props"
+        />
+        <div ref="textEl"
+             class="inline-flex items-center overflow-hidden whitespace-no-wrap"
+        >
+            <p-i v-if="props.icon"
+                 :name="iconName"
+                 :color="iconColor"
+                 width="1rem"
+                 height="1rem"
+                 class="flex-shrink-0 ml-1"
+            />
+            <p-lazy-img
+                v-if="props.imgIcon"
+                :src="imgIconUrl"
+                width="1rem"
+                height="1rem"
+                class="flex-shrink-0 ml-1"
+            />
+            <slot>
+                <div class="item-text overflow-hidden whitespace-no-wrap">
+                    <p-tooltip v-if="state.isEllipsis"
+                               position="bottom-start"
+                               :contents="props.label"
+                    >
+                        {{ props.label }}
+                    </p-tooltip>
+                    <span v-else>{{ props.label }}</span>
+                </div>
+            </slot>
+            <slot name="after-text"
+                  v-bind="props"
+            />
+            <span class="mark-wrapper h-full">
+                <new-mark v-if="props.highlightTag === 'new'" />
+                <update-mark v-else-if="props.highlightTag === 'update'" />
+                <beta-mark v-else-if="props.highlightTag === 'beta'" />
+            </span>
+        </div>
+        <slot name="right-extra"
+              v-bind="props"
+        />
+        <favorite-button
+            v-if="!hideFavorite && !isAdminMode"
+            :item-id="props.favoriteOptions?.id ? props.favoriteOptions.id : props.id"
+            :favorite-type="props.favoriteOptions?.type ? props.favoriteOptions.type : FAVORITE_TYPE.MENU"
+            :visible-active-case-only="!getIsHovered(props.id)"
+            scale="0.8"
+            class="flex-shrink-0 ml-1"
+        />
+    </router-link>
+</template>
+
+<style lang="postcss" scoped>
+.lsb-router-item {
+    &:focus, &:focus-within, &:active {
+        @apply bg-white border-secondary1;
+        box-shadow: 0 0 0 2px rgba(theme('colors.secondary1'), 0.2);
+    }
+    &.selected {
+        @apply bg-blue-200;
+    }
+    &.is-hide-favorite {
+        .favorite-button {
+            @apply hidden;
+        }
+        &:hover {
+            .favorite-button {
+                @apply block;
+            }
+        }
+    }
+    &:hover {
+        @apply bg-blue-100 cursor-pointer;
+    }
+    .item-text {
+        text-overflow: ellipsis;
+    }
+    .mark-wrapper {
+        margin-top: -0.25rem;
+    }
+}
+</style>

--- a/apps/web/src/common/modules/navigations/new-lsb/LSBTopTitle.vue
+++ b/apps/web/src/common/modules/navigations/new-lsb/LSBTopTitle.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { Location } from 'vue-router';
+
+import {
+    PLazyImg,
+} from '@cloudforet/mirinae';
+
+import { assetUrlConverter } from '@/lib/helper/asset-helper';
+
+
+const props = defineProps<{
+    label?: string;
+    icon?: string;
+    subText?: string;
+    visibleAddButton?: boolean;
+    addButtonLink?: Location;
+}>();
+</script>
+
+<template>
+    <div class=" flex items-center gap-1 h-8 mt-1 pb-2 px-2 text-gray-800 font-bold text-label-md">
+        <div class="flex items-center h-6">
+            <p-lazy-img
+                v-if="props.icon"
+                :src="assetUrlConverter(props.icon)"
+                width="1.5rem"
+                height="1.5rem"
+                class="icon rounded flex-shrink-0"
+            />
+            <span>
+                <slot>{{ props.label }}</slot>
+                <span v-if="props.subText"
+                      class="font-normal"
+                >{{ props.subText }}</span>
+            </span>
+        </div>
+    </div>
+</template>

--- a/apps/web/src/common/modules/navigations/new-lsb/composables/use-lsb-router-item-state.ts
+++ b/apps/web/src/common/modules/navigations/new-lsb/composables/use-lsb-router-item-state.ts
@@ -1,0 +1,50 @@
+import type { UnwrapRef, Ref } from 'vue';
+import { computed } from 'vue';
+import type { Location } from 'vue-router';
+import { useRouter } from 'vue-router/composables';
+
+import { assetUrlConverter } from '@/lib/helper/asset-helper';
+
+import type { LSBIcon } from '@/common/modules/navigations/new-lsb/type';
+
+interface UseLsbRouterItemProps {
+    to?: Ref<Readonly<Location>>;
+    currentPath?: Ref<Readonly<string>>;
+    icon?: Ref<Readonly<LSBIcon>>;
+    imgIcon?: Ref<Readonly<string>>;
+}
+export const useLsbRouterItemState = (props: UnwrapRef<UseLsbRouterItemProps>) => {
+    const router = useRouter();
+
+    const isSelected = computed<boolean>(() => {
+        let currentPath = props.currentPath;
+        if (!currentPath || !props.to) return false;
+
+        const resolved = router.resolve(props.to);
+        if (!resolved) return false;
+
+        if (currentPath.indexOf('?') > 0) {
+            currentPath = currentPath.slice(0, currentPath.indexOf('?'));
+        }
+        const resolvedHref = resolved.href;
+        return currentPath === resolvedHref;
+    });
+    const iconName = computed<string>(() => {
+        if (!props.icon) return '';
+        if (typeof props.icon === 'string') return props.icon;
+        return props.icon.name;
+    });
+    const iconColor = computed<string>(() => {
+        if (!props.icon) return 'inherit';
+        if (typeof props.icon === 'string') return 'inherit';
+        return props.icon.color || 'inherit';
+    });
+    const imgIconUrl = computed<string>(() => (props.imgIcon ? assetUrlConverter(props.imgIcon) : ''));
+
+    return {
+        isSelected,
+        iconName,
+        iconColor,
+        imgIconUrl,
+    };
+};

--- a/apps/web/src/common/modules/navigations/new-lsb/type.ts
+++ b/apps/web/src/common/modules/navigations/new-lsb/type.ts
@@ -1,0 +1,2 @@
+export type LSBIcon = string | { name: string; color?: string; };
+export type HighlightTagType = 'new' | 'beta' | 'update';

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,7 +210,7 @@
         "keycloak-js": "^10.0.2",
         "lodash": "^4.17.21",
         "numeral": "^2.0.6",
-        "pinia": "^2.0.28",
+        "pinia": "^2.2.7",
         "portal-vue": "^2.1.7",
         "process": "^0.11.10",
         "prosemirror-model": "^1.19.2",
@@ -863,31 +863,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "apps/web/node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "apps/web/node_modules/@vueuse/integrations": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-11.1.0.tgz",
@@ -986,31 +961,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "apps/web/node_modules/@vueuse/integrations/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "apps/web/node_modules/@vueuse/metadata": {
       "version": "10.7.2",
       "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.2.tgz",
@@ -1028,31 +978,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "apps/web/node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "apps/web/node_modules/acorn": {
@@ -11981,9 +11906,9 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
     "node_modules/@vue/reactivity": {
       "version": "3.4.31",
@@ -25582,12 +25507,12 @@
       }
     },
     "node_modules/pinia": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.28.tgz",
-      "integrity": "sha512-YClq9DkqCblq9rlyUual7ezMu/iICWdBtfJrDt4oWU9Zxpijyz7xB2xTwx57DaBQ96UGvvTMORzALr+iO5PVMw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.7.tgz",
+      "integrity": "sha512-M+X9Eh9V5De+8wyj0rD1cgB0zy1mPN/aBEpCI9y+DgVmzXV2dIwjYBluJ5cMQd/jAoHs0VW+EyUSHMZv/Wtcnw==",
       "dependencies": {
-        "@vue/devtools-api": "^6.4.5",
-        "vue-demi": "*"
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
@@ -25595,7 +25520,7 @@
       "peerDependencies": {
         "@vue/composition-api": "^1.4.0",
         "typescript": ">=4.4.4",
-        "vue": "^2.6.14 || ^3.2.0"
+        "vue": "^2.6.14 || ^3.5.11"
       },
       "peerDependenciesMeta": {
         "@vue/composition-api": {
@@ -34416,9 +34341,9 @@
       "dev": true
     },
     "node_modules/vue-demi": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.0.tgz",
-      "integrity": "sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -44254,9 +44179,9 @@
       }
     },
     "@vue/devtools-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
     "@vue/reactivity": {
       "version": "3.4.31",
@@ -54374,12 +54299,12 @@
       "dev": true
     },
     "pinia": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.28.tgz",
-      "integrity": "sha512-YClq9DkqCblq9rlyUual7ezMu/iICWdBtfJrDt4oWU9Zxpijyz7xB2xTwx57DaBQ96UGvvTMORzALr+iO5PVMw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.7.tgz",
+      "integrity": "sha512-M+X9Eh9V5De+8wyj0rD1cgB0zy1mPN/aBEpCI9y+DgVmzXV2dIwjYBluJ5cMQd/jAoHs0VW+EyUSHMZv/Wtcnw==",
       "requires": {
-        "@vue/devtools-api": "^6.4.5",
-        "vue-demi": "*"
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
       }
     },
     "pinkie": {
@@ -61390,9 +61315,9 @@
       "dev": true
     },
     "vue-demi": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.0.tgz",
-      "integrity": "sha512-gt58r2ogsNQeVoQ3EhoUAvUsH9xviydl0dWJj7dabBC/2L4uBId7ujtCwDRD0JhkGsV1i0CtfLAeyYKBht9oWg==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "requires": {}
     },
     "vue-docgen-api": {
@@ -61884,7 +61809,7 @@
         "keycloak-js": "^10.0.2",
         "lodash": "^4.17.21",
         "numeral": "^2.0.6",
-        "pinia": "^2.0.28",
+        "pinia": "^2.2.7",
         "portal-vue": "^2.1.7",
         "postcss": "^8.4.31",
         "postcss-config-custom": "*",
@@ -62211,14 +62136,6 @@
             "@vueuse/metadata": "10.7.2",
             "@vueuse/shared": "10.7.2",
             "vue-demi": ">=0.14.6"
-          },
-          "dependencies": {
-            "vue-demi": {
-              "version": "0.14.7",
-              "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-              "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-              "requires": {}
-            }
           }
         },
         "@vueuse/integrations": {
@@ -62254,12 +62171,6 @@
               "requires": {
                 "vue-demi": ">=0.14.10"
               }
-            },
-            "vue-demi": {
-              "version": "0.14.10",
-              "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-              "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-              "requires": {}
             }
           }
         },
@@ -62274,14 +62185,6 @@
           "integrity": "sha512-qFbXoxS44pi2FkgFjPvF4h7c9oMDutpyBdcJdMYIMg9XyXli2meFMuaKn+UMgsClo//Th6+beeCgqweT/79BVA==",
           "requires": {
             "vue-demi": ">=0.14.6"
-          },
-          "dependencies": {
-            "vue-demi": {
-              "version": "0.14.7",
-              "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-              "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-              "requires": {}
-            }
           }
         },
         "acorn": {


### PR DESCRIPTION
### To Reviewers
- [ ] Self-reviewed (coding conventions, bug-free, functionality verified, tests checked, documentation updated)
- [ ] Minor change, review optional (`style`, `chore`, `ci`, straightforward changes, etc.)
- [ ] Previously reviewed in feature branch, no further review needed
- [x] Need review or discussion

### Description (optional)

####  Example
<img width="314" alt="image" src="https://github.com/user-attachments/assets/29939790-3e32-4499-9606-4867babb6351">

```html
<l-s-b-container>
    <l-s-b-router-button icon="ic_dots-4-square">
        All Categories
    </l-s-b-router-button>
    <l-s-b-divider />
    <l-s-b-top-title>Category</l-s-b-top-title>
    <l-s-b-router-item id="test"
                       to="/test"
    >
        Test
    </l-s-b-router-item>
</l-s-b-container>
```


#### Key Changes

1. **New LSB Navigation Components Added**
   - **`LSBContainer`**: Base container for padding
   - **`LSBDivider`**: Divider between items
   - **`LSBTopTitle`**: Displays the top title of the LSB
   - **`LSBRouterButton`**: Single router button
   - **`LSBRouterItem`**: Repeatedly rendered router item

2. **LSB Router Item State Hook Added**
   - Common hook to manage routing state (current path, active status, etc.)
 
---
  
#### 주요 변경사항

1. **새로운 LSB 내비게이션 컴포넌트 추가**
   - **`LSBContainer`**: padding 처리용 기본 컨테이너
   - **`LSBDivider`**: 항목 간 구분선
   - **`LSBTopTitle`**: LSB 상단 제목 표시
   - **`LSBRouterButton`**: 단일 라우터 버튼
   - **`LSBRouterItem`**: 반복 렌더링되는 라우터 항목

2. **LSB 라우터 아이템 상태 훅 추가**
   - 라우팅 상태(현재 경로, 활성 여부 등)를 관리하는 공통 훅 구현


### Things to Talk About (optional)
