### PR TITLE
build: update tailwindcss and dependencies

### DIFF
--- a/apps/web/src/common/components/marks/BetaMark.vue
+++ b/apps/web/src/common/components/marks/BetaMark.vue
@@ -7,7 +7,7 @@
 
 <style lang="postcss">
 .beta-mark {
-    @apply text-coral;
+    @apply text-coral-default;
     font-size: 0.625rem;
     vertical-align: text-top;
     cursor: default;

--- a/apps/web/src/common/modules/monitoring/MetricChart.vue
+++ b/apps/web/src/common/modules/monitoring/MetricChart.vue
@@ -164,7 +164,7 @@ useResizeObserver(chartContext, throttle(() => {
             @apply text-sm font-bold capitalize truncate;
         }
         .chart-unit {
-            @apply text-sm text-gray flex-shrink ml-2;
+            @apply text-sm text-gray-default flex-shrink ml-2;
         }
     }
 

--- a/apps/web/src/common/modules/monitoring/Monitoring.vue
+++ b/apps/web/src/common/modules/monitoring/Monitoring.vue
@@ -472,6 +472,11 @@ section {
         row-gap: 3rem;
         column-gap: 1rem;
     }
+    .p-metric-chart {
+        @apply col-span-3;
+        @apply laptop:col-span-4;
+        @apply tablet:col-span-12;
+    }
 
     /* custom design-system component - p-button */
     :deep(.more-btn) {

--- a/apps/web/src/common/modules/monitoring/Monitoring.vue
+++ b/apps/web/src/common/modules/monitoring/Monitoring.vue
@@ -12,7 +12,7 @@
             <span class="title">
                 {{ $t('COMMON.MONITORING.RESOURCE') }}
             </span>
-            <span class="ml-4 text-gray text-sm">
+            <span class="ml-4 text-gray-default text-sm">
                 * {{ $t('COMMON.MONITORING.LIMIT_OF_RESOURCE', {
                     limitCount: 16,
                 }) }}
@@ -62,7 +62,7 @@
         <section class="chart-section">
             <i18n path="COMMON.MONITORING.DISPLAY_TIMEZONE"
                   tag="p"
-                  class="text-sm text-gray mb-12"
+                  class="text-sm text-gray-default mb-12"
             >
                 <template #timezone>
                     <strong>{{ $t('COMMON.MONITORING.LOCAL_TIME') }}</strong>
@@ -471,18 +471,6 @@ section {
         grid-auto-rows: auto;
         row-gap: 3rem;
         column-gap: 1rem;
-
-        .p-metric-chart {
-            @apply col-span-3;
-
-            @screen laptop {
-                @apply col-span-4;
-            }
-
-            @screen tablet {
-                @apply col-span-12;
-            }
-        }
     }
 
     /* custom design-system component - p-button */

--- a/apps/web/src/common/modules/navigations/gnb/GNBNavigationRail.vue
+++ b/apps/web/src/common/modules/navigations/gnb/GNBNavigationRail.vue
@@ -298,7 +298,7 @@ onMounted(async () => {
                 &.is-selected {
                     @apply relative bg-violet-100 text-violet-600;
                     &::before {
-                        @apply absolute bg-violet;
+                        @apply absolute bg-violet-default;
                         content: '';
                         top: 0.125rem;
                         left: -0.75rem;

--- a/apps/web/src/common/modules/navigations/lsb/modules/LSBRouterMenuItem.vue
+++ b/apps/web/src/common/modules/navigations/lsb/modules/LSBRouterMenuItem.vue
@@ -158,9 +158,9 @@ const getIconName = (icon: LSBIcon): string => {
         @apply bg-blue-100 cursor-pointer;
     }
     .text-wrapper {
-        @apply inline-flex items-center overflow-hidden whitespace-no-wrap;
+        @apply inline-flex items-center overflow-hidden whitespace-nowrap;
         .text {
-            @apply overflow-hidden whitespace-no-wrap;
+            @apply overflow-hidden whitespace-nowrap;
             text-overflow: ellipsis;
         }
         .icon {

--- a/apps/web/src/common/modules/navigations/top-bar/TopBar.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/TopBar.vue
@@ -103,7 +103,7 @@ const handleOpenMenu = (menuId: MenuId) => {
 @screen mobile {
     .top-bar {
         .middle-section {
-            @apply justify-end;
+            justify-content: flex-end;
         }
     }
 }

--- a/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-header/TopBarWorkspaces.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-header/TopBarWorkspaces.vue
@@ -309,9 +309,7 @@ onMounted(() => {
             gap: 0.25rem;
 
             .omitable-text {
-                @screen mobile {
-                    @apply hidden;
-                }
+                @apply mobile:hidden;
             }
         }
 
@@ -442,17 +440,13 @@ onMounted(() => {
             vertical-align: bottom;
             padding-left: 0.5rem;
 
-            @screen tablet {
-                @apply hidden;
-            }
+            @apply tablet:hidden;
         }
         .tablet-selected {
             @apply hidden text-label-lg text-gray-800;
             padding-left: 0.75rem;
 
-            @screen tablet {
-                @apply inline-block;
-            }
+            @apply tablet:inline-block;
         }
     }
 }

--- a/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-toolset/modules/top-bar-profile/TopBarProfile.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-toolset/modules/top-bar-profile/TopBarProfile.vue
@@ -418,7 +418,7 @@ watch(() => props.visible, (value) => {
         }
     }
 
-    @define-mixin menu-dropdown {
+    .profile-menu-wrapper {
         @apply bg-white border border-gray-200 rounded-xs;
         position: absolute;
         top: 100%;
@@ -426,9 +426,7 @@ watch(() => props.visible, (value) => {
         left: auto;
         z-index: 1000;
         box-shadow: 0 0 0.875rem rgba(0, 0, 0, 0.1);
-    }
-    .profile-menu-wrapper {
-        @mixin menu-dropdown;
+
         min-width: 19.5rem;
 
         .user-info {
@@ -486,7 +484,12 @@ watch(() => props.visible, (value) => {
                     .value {
                         position: relative;
                         .language-menu-wrapper, .currency-menu-wrapper {
-                            @mixin menu-dropdown;
+                            @apply bg-white border border-gray-200 rounded-xs;
+                            position: absolute;
+                            top: 100%;
+                            right: -0.5rem;
+                            box-shadow: 0 0 0.875rem rgba(0, 0, 0, 0.1);
+
                             left: -1rem;
                             min-width: 9.25rem;
                             max-height: 21rem;

--- a/apps/web/src/common/modules/portals/HandbookButton.vue
+++ b/apps/web/src/common/modules/portals/HandbookButton.vue
@@ -195,7 +195,7 @@ export default defineComponent({
 
 @screen lg {
     .handbook-contents {
-        @apply overflow-auto;
+        overflow: auto;
         height: calc(100vh - 10.325rem);
         &::before {
             bottom: 2.225rem;
@@ -209,7 +209,7 @@ export default defineComponent({
                 height: calc(100% - 3.5rem);
             }
             .tab-pane {
-                @apply overflow-auto;
+                overflow: auto;
                 height: calc(100% - 6.25rem);
             }
         }

--- a/apps/web/src/common/modules/widgets/DailyUpdates.vue
+++ b/apps/web/src/common/modules/widgets/DailyUpdates.vue
@@ -345,7 +345,8 @@ export default {
             background-color: rgba(theme('colors.white'));
         }
         .title {
-            @apply text-sm leading-normal;
+            font-size: 0.875rem;
+            line-height: 1.5;
         }
     }
 }
@@ -373,7 +374,7 @@ export default {
 }
 
 .card-wrapper {
-    @apply overflow-hidden whitespace-no-wrap w-full rounded-md;
+    @apply overflow-hidden whitespace-nowrap w-full rounded-md;
     height: 100%;
     &.fixed-height {
         height: 16rem;

--- a/apps/web/src/common/pages/AlertPublicDetailPage.vue
+++ b/apps/web/src/common/pages/AlertPublicDetailPage.vue
@@ -399,7 +399,9 @@ const handleRouteToSignInWithRedirectPath = () => {
         @screen tablet {
             margin-top: 0;
             .main-contents-wrapper {
-                @apply row-start-1 row-end-1 col-span-12;
+                grid-row-start: 1;
+                grid-row-end: 1;
+                grid-column: span 12 / span 12;
             }
         }
     }

--- a/apps/web/src/services/advanced/components/BookmarkLSB.vue
+++ b/apps/web/src/services/advanced/components/BookmarkLSB.vue
@@ -122,7 +122,7 @@ const state = reactive({
         @apply w-full;
     }
     .search-result-text {
-        @apply overflow-hidden whitespace-no-wrap;
+        @apply overflow-hidden whitespace-nowrap;
         text-overflow: ellipsis;
     }
     .search-empty {

--- a/apps/web/src/services/advanced/pages/admin/AdminDomainSettingsAutoDormancyConfigurationPage.vue
+++ b/apps/web/src/services/advanced/pages/admin/AdminDomainSettingsAutoDormancyConfigurationPage.vue
@@ -390,13 +390,14 @@ onMounted(async () => {
 
     @screen tablet {
         .cost-report-button {
-            @apply hidden;
+            display: none;
         }
     }
 
     @screen mobile {
         .cost-wrapper {
-            @apply flex-col items-center;
+            flex-direction: column;
+            align-items: center;
             .cost-threshold-chart {
                 width: auto;
                 height: auto;

--- a/apps/web/src/services/alert-manager/components/AlertDashboardAlertHistoryWidget.vue
+++ b/apps/web/src/services/alert-manager/components/AlertDashboardAlertHistoryWidget.vue
@@ -249,16 +249,18 @@ watch(() => state.currentDate, async () => {
     @screen tablet {
         .content-wrapper {
             .summary-wrapper {
-                @apply col-span-12 row-start-2;
+                grid-column: span 12 / span 12;
+                grid-row-start: 2;
 
                 /* custom design-system component - p-card */
                 :deep(.p-card) {
-                    @apply col-span-6;
+                    grid-column: span 6 / span 6;
                 }
             }
 
             .chart-wrapper {
-                @apply col-span-12 row-start-1;
+                grid-column: span 12 / span 12;
+                grid-row-start: 1;
                 height: 12rem;
                 padding-bottom: 1rem;
             }
@@ -270,7 +272,7 @@ watch(() => state.currentDate, async () => {
             .summary-wrapper {
                 /* custom design-system component - p-card */
                 :deep(.p-card) {
-                    @apply col-span-12;
+                    grid-column: span 12 / span 12;
                 }
             }
         }

--- a/apps/web/src/services/alert-manager/components/AlertDashboardAlertHistoryWidgetChart.vue
+++ b/apps/web/src/services/alert-manager/components/AlertDashboardAlertHistoryWidgetChart.vue
@@ -213,10 +213,3 @@ watch(() => props.activatedProjects, async (activatedProjects) => {
     }
 }
 </style>
-<style lang="postcss">
-.AlertHistoryChartAxisRendererX-group {
-    @screen tablet {
-        display: none;
-    }
-}
-</style>

--- a/apps/web/src/services/alert-manager/components/AlertDashboardAlertStateWidget.vue
+++ b/apps/web/src/services/alert-manager/components/AlertDashboardAlertStateWidget.vue
@@ -481,7 +481,9 @@ watch([() => state.isAssignedToMe, () => tabState.activeTab], async () => {
                         }
                     }
                     .body {
-                        @apply border-t-0 rounded-t-none;
+                        border-top-width: 0;
+                        border-top-left-radius: 0;
+                        border-top-right-radius: 0;
                         max-height: 21.875rem;
                     }
                 }

--- a/apps/web/src/services/alert-manager/components/AlertDashboardProjectSearchWidget.vue
+++ b/apps/web/src/services/alert-manager/components/AlertDashboardProjectSearchWidget.vue
@@ -229,7 +229,7 @@ watch(() => props.activatedProjects, async (activatedProjects) => {
     @screen mobile {
         .box-group {
             .box {
-                @apply col-span-12;
+                grid-column: span 12 / span 12;
             }
         }
     }

--- a/apps/web/src/services/alert-manager/components/AlertMainDataTableActions.vue
+++ b/apps/web/src/services/alert-manager/components/AlertMainDataTableActions.vue
@@ -253,11 +253,11 @@ const onConfirmResolve = () => {
 
     @screen mobile {
         .only-desktop {
-            @apply hidden;
+            display: none;
         }
 
         .only-mobile {
-            @apply inline-block;
+            display: inline-block;
         }
     }
 }

--- a/apps/web/src/services/alert-manager/components/AlertMainDataTableBottomFilters.vue
+++ b/apps/web/src/services/alert-manager/components/AlertMainDataTableBottomFilters.vue
@@ -158,17 +158,18 @@ watch([() => state.selectedAlertState, () => state.selectedUrgency, () => state.
     }
 
     @screen mobile {
-        @apply overflow-x-auto w-full flex-wrap;
-
+        width: 100%;
+        flex-wrap: wrap;
+        overflow-x: auto;
         .filter {
-            @apply w-full;
+            width: 100%;
             margin: 0.5rem 0;
 
             &.filter-assigned {
                 /* custom design-system component - p-checkbox */
                 :deep(.p-checkbox) {
                     .text {
-                        @apply inline-block;
+                        display: inline-block;
                         margin-left: 0.375rem;
                     }
                 }
@@ -176,11 +177,11 @@ watch([() => state.selectedAlertState, () => state.selectedUrgency, () => state.
         }
 
         .only-desktop {
-            @apply hidden;
+            display: none;
         }
 
         .only-mobile {
-            @apply inline-block;
+            display: inline-block;
         }
     }
 }

--- a/apps/web/src/services/alert-manager/components/EscalationPolicyFormRulesInput.vue
+++ b/apps/web/src/services/alert-manager/components/EscalationPolicyFormRulesInput.vue
@@ -453,7 +453,7 @@ watch(() => isAllValid.value, (_isAllValid) => {
 
         .label-row {
             .col-step {
-                @apply col-span-2;
+                grid-column: span 2 / span 2;
             }
             .col-notification, .col-rule {
                 display: none;
@@ -462,7 +462,7 @@ watch(() => isAllValid.value, (_isAllValid) => {
         .content-row {
             height: auto;
             .col-step {
-                @apply col-span-2;
+                grid-column: span 2 / span 2;
                 height: 100%;
                 padding-top: 0.375rem;
             }
@@ -470,16 +470,21 @@ watch(() => isAllValid.value, (_isAllValid) => {
                 display: none;
             }
             .col-mobile-input {
-                @apply col-span-8 grid grid-cols-8 text-gray-900;
+                grid-column: span 8 / span 8;
+                display: grid;
+                grid-template-columns: repeat(8, minmax(0, 1fr));
+
+                --tw-text-opacity: 1;
+                color: rgb(35 37 51 / var(--tw-text-opacity, 1));
                 row-gap: 0.5rem;
                 font-size: 0.75rem;
 
                 .label {
-                    @apply col-span-4;
+                    grid-column: span 4 / span 4;
                     margin: auto 0;
                 }
                 .input {
-                    @apply col-span-4;
+                    grid-column: span 4 / span 4;
 
                     /* custom design-system component - p-select-dropdown */
                     :deep(.p-select-dropdown) {
@@ -490,7 +495,7 @@ watch(() => isAllValid.value, (_isAllValid) => {
                     }
                 }
                 .col-mobile-rule {
-                    @apply col-span-8;
+                    grid-column: span 8 / span 8;
                     display: flex;
                     align-items: center;
                     justify-content: space-between;
@@ -503,15 +508,17 @@ watch(() => isAllValid.value, (_isAllValid) => {
         }
         .add-row {
             .col-icon {
-                @apply col-span-2;
+                grid-column: span 2 / span 2;
             }
             .col-mobile-label {
-                @apply col-span-4 text-gray-900;
+                --tw-text-opacity: 1;
+                color: rgb(35 37 51 / var(--tw-text-opacity, 1));
+                grid-column: span 4 / span 4;
                 display: block;
                 font-size: 0.75rem;
             }
             .col-input {
-                @apply col-span-4;
+                grid-column: span 4 / span 4;
                 .repeat-input {
                     width: 6rem;
                 }
@@ -520,7 +527,7 @@ watch(() => isAllValid.value, (_isAllValid) => {
                 display: none;
             }
             .add-button {
-                @apply col-span-12;
+                grid-column: span 12 / span 12;
                 position: relative;
                 margin-top: 0.75rem;
             }

--- a/apps/web/src/services/alert-manager/pages/AlertDashboardPage.vue
+++ b/apps/web/src/services/alert-manager/pages/AlertDashboardPage.vue
@@ -99,10 +99,10 @@ const listProjectAlertConfig = async () => {
     @screen tablet {
         .widget-wrapper {
             .current-project-status-widget {
-                @apply col-span-6;
+                grid-column: span 6 / span 6;
             }
             .top5-project-activity-widget {
-                @apply col-span-6;
+                grid-column: span 6 / span 6;
             }
         }
     }
@@ -110,10 +110,10 @@ const listProjectAlertConfig = async () => {
     @screen mobile {
         .widget-wrapper {
             .current-project-status-widget {
-                @apply col-span-12;
+                grid-column: span 12 / span 12;
             }
             .top5-project-activity-widget {
-                @apply col-span-12;
+                grid-column: span 12 / span 12;
             }
         }
     }

--- a/apps/web/src/services/alert-manager/pages/AlertDetailPage.vue
+++ b/apps/web/src/services/alert-manager/pages/AlertDetailPage.vue
@@ -221,17 +221,21 @@ const alertTitleEditConfirm = async () => {
     @screen tablet {
         margin-top: 0;
         .main-contents-wrapper {
-            @apply row-start-1 row-end-1 col-span-12;
+            grid-row-start: 1;
+            grid-row-end: 1;
+            grid-column: span 12 / span 12;
         }
 
         .sub-contents-wrapper {
-            @apply row-start-2 row-end-2 col-span-12;
+            grid-row-start: 2;
+            grid-row-end: 2;
+            grid-column: span 12 / span 12;
         }
     }
 
     @screen mobile {
         .sub-contents-wrapper {
-            @apply col-span-12;
+            grid-column: span 12 / span 12;
             margin-top: -4rem;
         }
     }

--- a/apps/web/src/services/asset-inventory/components/CloudServices.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServices.vue
@@ -276,18 +276,9 @@ export default {
 <style lang="postcss" scoped>
 .card-wrapper {
     @apply grid gap-2 grid-cols-1;
-
-    @screen sm {
-        @apply grid-cols-2;
-    }
-
-    @screen md {
-        @apply grid-cols-4;
-    }
-
-    @screen lg {
-        @apply grid-cols-1;
-    }
+    @apply sm:grid-cols-2;
+    @apply md:grid-cols-4;
+    @apply lg:grid-cols-1;
 
     .card {
         display: flex;
@@ -345,7 +336,7 @@ export default {
         font-size: 0.875rem;
     }
     .name {
-        @apply text-xs text-gray truncate leading-tight;
+        @apply text-xs text-gray-default truncate leading-tight;
         text-decoration: none;
     }
     .count {

--- a/apps/web/src/services/asset-inventory/components/CollectorCreateStep1SearchFilter.vue
+++ b/apps/web/src/services/asset-inventory/components/CollectorCreateStep1SearchFilter.vue
@@ -243,12 +243,13 @@ watch(() => state.selectedRepository, (repository) => {
 }
 
 @screen tablet {
-    @apply flex-col;
+    flex-direction: column;
 
     .left-area {
         width: 100%;
         .dropdown-container {
-            @apply flex gap-4;
+            display: flex;
+            gap: 1rem;
         }
     }
 }
@@ -256,7 +257,9 @@ watch(() => state.selectedRepository, (repository) => {
 @screen mobile {
     .left-area {
         .dropdown-container {
-            @apply grid grid-cols-2 gap-4;
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 1rem;
             width: 100%;
         }
     }

--- a/apps/web/src/services/asset-inventory/components/CollectorMainContentItem.vue
+++ b/apps/web/src/services/asset-inventory/components/CollectorMainContentItem.vue
@@ -244,7 +244,7 @@ watch(() => props.item.schedule, (schedule) => {
                 margin-top: 1.125rem;
 
                 @screen tablet {
-                    @apply flex-col;
+                    flex-direction: column;
                     gap: 1rem;
                 }
                 .collector-info-view {
@@ -258,7 +258,7 @@ watch(() => props.item.schedule, (schedule) => {
                     }
 
                     @screen mobile {
-                        @apply relative;
+                        position: relative;
                         display: initial;
                     }
                 }

--- a/apps/web/src/services/asset-inventory/components/CollectorMainContents.vue
+++ b/apps/web/src/services/asset-inventory/components/CollectorMainContents.vue
@@ -333,14 +333,8 @@ onMounted(async () => {
         }
         .collector-lists {
             @apply grid grid-cols-3 gap-4;
-
-            @screen desktop {
-                @apply grid-cols-2;
-            }
-
-            @screen tablet {
-                @apply flex flex-col;
-            }
+            @apply desktop:grid-cols-2;
+            @apply tablet:flex tablet:flex-col;
         }
     }
 }

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerLSB.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerLSB.vue
@@ -474,7 +474,7 @@ watch(() => storeState.selectedNamespace, (selectedNamespace) => {
                         @apply bg-blue-100 cursor-pointer;
                     }
                     .text {
-                        @apply text-label-md overflow-hidden whitespace-no-wrap;
+                        @apply text-label-md overflow-hidden whitespace-nowrap;
                         text-overflow: ellipsis;
                     }
                 }

--- a/apps/web/src/services/asset-inventory/components/RecentCollectorJobList.vue
+++ b/apps/web/src/services/asset-inventory/components/RecentCollectorJobList.vue
@@ -162,9 +162,9 @@ watch(() => props.recentJobs, () => {
 
         @screen mobile {
             .jobs-contents {
-                @apply relative;
+                position: relative;
                 &::before {
-                    @apply absolute;
+                    position: absolute;
                     content: '';
                     top: 0;
                     bottom: 0;
@@ -219,7 +219,7 @@ watch(() => props.recentJobs, () => {
     }
 
     @screen mobile {
-        @apply absolute;
+        position: absolute;
         top: 0;
         right: 0;
     }

--- a/apps/web/src/services/auth/components/SignInContainer.vue
+++ b/apps/web/src/services/auth/components/SignInContainer.vue
@@ -50,7 +50,8 @@ const state = reactive({
         overflow-y: auto;
 
         .contents-wrapper {
-            @apply flex-col static;
+            flex-direction: column;
+            position: static;
         }
     }
 }

--- a/apps/web/src/services/cost-explorer/components/BudgetCreateFormAmountPlanLastMonthsCost.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetCreateFormAmountPlanLastMonthsCost.vue
@@ -183,10 +183,11 @@ watch([() => props.projectId, () => props.dataSourceId, () => props.workspaceId]
     @screen mobile {
         padding-right: 8.75rem;
         label {
-            @apply block;
+            display: block;
         }
         .data {
-            @apply border-none block;
+            display: block;
+            border-style: none;
             padding: 0;
         }
     }

--- a/apps/web/src/services/cost-explorer/components/BudgetCreateFormAmountPlanMonthly.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetCreateFormAmountPlanMonthly.vue
@@ -216,24 +216,24 @@ watch(() => state.monthAmountInputMap, (monthAmountInputMap) => {
 
     @screen tablet {
         .input-wrapper {
-            @apply grid-cols-4;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
         }
     }
 
     @screen mobile {
         .header {
-            @apply relative;
+            position: relative;
             .title {
-                @apply flex-shrink;
+                flex-shrink: 1;
             }
             .p-button {
-                @apply absolute;
+                position: absolute;
                 bottom: 0;
                 right: 0;
             }
         }
         .input-wrapper {
-            @apply grid-cols-2;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
         }
     }
 }

--- a/apps/web/src/services/cost-explorer/components/BudgetCreateFormAmountPlanUnitSelect.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetCreateFormAmountPlanUnitSelect.vue
@@ -91,7 +91,7 @@ const handleUnitChange = (value?: BudgetTimeUnit) => {
 
 @screen mobile {
     .budget-create-form-amount-plan-unit-select {
-        @apply flex-col;
+        flex-direction: column;
         row-gap: 0.5rem;
     }
 }

--- a/apps/web/src/services/cost-explorer/components/BudgetDetailInfo.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetDetailInfo.vue
@@ -242,7 +242,7 @@ watch(() => costTypeRef.value, (costType) => {
     }
 
     @screen tablet {
-        @apply flex-col;
+        flex-direction: column;
         row-gap: 0.5rem;
         .summary-card {
             width: auto;

--- a/apps/web/src/services/cost-explorer/components/BudgetDetailInfoAmountPlanningTypePopover.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetDetailInfoAmountPlanningTypePopover.vue
@@ -95,10 +95,12 @@ const dateFormatter = (date: string) => dayjs(date).format('MMMM YYYY');
 
 @screen mobile {
     .monthly-wrapper > p:nth-child(6n+1), .monthly-wrapper > p:nth-child(6n+2), .monthly-wrapper > p:nth-child(6n+3) {
-        @apply bg-white;
+        --tw-bg-opacity: 1;
+        background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
     }
     .monthly-wrapper > p:nth-child(4n+1), .monthly-wrapper > p:nth-child(4n+2) {
-        @apply bg-gray-100;
+        --tw-bg-opacity: 1;
+        background-color: rgb(247 247 247 / var(--tw-bg-opacity, 1));
     }
 }
 </style>

--- a/apps/web/src/services/cost-explorer/components/BudgetDetailNotifications.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetDetailNotifications.vue
@@ -270,7 +270,7 @@ const handleBudgetNotifications = () => {
     }
 
     @screen tablet {
-        @apply flex-col;
+        flex-direction: column;
         row-gap: 1.5em;
 
         .noti-condition {

--- a/apps/web/src/services/cost-explorer/components/BudgetMainList.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetMainList.vue
@@ -200,10 +200,7 @@ const handleUpdateSort = (sort: Sort) => {
     }
     .budget-list-card-box {
         @apply grid grid-cols-2 gap-4;
-
-        @screen mobile {
-            @apply grid-cols-1;
-        }
+        @apply mobile:grid-cols-1;
     }
 }
 </style>

--- a/apps/web/src/services/cost-explorer/components/BudgetMainToolbox.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetMainToolbox.vue
@@ -250,9 +250,11 @@ watch(() => state.sort, (sort) => { emit('update-sort', sort); });
 
     @screen mobile {
         .top {
-            @apply flex flex-wrap gap-4;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
             .period-box {
-                @apply pl-0;
+                padding-left: 0;
 
                 &::before {
                     display: none;

--- a/apps/web/src/services/cost-explorer/components/CostReportMonthlyTotalAmountSummaryCard.vue
+++ b/apps/web/src/services/cost-explorer/components/CostReportMonthlyTotalAmountSummaryCard.vue
@@ -411,7 +411,7 @@ useResizeObserver(chartContext, throttle(() => {
     @apply col-span-12;
 
     @screen lg {
-        @apply col-span-6;
+        grid-column: span 6 / span 6;
     }
 
     .date-range-text {
@@ -455,7 +455,7 @@ useResizeObserver(chartContext, throttle(() => {
     @apply col-span-12;
 
     @screen lg {
-        @apply col-span-6;
+        grid-column: span 6 / span 6;
     }
 
     .amount-col {

--- a/apps/web/src/services/cost-explorer/pages/CostExplorerHome.vue
+++ b/apps/web/src/services/cost-explorer/pages/CostExplorerHome.vue
@@ -190,12 +190,13 @@ const SERVICE_CONTENTS = {
 
 @screen tablet {
     .service-topic {
-        @apply flex-col;
+        flex-direction: column;
         .service-contents {
             width: 100%;
             text-align: center;
             h2 {
-                @apply text-display-lg;
+                font-size: 2rem/* 32px */;
+                line-height: 1.25;
             }
         }
         .image-wrapper {
@@ -206,7 +207,7 @@ const SERVICE_CONTENTS = {
         }
     }
     .sub-menu-list {
-        @apply flex-col;
+        flex-direction: column;
     }
 }
 

--- a/apps/web/src/services/dashboards/components/dashboard-create/DashboardCreateStep1.vue
+++ b/apps/web/src/services/dashboards/components/dashboard-create/DashboardCreateStep1.vue
@@ -232,9 +232,7 @@ onMounted(() => {
         @apply flex gap-4;
         margin-top: 1.5rem;
 
-        @screen tablet {
-            @apply flex-col;
-        }
+        @apply tablet:flex-col;
 
         .template-contents-area {
             flex-grow: 1;

--- a/apps/web/src/services/iam/components/RoleUpdateFormRoleType.vue
+++ b/apps/web/src/services/iam/components/RoleUpdateFormRoleType.vue
@@ -151,14 +151,14 @@ watch(() => props.initialData, (initialData) => {
         }
 
         @screen tablet {
-            @apply flex-col;
+            flex-direction: column;
             max-width: 43rem;
             .card {
                 padding-top: 1rem;
                 padding-bottom: 1rem;
                 .card-content {
                     .role-type-icon {
-                        @apply hidden;
+                        display: none;
                     }
                     .role-type-description {
                         max-width: unset;

--- a/apps/web/src/services/landing/components/DomainLandingRecommendation.vue
+++ b/apps/web/src/services/landing/components/DomainLandingRecommendation.vue
@@ -227,7 +227,7 @@ const handleClickCardButton = (type: string) => {
 
     @screen tablet {
         .card-wrapper {
-            @apply flex-col;
+            flex-direction: column;
             .card {
                 flex: initial;
                 height: 13.625rem;

--- a/apps/web/src/services/landing/components/DomainLandingTitle.vue
+++ b/apps/web/src/services/landing/components/DomainLandingTitle.vue
@@ -77,7 +77,8 @@ const handleClickStartButton = () => {
 
     @screen tablet {
         .title {
-            @apply text-display-md;
+            font-size: 1.5rem;
+            line-height: 1.25;
             max-width: 40.5rem;
             .icon {
                 width: 2rem !important;

--- a/apps/web/src/services/landing/components/workspace-landing/landing-group-workspaces/LandingWorkspaceBoard.vue
+++ b/apps/web/src/services/landing/components/workspace-landing/landing-group-workspaces/LandingWorkspaceBoard.vue
@@ -272,7 +272,8 @@ const handleClickBoardItem = (item: WorkspaceBoardSet) => {
     }
 
     @screen mobile {
-        @apply flex flex-col;
+        display: flex;
+        flex-direction: column;
         gap: 0.5rem;
     }
 }

--- a/apps/web/src/services/my-page/components/UserAccountBaseInformation.vue
+++ b/apps/web/src/services/my-page/components/UserAccountBaseInformation.vue
@@ -198,7 +198,7 @@ watch(() => store.state.user.language, (language) => {
 
     @screen mobile {
         .input-form-wrapper {
-            @apply flex-col;
+            flex-direction: column;
         }
         .p-text-input,
         .p-select-dropdown {

--- a/apps/web/src/services/my-page/components/UserAccountChangePassword.vue
+++ b/apps/web/src/services/my-page/components/UserAccountChangePassword.vue
@@ -212,7 +212,7 @@ const updateUser = async (userParam: UpdateUserRequest) => {
 
     @screen mobile {
         .input-form-wrapper {
-            @apply flex-col;
+            flex-direction: column;
         }
         .p-text-input {
             width: 100%;

--- a/apps/web/src/services/my-page/components/UserAccountMultiFactorAuthModalEmailInfo.vue
+++ b/apps/web/src/services/my-page/components/UserAccountMultiFactorAuthModalEmailInfo.vue
@@ -159,7 +159,8 @@ const handleClickSendCodeButton = async () => {
             @apply flex justify-between items-center;
 
             @screen mobile {
-                @apply flex-col items-start;
+                flex-direction: column;
+                align-items: flex-start;
                 gap: 0.5rem;
             }
             .email-info {

--- a/apps/web/src/services/my-page/pages/UserAccountPage.vue
+++ b/apps/web/src/services/my-page/pages/UserAccountPage.vue
@@ -95,9 +95,7 @@ const state = reactive({
                 @apply font-bold;
             }
 
-            @screen mobile {
-                @apply hidden;
-            }
+            @apply mobile:hidden;
         }
         .user-account-wrapper {
             width: 100%;

--- a/apps/web/src/services/project/ProjectLSB.vue
+++ b/apps/web/src/services/project/ProjectLSB.vue
@@ -258,7 +258,7 @@ onClickOutside(menuRef, () => {
         margin-bottom: 0.5rem;
     }
     .search-result-text {
-        @apply overflow-hidden whitespace-no-wrap;
+        @apply overflow-hidden whitespace-nowrap;
         text-overflow: ellipsis;
     }
     .search-empty {

--- a/apps/web/src/services/project/components/ProjectAlertEventRuleContent.vue
+++ b/apps/web/src/services/project/components/ProjectAlertEventRuleContent.vue
@@ -211,10 +211,10 @@ table {
 
 @screen tablet {
     .left-section {
-        @apply col-span-12;
+        grid-column: span 12 / span 12;
     }
     .right-section {
-        @apply col-span-12;
+        grid-column: span 12 / span 12;
         margin-top: 1rem;
     }
 }

--- a/apps/web/src/services/project/components/ProjectAlertSettingsTab.vue
+++ b/apps/web/src/services/project/components/ProjectAlertSettingsTab.vue
@@ -317,7 +317,7 @@ const init = async () => {
     @screen tablet {
         .section {
             &.notification-policy-wrapper, &.auto-recovery-wrapper, &.event-rule-wrapper {
-                @apply col-span-12;
+                grid-column: span 12 / span 12;
             }
         }
     }

--- a/apps/web/src/services/project/components/ProjectAlertWebhookCreateStep1.vue
+++ b/apps/web/src/services/project/components/ProjectAlertWebhookCreateStep1.vue
@@ -164,7 +164,7 @@ onMounted(async () => {
     @screen tablet {
         min-width: 30rem;
         .card-wrapper {
-            @apply grid-cols-1;
+            grid-template-columns: repeat(1, minmax(0, 1fr));
             .card {
                 max-width: initial;
             }

--- a/apps/web/src/services/project/components/ProjectSummaryAllSummaryWidget.vue
+++ b/apps/web/src/services/project/components/ProjectSummaryAllSummaryWidget.vue
@@ -589,9 +589,7 @@ onUnmounted(() => {
             @apply col-span-12;
             position: relative;
 
-            @screen lg {
-                @apply col-span-7;
-            }
+            @apply lg:col-span-7;
             .toggle-button-group {
                 position: absolute;
                 right: 0.5rem;
@@ -606,15 +604,8 @@ onUnmounted(() => {
             }
         }
         .summary-wrapper {
-            @apply col-span-12;
+            @apply col-span-12 md:col-span-4 lg:col-span-2;
 
-            @screen md {
-                @apply col-span-4;
-            }
-
-            @screen lg {
-                @apply col-span-2;
-            }
             .sub-title {
                 padding-left: 0.5rem;
             }
@@ -686,15 +677,8 @@ onUnmounted(() => {
             }
         }
         .region-service-wrapper {
-            @apply col-span-12;
+            @apply col-span-12 md:col-span-5 lg:col-span-3;
 
-            @screen md {
-                @apply col-span-5;
-            }
-
-            @screen lg {
-                @apply col-span-3;
-            }
             .sub-title {
                 padding-left: 0.5rem;
             }

--- a/apps/web/src/services/project/pages/ProjectDashboardPage.vue
+++ b/apps/web/src/services/project/pages/ProjectDashboardPage.vue
@@ -137,7 +137,7 @@ onUnmounted(() => {
                     @apply text-label-xl font-bold text-gray-800;
                 }
                 .beta-mark {
-                    @apply text-coral;
+                    @apply text-coral-default;
                     font-size: 0.625rem;
                     cursor: default;
                     margin-left: 0.125rem;

--- a/apps/web/src/services/workspace-home/components/BookmarkBoard.vue
+++ b/apps/web/src/services/workspace-home/components/BookmarkBoard.vue
@@ -400,7 +400,7 @@ const checkSelectedId = (id?: string) => {
 
         @screen tablet {
             .bookmark-board-wrapper {
-                @apply grid-cols-4;
+                grid-template-columns: repeat(4, minmax(0, 1fr));
             }
         }
 
@@ -411,10 +411,10 @@ const checkSelectedId = (id?: string) => {
                     :deep(.p-board-item) {
                         &:last-child {
                             .content {
-                                @apply items-center justify-center;
-
+                                align-items: center;
+                                justify-content: center;
                                 .bookmark-label {
-                                    @apply hidden;
+                                    display: none;
                                 }
                             }
                         }
@@ -425,7 +425,7 @@ const checkSelectedId = (id?: string) => {
                 :deep(.p-board-item) {
                     padding: 0.5rem;
                     .content {
-                        @apply flex-col;
+                        flex-direction: column;
                         gap: 0.125rem;
                     }
                 }
@@ -443,7 +443,7 @@ const checkSelectedId = (id?: string) => {
                         }
 
                         .show-more {
-                            @apply bg-transparent;
+                            background-color: transparent;
                         }
 
                         .folder-item-icon-wrapper {
@@ -460,7 +460,7 @@ const checkSelectedId = (id?: string) => {
                             }
                         }
                         .overlay {
-                            @apply hidden;
+                            display: none;
                         }
                     }
                 }
@@ -474,12 +474,12 @@ const checkSelectedId = (id?: string) => {
             @apply grid-cols-4;
 
             @screen tablet {
-                @apply grid-cols-1;
+                grid-template-columns: repeat(1, minmax(0, 1fr));
 
                 /* custom design-system component - p-board-item */
                 :deep(.p-board-item) {
                     .content-area .desktop {
-                        @apply block;
+                        display: block;
                     }
                 }
             }

--- a/apps/web/src/services/workspace-home/components/UserConfigs.vue
+++ b/apps/web/src/services/workspace-home/components/UserConfigs.vue
@@ -23,7 +23,7 @@ import UserConfigStarred from '@/services/workspace-home/components/UserConfigSt
     }
 
     @screen mobile {
-        @apply flex-col;
+        flex-direction: column;
         .box-wrapper {
             min-height: unset;
         }

--- a/apps/web/tailwind.config.cjs
+++ b/apps/web/tailwind.config.cjs
@@ -2,7 +2,7 @@
 const spaceoneTailwindConfig = require('@cloudforet/mirinae/tailwind.config.cjs');
 
 module.exports = {
-    purge: [
+    content: [
         "./index.html",
         "./src/**/*.{js,ts,jsx,tsx,vue}",
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "eslint-config-custom": "*",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.0",
-        "tailwindcss": "^3.4.15",
         "turbo": "^1.10.5"
       },
       "engines": {
@@ -36306,7 +36305,8 @@
         "postcss-mixins": "^6.2.3",
         "postcss-nested": "^4.2.3",
         "postcss-preset-env": "6.7.0",
-        "postcss-simple-vars": "^5.0.2"
+        "postcss-simple-vars": "^5.0.2",
+        "tailwindcss": "^3.4.15"
       }
     },
     "packages/postcss-config-custom/node_modules/autoprefixer": {
@@ -54717,7 +54717,8 @@
         "postcss-mixins": "^6.2.3",
         "postcss-nested": "^4.2.3",
         "postcss-preset-env": "6.7.0",
-        "postcss-simple-vars": "^5.0.2"
+        "postcss-simple-vars": "^5.0.2",
+        "tailwindcss": "^3.4.15"
       },
       "dependencies": {
         "autoprefixer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-config-custom": "*",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.0",
+        "tailwindcss": "^3.4.15",
         "turbo": "^1.10.5"
       },
       "engines": {
@@ -1419,6 +1420,18 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.0.tgz",
       "integrity": "sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==",
       "dev": true
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@amcharts/amcharts5": {
       "version": "5.4.7",
@@ -4474,108 +4487,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA=="
-    },
-    "node_modules/@fullhuman/postcss-purgecss": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz",
-      "integrity": "sha512-qnKm5dIOyPGJ70kPZ5jiz0I9foVOic0j+cOzNDoo8KoCf6HjicIZ99UfO2OmE7vCYSKAAepEwJtNzpiiZAh9xw==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "7.0.32",
-        "purgecss": "^2.3.0"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss/node_modules/chalk/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@fullhuman/postcss-purgecss/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss/node_modules/postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/postcss"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/@gtm-support/core": {
       "version": "1.3.0",
@@ -12637,6 +12548,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -13772,9 +13689,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "funding": [
         {
           "type": "opencollective",
@@ -13790,10 +13707,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001629",
-        "electron-to-chromium": "^1.4.796",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.16"
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -14055,9 +13972,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001640",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
-      "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
+      "version": "1.0.30001684",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+      "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -16310,15 +16227,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
-      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -16435,27 +16343,16 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/detective": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
-      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
-      "dev": true,
-      "dependencies": {
-        "acorn-node": "^1.8.2",
-        "defined": "^1.0.0",
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "detective": "bin/detective.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/dfa": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -16496,6 +16393,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -16710,9 +16613,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.818",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.818.tgz",
-      "integrity": "sha512-eGvIk2V0dGImV9gWLq8fDfTTsCAeMDwZqEPMr+jMInxZdnp9Us8UpovYpRCf9NQ7VOFgrN2doNSgvISbsbNpxA=="
+      "version": "1.5.64",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
+      "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -17403,9 +17306,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
@@ -19011,6 +18914,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -20339,11 +20255,14 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -21168,6 +21087,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-base64": {
@@ -24232,6 +24160,17 @@
         "url": "https://github.com/sponsors/raouldeheer"
       }
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -24345,15 +24284,6 @@
         "node": ">= 0.10.5"
       }
     },
-    "node_modules/node-emoji": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -24409,9 +24339,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/nopt": {
       "version": "6.0.0",
@@ -24465,12 +24395,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha512-dxvWdI8gw6eAvk9BlPffgEoGfM7AdijoCwOEJge3e3ulT2XLgmU7KvvxprOaCu05Q1uGRHmOhHe1r6emZoKyFw==",
-      "dev": true
-    },
-    "node_modules/normalize.css": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
       "dev": true
     },
     "node_modules/npm-run-path": {
@@ -24791,9 +24715,9 @@
       }
     },
     "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true,
       "engines": {
         "node": ">= 6"
@@ -25755,9 +25679,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.41",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -25774,8 +25698,8 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -26632,100 +26556,6 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/postcss-functions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-      "integrity": "sha512-N5yWXWKA+uhpLQ9ZhBRl2bIAdM6oVJYpDojuI1nF2SzXBimJcdjFwiAouBVbO5VuOF3qA6BSFWFc3wXbbj72XQ==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.2",
-        "object-assign": "^4.1.1",
-        "postcss": "^6.0.9",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
-    "node_modules/postcss-functions/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-functions/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-functions/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/postcss-functions/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/postcss-functions/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-functions/node_modules/postcss": {
-      "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-functions/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
-    },
-    "node_modules/postcss-functions/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-gap-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
@@ -26915,9 +26745,9 @@
       }
     },
     "node_modules/postcss-import": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.0.0.tgz",
-      "integrity": "sha512-Y20shPQ07RitgBGv2zvkEAu9bqvrD77C9axhj/aA1BQj4czape2MdClCExvB27EwYEJdGgKZBpKanb0t1rK2Kg==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -27042,6 +26872,65 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/postcss-loader": {
@@ -27997,9 +27886,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -28065,9 +27954,9 @@
       }
     },
     "node_modules/postcss/node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -28677,122 +28566,6 @@
         "async-limiter": "~1.0.0"
       }
     },
-    "node_modules/purgecss": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.3.0.tgz",
-      "integrity": "sha512-BE5CROfVGsx2XIhxGuZAT7rTH9lLeQx/6M0P7DTXQH4IUc3BBzs9JUzt4yzGf3JrH9enkeq6YJBe9CTtkm1WmQ==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^5.0.0",
-        "glob": "^7.0.0",
-        "postcss": "7.0.32",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "bin": {
-        "purgecss": "bin/purgecss"
-      }
-    },
-    "node_modules/purgecss/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/purgecss/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/purgecss/node_modules/chalk/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/purgecss/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/purgecss/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/purgecss/node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/purgecss/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/purgecss/node_modules/postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/postcss"
-      }
-    },
-    "node_modules/purgecss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -29387,22 +29160,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/reduce-css-calc": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-      "dev": true,
-      "dependencies": {
-        "css-unit-converter": "^1.1.1",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
-    "node_modules/reduce-css-calc/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
-    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -29950,11 +29707,11 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -31109,9 +30866,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -31982,6 +31739,118 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sucrase/node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sucrase/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sucrase/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sucrase/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sugarss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
@@ -32265,89 +32134,96 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.9.6.tgz",
-      "integrity": "sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.15.tgz",
+      "integrity": "sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==",
       "dev": true,
       "dependencies": {
-        "@fullhuman/postcss-purgecss": "^2.1.2",
-        "autoprefixer": "^9.4.5",
-        "browserslist": "^4.12.0",
-        "bytes": "^3.0.0",
-        "chalk": "^3.0.0 || ^4.0.0",
-        "color": "^3.1.2",
-        "detective": "^5.2.0",
-        "fs-extra": "^8.0.0",
-        "html-tags": "^3.1.0",
-        "lodash": "^4.17.20",
-        "node-emoji": "^1.8.1",
-        "normalize.css": "^8.0.1",
-        "object-hash": "^2.0.3",
-        "postcss": "^7.0.11",
-        "postcss-functions": "^3.0.0",
-        "postcss-js": "^2.0.0",
-        "postcss-nested": "^4.1.1",
-        "postcss-selector-parser": "^6.0.0",
-        "postcss-value-parser": "^4.1.0",
-        "pretty-hrtime": "^1.0.3",
-        "reduce-css-calc": "^2.1.6",
-        "resolve": "^1.14.2"
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
         "tailwindcss": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.9.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/tailwindcss/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+    "node_modules/tailwindcss/node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
+    "node_modules/tailwindcss/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/tailwindcss/node_modules/postcss-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "camelcase-css": "^2.0.1"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "node": "^12 || ^14 || >= 16"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
       }
     },
-    "node_modules/tailwindcss/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+    "node_modules/tailwindcss/node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
       }
     },
     "node_modules/tapable": {
@@ -32703,6 +32579,27 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/throttle-debounce": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
@@ -33014,6 +32911,12 @@
       "engines": {
         "node": ">=6.10"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "node_modules/ts-loader": {
       "version": "8.4.0",
@@ -33794,9 +33697,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "funding": [
         {
           "type": "opencollective",
@@ -33812,8 +33715,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -33823,9 +33726,9 @@
       }
     },
     "node_modules/update-browserslist-db/node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -36393,7 +36296,7 @@
     "packages/postcss-config-custom": {
       "version": "1.12.0-dev11",
       "devDependencies": {
-        "autoprefixer": "^9.8.8",
+        "autoprefixer": "^10.4.20",
         "postcss-comment": "^2.0.0",
         "postcss-conditionals": "^2.1.0",
         "postcss-easy-import": "^3.0.0",
@@ -36403,9 +36306,51 @@
         "postcss-mixins": "^6.2.3",
         "postcss-nested": "^4.2.3",
         "postcss-preset-env": "6.7.0",
-        "postcss-simple-vars": "^5.0.2",
-        "tailwindcss": "^1.9.6"
+        "postcss-simple-vars": "^5.0.2"
       }
+    },
+    "packages/postcss-config-custom/node_modules/autoprefixer": {
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "packages/postcss-config-custom/node_modules/autoprefixer/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
     },
     "packages/postcss-config-custom/node_modules/postcss-preset-env": {
       "version": "6.7.0",
@@ -36453,6 +36398,28 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "packages/postcss-config-custom/node_modules/postcss-preset-env/node_modules/autoprefixer": {
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
       }
     },
     "packages/postcss-config-custom/node_modules/postcss-preset-env/node_modules/postcss": {
@@ -36540,6 +36507,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.0.tgz",
       "integrity": "sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==",
+      "dev": true
+    },
+    "@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true
     },
     "@amcharts/amcharts5": {
@@ -39139,90 +39112,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA=="
-    },
-    "@fullhuman/postcss-purgecss": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz",
-      "integrity": "sha512-qnKm5dIOyPGJ70kPZ5jiz0I9foVOic0j+cOzNDoo8KoCf6HjicIZ99UfO2OmE7vCYSKAAepEwJtNzpiiZAh9xw==",
-      "dev": true,
-      "requires": {
-        "postcss": "7.0.32",
-        "purgecss": "^2.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.32",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
     },
     "@gtm-support/core": {
       "version": "1.3.0",
@@ -44785,6 +44674,12 @@
         "color-convert": "^2.0.1"
       }
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
     "anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -45681,14 +45576,14 @@
       }
     },
     "browserslist": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "requires": {
-        "caniuse-lite": "^1.0.30001629",
-        "electron-to-chromium": "^1.4.796",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.16"
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
       }
     },
     "bser": {
@@ -45880,9 +45775,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001640",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
-      "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA=="
+      "version": "1.0.30001684",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+      "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ=="
     },
     "case-anything": {
       "version": "2.1.13",
@@ -47577,12 +47472,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "defined": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
-      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "dev": true
-    },
     "defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -47667,21 +47556,16 @@
         "debug": "4"
       }
     },
-    "detective": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
-      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
-      "dev": true,
-      "requires": {
-        "acorn-node": "^1.8.2",
-        "defined": "^1.0.0",
-        "minimist": "^1.2.6"
-      }
-    },
     "dfa": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
+    },
+    "didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
     },
     "diff": {
       "version": "4.0.2",
@@ -47713,6 +47597,12 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -47898,9 +47788,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.818",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.818.tgz",
-      "integrity": "sha512-eGvIk2V0dGImV9gWLq8fDfTTsCAeMDwZqEPMr+jMInxZdnp9Us8UpovYpRCf9NQ7VOFgrN2doNSgvISbsbNpxA=="
+      "version": "1.5.64",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
+      "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -48348,9 +48238,9 @@
       "optional": true
     },
     "escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -49627,6 +49517,12 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
     },
+    "fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -50593,11 +50489,11 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
       }
     },
     "is-data-descriptor": {
@@ -51174,6 +51070,12 @@
           }
         }
       }
+    },
+    "jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "dev": true
     },
     "js-base64": {
       "version": "2.6.4",
@@ -53373,6 +53275,17 @@
       "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
       "dev": true
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -53461,15 +53374,6 @@
         "minimatch": "^3.0.2"
       }
     },
-    "node-emoji": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.21"
-      }
-    },
     "node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -53516,9 +53420,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "nopt": {
       "version": "6.0.0",
@@ -53557,12 +53461,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha512-dxvWdI8gw6eAvk9BlPffgEoGfM7AdijoCwOEJge3e3ulT2XLgmU7KvvxprOaCu05Q1uGRHmOhHe1r6emZoKyFw==",
-      "dev": true
-    },
-    "normalize.css": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
       "dev": true
     },
     "npm-run-path": {
@@ -53790,9 +53688,9 @@
       }
     },
     "object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true
     },
     "object-inspect": {
@@ -54496,19 +54394,19 @@
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
     },
     "postcss": {
-      "version": "8.4.41",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "requires": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "dependencies": {
         "picocolors": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-          "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         }
       }
     },
@@ -54809,7 +54707,7 @@
     "postcss-config-custom": {
       "version": "file:packages/postcss-config-custom",
       "requires": {
-        "autoprefixer": "^9.8.8",
+        "autoprefixer": "^10.4.20",
         "postcss-comment": "^2.0.0",
         "postcss-conditionals": "^2.1.0",
         "postcss-easy-import": "^3.0.0",
@@ -54819,10 +54717,31 @@
         "postcss-mixins": "^6.2.3",
         "postcss-nested": "^4.2.3",
         "postcss-preset-env": "6.7.0",
-        "postcss-simple-vars": "^5.0.2",
-        "tailwindcss": "^1.9.6"
+        "postcss-simple-vars": "^5.0.2"
       },
       "dependencies": {
+        "autoprefixer": {
+          "version": "10.4.20",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+          "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.23.3",
+            "caniuse-lite": "^1.0.30001646",
+            "fraction.js": "^4.3.7",
+            "normalize-range": "^0.1.2",
+            "picocolors": "^1.0.1",
+            "postcss-value-parser": "^4.2.0"
+          },
+          "dependencies": {
+            "picocolors": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+              "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+              "dev": true
+            }
+          }
+        },
         "postcss-preset-env": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz",
@@ -54868,6 +54787,21 @@
             "postcss-selector-not": "^4.0.0"
           },
           "dependencies": {
+            "autoprefixer": {
+              "version": "9.8.8",
+              "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+              "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
+              "dev": true,
+              "requires": {
+                "browserslist": "^4.12.0",
+                "caniuse-lite": "^1.0.30001109",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "picocolors": "^0.2.1",
+                "postcss": "^7.0.32",
+                "postcss-value-parser": "^4.1.0"
+              }
+            },
             "postcss": {
               "version": "7.0.39",
               "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
@@ -55244,87 +55178,6 @@
         }
       }
     },
-    "postcss-functions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-      "integrity": "sha512-N5yWXWKA+uhpLQ9ZhBRl2bIAdM6oVJYpDojuI1nF2SzXBimJcdjFwiAouBVbO5VuOF3qA6BSFWFc3wXbbj72XQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.2",
-        "object-assign": "^4.1.1",
-        "postcss": "^6.0.9",
-        "postcss-value-parser": "^3.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "postcss-gap-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
@@ -55481,9 +55334,9 @@
       }
     },
     "postcss-import": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.0.0.tgz",
-      "integrity": "sha512-Y20shPQ07RitgBGv2zvkEAu9bqvrD77C9axhj/aA1BQj4czape2MdClCExvB27EwYEJdGgKZBpKanb0t1rK2Kg==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.0.0",
@@ -55575,6 +55428,30 @@
             "picocolors": "^0.2.1",
             "source-map": "^0.6.1"
           }
+        }
+      }
+    },
+    "postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "requires": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "dependencies": {
+        "lilconfig": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+          "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+          "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+          "dev": true
         }
       }
     },
@@ -56315,9 +56192,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -56921,98 +56798,6 @@
         }
       }
     },
-    "purgecss": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.3.0.tgz",
-      "integrity": "sha512-BE5CROfVGsx2XIhxGuZAT7rTH9lLeQx/6M0P7DTXQH4IUc3BBzs9JUzt4yzGf3JrH9enkeq6YJBe9CTtkm1WmQ==",
-      "dev": true,
-      "requires": {
-        "commander": "^5.0.0",
-        "glob": "^7.0.0",
-        "postcss": "7.0.32",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.32",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -57460,24 +57245,6 @@
         "strip-indent": "^3.0.0"
       }
     },
-    "reduce-css-calc": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-      "dev": true,
-      "requires": {
-        "css-unit-converter": "^1.1.1",
-        "postcss-value-parser": "^3.3.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        }
-      }
-    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -57903,11 +57670,11 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -58837,9 +58604,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -59586,6 +59353,83 @@
         "stylelint-config-recommended": "^3.0.0"
       }
     },
+    "sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "foreground-child": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+          "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "signal-exit": "^4.0.1"
+          }
+        },
+        "glob": {
+          "version": "10.4.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+          "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        }
+      }
+    },
     "sugarss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
@@ -59818,70 +59662,64 @@
       }
     },
     "tailwindcss": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.9.6.tgz",
-      "integrity": "sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.15.tgz",
+      "integrity": "sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==",
       "dev": true,
       "requires": {
-        "@fullhuman/postcss-purgecss": "^2.1.2",
-        "autoprefixer": "^9.4.5",
-        "browserslist": "^4.12.0",
-        "bytes": "^3.0.0",
-        "chalk": "^3.0.0 || ^4.0.0",
-        "color": "^3.1.2",
-        "detective": "^5.2.0",
-        "fs-extra": "^8.0.0",
-        "html-tags": "^3.1.0",
-        "lodash": "^4.17.20",
-        "node-emoji": "^1.8.1",
-        "normalize.css": "^8.0.1",
-        "object-hash": "^2.0.3",
-        "postcss": "^7.0.11",
-        "postcss-functions": "^3.0.0",
-        "postcss-js": "^2.0.0",
-        "postcss-nested": "^4.1.1",
-        "postcss-selector-parser": "^6.0.0",
-        "postcss-value-parser": "^4.1.0",
-        "pretty-hrtime": "^1.0.3",
-        "reduce-css-calc": "^2.1.6",
-        "resolve": "^1.14.2"
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "postcss": {
-          "version": "7.0.39",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-          "dev": true,
-          "requires": {
-            "picocolors": "^0.2.1",
-            "source-map": "^0.6.1"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+        "arg": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+          "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
           "dev": true
+        },
+        "picocolors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+          "dev": true
+        },
+        "postcss-js": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+          "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+          "dev": true,
+          "requires": {
+            "camelcase-css": "^2.0.1"
+          }
+        },
+        "postcss-nested": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+          "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.1.1"
+          }
         }
       }
     },
@@ -60151,6 +59989,24 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "throttle-debounce": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
@@ -60400,6 +60256,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true
+    },
+    "ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
     "ts-loader": {
@@ -60981,18 +60843,18 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "requires": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "dependencies": {
         "picocolors": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-          "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "eslint-config-custom": "*",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.0",
-    "turbo": "^1.10.5",
-    "tailwindcss": "^3.4.15"
+    "turbo": "^1.10.5"
   },
   "engines": {
     "npm": ">=10.2.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "eslint-config-custom": "*",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.0",
-    "turbo": "^1.10.5"
+    "turbo": "^1.10.5",
+    "tailwindcss": "^3.4.15"
   },
   "engines": {
     "npm": ">=10.2.3",

--- a/packages/mirinae/src/controls/checkbox-group/PCheckboxGroup.stories.ts
+++ b/packages/mirinae/src/controls/checkbox-group/PCheckboxGroup.stories.ts
@@ -89,8 +89,8 @@ export const Direction: Story = {
         components: { PCheckboxGroup, PCheckbox },
         template: `
         <div>
-            <div class="flex flex-col row-gap-8">
-                <div class="flex flex-col row-gap-2">
+            <div class="flex flex-col gap-y-8">
+                <div class="flex flex-col gap-y-2">
                     <p>Horizontal (default)</p>
                     <p-checkbox-group direction="horizontal">
                         <p-checkbox :key="value" v-for="value in horizontalValues" v-model="horizontalSelected" :value="value">
@@ -98,7 +98,7 @@ export const Direction: Story = {
                         </p-checkbox>
                     </p-checkbox-group>
                 </div>
-                <div class="flex flex-col row-gap-2">
+                <div class="flex flex-col gap-y-2">
                     <p>Vertical</p>
                     <p-checkbox-group direction="vertical">
                         <p-checkbox :key="value" v-for="value in verticalValues" v-model="verticalSelected" :value="value">

--- a/packages/mirinae/src/controls/dropdown/select-dropdown/components/dropdown-button.vue
+++ b/packages/mirinae/src/controls/dropdown/select-dropdown/components/dropdown-button.vue
@@ -191,7 +191,7 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
 .dropdown-button-component {
     /* style type - default */
     .dropdown-button {
-        @apply flex justify-between items-center bg-white text-label-md font-normal border rounded border-gray-300 cursor-pointer;
+        @apply flex justify-between items-center bg-white text-label-md font-normal border rounded-default border-gray-300 cursor-pointer;
         width: 100%;
         min-height: 2rem;
         gap: 0.25rem;
@@ -267,7 +267,7 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
             @apply cursor-not-allowed text-gray-300;
         }
         &.tertiary-icon-button {
-            @apply bg-gray-200 rounded border-transparent;
+            @apply bg-gray-200 rounded-default border-transparent;
         }
     }
 
@@ -344,7 +344,7 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
         }
     }
     &.tertiary-icon-button {
-        @apply border border-gray-300 rounded bg-white;
+        @apply border border-gray-300 rounded-default bg-white;
         &:not(.disabled, .readonly, .invalid):hover {
             @apply bg-gray-100;
         }
@@ -419,7 +419,7 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
             @apply bg-blue-300 text-secondary;
         }
         &.tertiary-icon-button {
-            @apply bg-gray-200 rounded;
+            @apply bg-gray-200 rounded-default;
         }
     }
 
@@ -451,7 +451,7 @@ const handleTagDelete = (item: SelectDropdownMenuItem, idx: number) => {
             }
         }
         &.tertiary-icon-button {
-            @apply bg-gray-200 rounded;
+            @apply bg-gray-200 rounded-default;
         }
     }
 

--- a/packages/mirinae/src/controls/radio-group/PRadioGroup.stories.ts
+++ b/packages/mirinae/src/controls/radio-group/PRadioGroup.stories.ts
@@ -89,8 +89,8 @@ export const Direction: Story = {
         components: { PRadioGroup, PRadio },
         template: `
         <div>
-            <div class="flex flex-col row-gap-8">
-                <div class="flex flex-col row-gap-2">
+            <div class="flex flex-col gap-y-8">
+                <div class="flex flex-col gap-y-2">
                     <p>Horizontal (default)</p>
                     <p-radio-group direction="horizontal">
                         <p-radio :key="value" v-for="value in horizontalValues" v-model="horizontalSelected" :value="value">
@@ -98,7 +98,7 @@ export const Direction: Story = {
                         </p-radio>
                     </p-radio-group>
                 </div>
-                <div class="flex flex-col row-gap-2">
+                <div class="flex flex-col gap-y-2">
                     <p>Vertical</p>
                     <p-radio-group direction="vertical">
                         <p-radio :key="value" v-for="value in verticalValues" v-model="verticalSelected" :value="value">

--- a/packages/mirinae/src/controls/search/search/PSearch.vue
+++ b/packages/mirinae/src/controls/search/search/PSearch.vue
@@ -326,7 +326,7 @@ export default defineComponent<SearchProps>({
             @apply border-secondary;
         }
         .input-wrapper {
-            @apply flex flex-wrap flex-grow row-gap-2;
+            @apply flex flex-wrap flex-grow gap-y-2;
         }
         input {
             @apply border-0 bg-transparent w-full;

--- a/packages/mirinae/src/data-display/badge/PBadge.vue
+++ b/packages/mirinae/src/data-display/badge/PBadge.vue
@@ -102,7 +102,7 @@ const state = reactive({
     letter-spacing: 0.02rem;
     padding: 0 0.5rem;
 
-    @apply text-white bg-gray;
+    @apply text-white bg-gray-500;
     &.badge-round {
         @apply rounded-full;
     }

--- a/packages/mirinae/src/data-display/cards/card/PCard.stories.ts
+++ b/packages/mirinae/src/data-display/cards/card/PCard.stories.ts
@@ -149,7 +149,7 @@ export const Slots: Story = {
                     <div class="flex justify-between items-center">
                         <span>8.5</span><span>145</span>
                     </div>
-                    <div class="flex justify-between items-center text-gray text-xs mt-1">
+                    <div class="flex justify-between items-center text-gray-default text-xs mt-1">
                         <span>Dail Average</span><span class="text-right">Monthly Total</span>
                     </div>
                 </p-card>

--- a/packages/mirinae/src/data-display/tags/PTag.vue
+++ b/packages/mirinae/src/data-display/tags/PTag.vue
@@ -130,7 +130,7 @@ export default defineComponent<Props>({
         }
     }
     &.outline {
-        @apply text-gray-dark bg-transparent border border-gray-200;
+        @apply text-gray-dark bg-transparent border border-gray-200 outline-0;
         &.selected {
             @apply bg-blue-200 border-blue-300;
         }

--- a/packages/mirinae/src/data-display/text-list/PTextList.vue
+++ b/packages/mirinae/src/data-display/text-list/PTextList.vue
@@ -3,7 +3,7 @@
         <component :is="component"
                    v-for="(item, i) in displayItems"
                    :key="i"
-                   class="list-item"
+                   class="list-item-wrapper"
                    :class="{'line-break': isLineBreak && i < displayItems.length - 1}"
                    :href="getHref(item, i)"
                    :target="linkTarget || undefined"
@@ -93,7 +93,7 @@ export default defineComponent<TextListProps>({
 
 <style lang="postcss">
 .p-text-list {
-    > .list-item {
+    > .list-item-wrapper {
         > .delimiter {
             white-space: pre;
         }

--- a/packages/mirinae/src/foundation/icons/PI.stories.ts
+++ b/packages/mirinae/src/foundation/icons/PI.stories.ts
@@ -44,7 +44,7 @@ export const AllIcons: Story = {
             <div style="width: 100%; padding: 32px; border: 1px solid #eee; display: grid; row-gap: 1rem; column-gap: 1rem;  grid-template-columns: repeat(auto-fill, minmax(200px,1fr));">
                 <div v-for="icon in icons" :key="icon" class="flex flex-col items-center p-4 rounded hover:bg-secondary-2">
                     <p-i :name="icon" class="flex-shrink-0"/>
-                    <label class="mt-4 whitespace-no-wrap break-words text-xs text-gray-600" >{{icon}}</label>
+                    <label class="mt-4 whitespace-nowrap break-words text-xs text-gray-600" >{{icon}}</label>
                 </div>
             </div>
         `,
@@ -63,7 +63,7 @@ export const Animation: Story = {
             <div style="padding: 32px; border: 1px solid #eee; display: grid; row-gap: 1rem; column-gap: 1rem;  grid-template-columns: repeat(auto-fill, minmax(100px,1fr));">
                 <div v-for="icon in icons" :key="icon" class="flex flex-col items-center p-4 rounded hover:bg-secondary-2">
                     <p-i :name="icon" animation="spin" class="flex-shrink-0"/>
-                    <label class="mt-4 whitespace-no-wrap break-words text-xs text-gray-600" >{{icon}}</label>
+                    <label class="mt-4 whitespace-nowrap break-words text-xs text-gray-600" >{{icon}}</label>
                 </div>
             </div>
         `,

--- a/packages/mirinae/src/navigation/pagination/date-pagination/PDatePagination.vue
+++ b/packages/mirinae/src/navigation/pagination/date-pagination/PDatePagination.vue
@@ -129,9 +129,7 @@ export default {
             margin-right: 1rem;
         }
 
-        @screen lg {
-            @apply min-w-16;
-        }
+        @apply lg:min-w-16;
     }
 }
 </style>

--- a/packages/mirinae/src/navigation/pagination/pagination/PPagination.vue
+++ b/packages/mirinae/src/navigation/pagination/pagination/PPagination.vue
@@ -181,9 +181,8 @@ export default {
     align-items: center;
     flex-wrap: nowrap;
 
-    @screen lg {
-        @apply min-w-16;
-    }
+    @apply lg:min-w-16;
+
     .page-number-wrapper {
         @apply min-h-8 min-w-12 items-center justify-center inline-flex cursor-pointer;
         .page-number-list {
@@ -203,9 +202,7 @@ export default {
             }
         }
 
-        @screen lg {
-            @apply min-w-16;
-        }
+        @apply lg:min-w-16;
     }
     &.sm {
         .page-number-wrapper {

--- a/packages/mirinae/src/navigation/pagination/text-pagination/PTextPagination.vue
+++ b/packages/mirinae/src/navigation/pagination/text-pagination/PTextPagination.vue
@@ -105,9 +105,7 @@ export default defineComponent<Props>({
     align-items: center;
     flex-wrap: nowrap;
 
-    @screen lg {
-        @apply min-w-16;
-    }
+    @apply lg:min-w-16;
 }
 .page-number {
     @apply min-h-8 min-w-12 items-center justify-center inline-flex cursor-default;
@@ -119,9 +117,7 @@ export default defineComponent<Props>({
         }
     }
 
-    @screen lg {
-        @apply min-w-16;
-    }
+    @apply lg:min-w-16;
 }
 
 </style>

--- a/packages/mirinae/src/styles/tailwind.pcss
+++ b/packages/mirinae/src/styles/tailwind.pcss
@@ -1,7 +1,7 @@
 /* Tailwind CSS */
-@import "tailwindcss/dist/base.css";
-@import "tailwindcss/dist/components.css";
-@import "tailwindcss/dist/utilities.css";
+@import "tailwindcss/base.css";
+@import "tailwindcss/components.css";
+@import "tailwindcss/utilities.css";
 
 pre {
     @apply font-sans;

--- a/packages/mirinae/tailwind.config.cjs
+++ b/packages/mirinae/tailwind.config.cjs
@@ -18,6 +18,7 @@ const percent = _.fromPairs(rawPercent.map((value) => [value, `${eval(value) * 1
 module.exports = {
     theme: {
         borderRadius: {
+            DEFAULT: '0.25rem',
             none: '0',
             '2xs': '0.063rem', // 1px
             xs: '0.125rem', // 2px
@@ -39,6 +40,7 @@ module.exports = {
             ...defaultTheme.minWidth,
             ...theme('spacing'),
             ...percent,
+            'full': '100%',
             '2xs': theme('screens.2xs.min'),
             xs: theme('screens.xs.min'),
             sm: theme('screens.sm.min'),
@@ -72,18 +74,18 @@ module.exports = {
             serif: ['Roboto'],
         },
         screens: {
-            '2xs': { min: '375px' },
-            xs: { min: '478px' },
-            sm: { min: '576px' },
-            md: { min: '768px' },
-            lg: { min: '1024px' },
-            xl: { min: '1440px' },
-            '2xl': { min: '1920px' },
-            '3xl': { min: '2560px' },
-            mobile: { max: `${screens.mobile.max}px` },
-            tablet: { max: `${screens.tablet.max}px` },
-            laptop: { max: `${screens.laptop.max}px` },
-            desktop: { max: `${screens.desktop.max}px` },
+            '2xs': '375px' ,
+            xs: '478px' ,
+            sm: '576px' ,
+            md: '768px' ,
+            lg: '1024px' ,
+            xl: '1440px' ,
+            '2xl': '1920px' ,
+            '3xl': '2560px' ,
+            mobile: { max:`${screens.mobile.max}px`},
+            tablet: { max:`${screens.tablet.max}px`},
+            laptop: { max:`${screens.laptop.max}px`},
+            desktop: { max:`${screens.desktop.max}px`},
         },
         fontSize: {
             ...defaultTheme.fontSize,

--- a/packages/postcss-config-custom/package.json
+++ b/packages/postcss-config-custom/package.json
@@ -14,6 +14,7 @@
     "postcss-mixins": "^6.2.3",
     "postcss-nested": "^4.2.3",
     "postcss-preset-env": "6.7.0",
-    "postcss-simple-vars": "^5.0.2"
+    "postcss-simple-vars": "^5.0.2",
+    "tailwindcss": "^3.4.15"
   }
 }

--- a/packages/postcss-config-custom/package.json
+++ b/packages/postcss-config-custom/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "devDependencies": {
-    "autoprefixer": "^9.8.8",
+    "autoprefixer": "^10.4.20",
     "postcss-comment": "^2.0.0",
     "postcss-conditionals": "^2.1.0",
     "postcss-easy-import": "^3.0.0",
@@ -14,7 +14,6 @@
     "postcss-mixins": "^6.2.3",
     "postcss-nested": "^4.2.3",
     "postcss-preset-env": "6.7.0",
-    "postcss-simple-vars": "^5.0.2",
-    "tailwindcss": "^1.9.6"
+    "postcss-simple-vars": "^5.0.2"
   }
 }


### PR DESCRIPTION
### To Reviewers
- [x] Self-reviewed (coding conventions, bug-free, functionality verified, tests checked, documentation updated)
- [ ] Minor change, review optional (`style`, `chore`, `ci`, straightforward changes, etc.)
- [ ] Previously reviewed in feature branch, no further review needed
- [ ] Need review or discussion

### Description (optional)

This PR focuses on improving build memory usage and build time.
#### Issue
The build process consumed a significant amount of memory compared to the size of the project.

#### Resolution Process

1. Added Memory Usage Logging
- Introduced a custom Rollup plugin (memory-logger) to log memory usage during the build process.
- Identified a 4GB memory spike when transforming the mirinae/dist/style.css file.
- PostCSS Plugin Investigation

2. Disabled PostCSS plugins one by one to track the issue.
- Pinpointed the issue to the TailwindCSS plugin:
- Disabling the TailwindCSS plugin reduced memory usage from ~8GB to ~2GB.


3. Upgraded TailwindCSS (v1.x → v3.x)
- Upgraded to TailwindCSS 3.x to resolve performance issues and leverage the JIT (Just-In-Time) engine.
- Improved compatibility with PostCSS 8 and modern build tools (e.g., Vite).


4. Updated console and design system codebase to align with TailwindCSS 3.x changes:
- bg-gray → bg-gray-default (default values now require explicit definition).
- rounded → rounded-default.
- Replaced row-gap-{n} and col-gap-{n} with gap-y-{n} and gap-x-{n}.
- Refactored styles to remove nested at-rules (@media, @import, etc.) as required by the JIT engine.


#### Results


Before TailwindCSS Upgrade:
- Build memory usage: ~8GB
- Console build time: ~15 minutes

After TailwindCSS Upgrade:
- Build memory usage: Reduced to ~2GB.
- Console build time: Reduced to ~2 minutes.

-----



이 PR은 앱 빌드 메모리와 빌드 시간에대한 개선작업입니다.
조사 결과, TailwindCSS 플러그인이 주요 원인으로 확인되었으며, 이를 해결하기 위해 TailwindCSS를 3.x로 업그레이드하고 관련 코드를 수정하였습니다.

#### 이슈 사항
프로젝트에비해 빌드 시, 큰용량의 메모리를 사용함.

#### 이슈 해결 과정

1. 메모리 사용량 로깅 추가
- Rollup의 커스텀 플러그인(memory-logger)을 추가하여 빌드 과정의 메모리 사용량을 로깅.
- mirinae/dist/style.css 파일 변환 시 메모리가 4GB 급증하는 문제를 확인.
- postcss 플러그인 이슈 의심

2. PostCSS 플러그인들을 하나씩 비활성화하며 문제를 추적.
- postcss/TailwindCSS 플러그인 이슈 의심
- TailwindCSS 플러그인을 비활성화했을 때 메모리 사용량이 약 8GB → 2GB로 감소.


3. TailwindCSS 업그레이드 (v1.x → v3.x)
- 성능 문제를 해결하고 JIT(Just-In-Time) 엔진을 활용하기 위해 TailwindCSS를 3.x로 업그레이드.
- PostCSS 8 및 최신 빌드 도구(Vite 등)와의 호환성 문제 개선되었다고 함.

4. TailwindCSS 3.x에 맞춰 콘솔과 디자인 시스템 코드 수정
- bg-gray → bg-gray-default (해당 컬러의 기본값 형식이 변경됨).
- rounded → rounded-default (명시적으로 기본값 정의 필요).
- row-gap-{n} 및 col-gap-{n} → gap-y-{n} 및 gap-x-{n}으로 변경.
- JIT 엔진 도입에 따라 중첩된 at-rule(@media, @import 등) 사용 불가:
    - 관련 스타일을 비중첩 형태로 리팩터링.

#### 결과
TailwindCSS 업그레이드 전:
- 빌드 메모리 사용량:  약 8GB
- 콘솔 빌드 속도: 약 15 분
TailwindCSS 업그레이드 후:
- 빌드 메모리 사용량: 약 2GB로 감소.
- 콘솔 빌드 속도: 약 2분

### Things to Talk About (optional)
