### PR TITLE
feat: apply tab switching when the details button in the overview tab is clicked

### DIFF
--- a/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabs.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabs.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { computed, reactive } from 'vue';
+import {
+    computed, reactive, watch,
+} from 'vue';
 
 import {
     PHorizontalLayout, PTab,
@@ -7,6 +9,8 @@ import {
 import type { TabItem } from '@cloudforet/mirinae/types/navigation/tabs/tab/type';
 
 import { i18n } from '@/translations';
+
+import { replaceUrlQuery } from '@/lib/router-query-string';
 
 import ServiceDetailTabsNotifications from '@/services/alert-manager-v2/components/ServiceDetailTabsNotifications.vue';
 import ServiceDetailTabsNotificationsDetailTabs
@@ -33,6 +37,10 @@ const state = reactive({
     selectedWebhook: [],
     selectedNotifications: [],
 });
+
+watch(() => tabState.activeTab, (activeTab) => {
+    replaceUrlQuery('tab', activeTab);
+}, { immediate: true });
 </script>
 
 <template>

--- a/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabs.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabs.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import {
-    computed, reactive, watch,
+    computed, onMounted, onUnmounted, reactive, watch,
 } from 'vue';
+import { useRoute } from 'vue-router/composables';
 
 import {
     PHorizontalLayout, PTab,
@@ -21,7 +22,13 @@ import ServiceDetailTabsWebhook from '@/services/alert-manager-v2/components/Ser
 import ServiceDetailTabsWebhookDetailTabs
     from '@/services/alert-manager-v2/components/ServiceDetailTabsWebhookDetailTabs.vue';
 import { SERVICE_DETAIL_TABS } from '@/services/alert-manager-v2/constants/alert-manager-constant';
+import { useServiceDetailPageStore } from '@/services/alert-manager-v2/store/service-detail-page-store';
 import type { ServiceDetailTabsType } from '@/services/alert-manager-v2/types/alert-manager-type';
+
+const serviceDetailPageStore = useServiceDetailPageStore();
+const serviceDetailPageState = serviceDetailPageStore.state;
+
+const route = useRoute();
 
 const tabState = reactive({
     tabs: computed<TabItem[]>(() => ([
@@ -33,14 +40,33 @@ const tabState = reactive({
     ])),
     activeTab: SERVICE_DETAIL_TABS.OVERVIEW as ServiceDetailTabsType,
 });
+const storeState = reactive({
+    currentTab: computed<ServiceDetailTabsType>(() => serviceDetailPageState.currentTab),
+});
 const state = reactive({
     selectedWebhook: [],
     selectedNotifications: [],
 });
 
 watch(() => tabState.activeTab, (activeTab) => {
+    serviceDetailPageStore.setCurrentTab(activeTab);
     replaceUrlQuery('tab', activeTab);
-}, { immediate: true });
+});
+watch(() => storeState.currentTab, (currentTab) => {
+    tabState.activeTab = currentTab;
+});
+
+onMounted(() => {
+    if (route.query.tab) {
+        serviceDetailPageStore.setCurrentTab(route.query.tab as ServiceDetailTabsType);
+    } else {
+        serviceDetailPageStore.setCurrentTab(SERVICE_DETAIL_TABS.OVERVIEW);
+    }
+});
+
+onUnmounted(() => {
+    serviceDetailPageStore.initState();
+});
 </script>
 
 <template>

--- a/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewEscalationPolicy.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewEscalationPolicy.vue
@@ -3,8 +3,11 @@ import { useElementSize } from '@vueuse/core/index';
 import { computed, reactive, ref } from 'vue';
 
 import {
-    PFieldTitle, PIconButton, PDivider, PLink, PBadge,
+    PFieldTitle, PIconButton, PDivider, PBadge, PTextButton,
 } from '@cloudforet/mirinae';
+
+import { SERVICE_DETAIL_TABS } from '@/services/alert-manager-v2/constants/alert-manager-constant';
+import { useServiceDetailPageStore } from '@/services/alert-manager-v2/store/service-detail-page-store';
 
 const ITEM_DEFAULT_WIDTH = 184 + 8;
 const DEFAULT_LEFT_PADDING = 16;
@@ -12,6 +15,7 @@ const DEFAULT_LEFT_PADDING = 16;
 const rowItemsWrapperRef = ref<null | HTMLElement>(null);
 const itemEl = ref<null | HTMLElement>(null);
 
+const serviceDetailPageStore = useServiceDetailPageStore();
 const { width: rowItemsWrapperWidth } = useElementSize(rowItemsWrapperRef);
 
 const state = reactive({
@@ -66,9 +70,9 @@ const handleClickArrowButton = (increment: number) => {
     element.el.style.marginLeft = increment === 1 ? `-${marginLeft}px` : `${marginLeft}px`;
 };
 
-const handleRouteDetail = () => {
-    console.log('handleRouteDetail');
-};
+const handleRouteDetail = () => (
+    serviceDetailPageStore.setActiveTab(SERVICE_DETAIL_TABS.SETTINGS)
+);
 </script>
 
 <template>
@@ -126,12 +130,11 @@ const handleRouteDetail = () => {
         <div>
             <p-divider class="bg-gray-150" />
             <div class="link-wrapper">
-                <p-link :text="$t('ALERT_MANAGER.SERVICE.DETAILS')"
-                        action-icon="internal-link"
-                        new-tab
-                        highlight
-                        :to="handleRouteDetail"
-                />
+                <p-text-button style-type="highlight"
+                               @click="handleRouteDetail"
+                >
+                    {{ $t('ALERT_MANAGER.SERVICE.DETAILS') }}
+                </p-text-button>
             </div>
         </div>
     </div>

--- a/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewEscalationPolicy.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewEscalationPolicy.vue
@@ -71,7 +71,7 @@ const handleClickArrowButton = (increment: number) => {
 };
 
 const handleRouteDetail = () => (
-    serviceDetailPageStore.setActiveTab(SERVICE_DETAIL_TABS.SETTINGS)
+    serviceDetailPageStore.setCurrentTab(SERVICE_DETAIL_TABS.SETTINGS)
 );
 </script>
 

--- a/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewNotification.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewNotification.vue
@@ -3,10 +3,13 @@ import { useElementSize } from '@vueuse/core/index';
 import { computed, reactive, ref } from 'vue';
 
 import {
-    PFieldTitle, PIconButton, PLazyImg, PDivider, PLink,
+    PFieldTitle, PIconButton, PLazyImg, PDivider, PTextButton,
 } from '@cloudforet/mirinae';
 
 import { assetUrlConverter } from '@/lib/helper/asset-helper';
+
+import { SERVICE_DETAIL_TABS } from '@/services/alert-manager-v2/constants/alert-manager-constant';
+import { useServiceDetailPageStore } from '@/services/alert-manager-v2/store/service-detail-page-store';
 
 const ITEM_DEFAULT_WIDTH = 120 + 8;
 const DEFAULT_LEFT_PADDING = 16;
@@ -14,6 +17,7 @@ const DEFAULT_LEFT_PADDING = 16;
 const rowItemsWrapperRef = ref<null | HTMLElement>(null);
 const itemEl = ref<null | HTMLElement>(null);
 
+const serviceDetailPageStore = useServiceDetailPageStore();
 const { width: rowItemsWrapperWidth } = useElementSize(rowItemsWrapperRef);
 
 const state = reactive({
@@ -62,9 +66,9 @@ const handleClickArrowButton = (increment: number) => {
     element.el.style.marginLeft = increment === 1 ? `-${marginLeft}px` : `${marginLeft}px`;
 };
 
-const handleRouteDetail = () => {
-    console.log('handleRouteDetail');
-};
+const handleRouteDetail = () => (
+    serviceDetailPageStore.setActiveTab(SERVICE_DETAIL_TABS.NOTIFICATIONS)
+);
 </script>
 
 <template>
@@ -119,12 +123,11 @@ const handleRouteDetail = () => {
         <div>
             <p-divider class="bg-gray-150" />
             <div class="link-wrapper">
-                <p-link :text="$t('ALERT_MANAGER.SERVICE.DETAILS')"
-                        action-icon="internal-link"
-                        new-tab
-                        highlight
-                        :to="handleRouteDetail"
-                />
+                <p-text-button style-type="highlight"
+                               @click="handleRouteDetail"
+                >
+                    {{ $t('ALERT_MANAGER.SERVICE.DETAILS') }}
+                </p-text-button>
             </div>
         </div>
     </div>

--- a/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewNotification.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewNotification.vue
@@ -67,7 +67,7 @@ const handleClickArrowButton = (increment: number) => {
 };
 
 const handleRouteDetail = () => (
-    serviceDetailPageStore.setActiveTab(SERVICE_DETAIL_TABS.NOTIFICATIONS)
+    serviceDetailPageStore.setCurrentTab(SERVICE_DETAIL_TABS.NOTIFICATIONS)
 );
 </script>
 

--- a/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewWebhook.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewWebhook.vue
@@ -73,7 +73,7 @@ const handleClickArrowButton = (increment: number) => {
 };
 
 const handleRouteDetail = () => (
-    serviceDetailPageStore.setActiveTab(SERVICE_DETAIL_TABS.WEBHOOK)
+    serviceDetailPageStore.setCurrentTab(SERVICE_DETAIL_TABS.WEBHOOK)
 );
 </script>
 

--- a/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewWebhook.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceDetailTabsOverviewWebhook.vue
@@ -3,10 +3,13 @@ import { useElementSize } from '@vueuse/core/index';
 import { computed, reactive, ref } from 'vue';
 
 import {
-    PFieldTitle, PIconButton, PLazyImg, PDivider, PLink,
+    PFieldTitle, PIconButton, PLazyImg, PDivider, PTextButton,
 } from '@cloudforet/mirinae';
 
 import { assetUrlConverter } from '@/lib/helper/asset-helper';
+
+import { SERVICE_DETAIL_TABS } from '@/services/alert-manager-v2/constants/alert-manager-constant';
+import { useServiceDetailPageStore } from '@/services/alert-manager-v2/store/service-detail-page-store';
 
 const ITEM_DEFAULT_WIDTH = 184 + 8;
 const DEFAULT_LEFT_PADDING = 16;
@@ -14,8 +17,8 @@ const DEFAULT_LEFT_PADDING = 16;
 const rowItemsWrapperRef = ref<null | HTMLElement>(null);
 const itemEl = ref<null | HTMLElement>(null);
 
+const serviceDetailPageStore = useServiceDetailPageStore();
 const { width: rowItemsWrapperWidth } = useElementSize(rowItemsWrapperRef);
-
 
 const state = reactive({
     pageStart: 0,
@@ -69,9 +72,9 @@ const handleClickArrowButton = (increment: number) => {
     element.el.style.marginLeft = increment === 1 ? `-${marginLeft}px` : `${marginLeft}px`;
 };
 
-const handleRouteDetail = () => {
-    console.log('handleRouteDetail');
-};
+const handleRouteDetail = () => (
+    serviceDetailPageStore.setActiveTab(SERVICE_DETAIL_TABS.WEBHOOK)
+);
 </script>
 
 <template>
@@ -128,12 +131,11 @@ const handleRouteDetail = () => {
         </div>
         <p-divider class="bg-gray-150" />
         <div class="link-wrapper">
-            <p-link :text="$t('ALERT_MANAGER.SERVICE.DETAILS')"
-                    action-icon="internal-link"
-                    new-tab
-                    highlight
-                    :to="handleRouteDetail"
-            />
+            <p-text-button style-type="highlight"
+                           @click="handleRouteDetail"
+            >
+                {{ $t('ALERT_MANAGER.SERVICE.DETAILS') }}
+            </p-text-button>
         </div>
     </div>
 </template>

--- a/apps/web/src/services/alert-manager-v2/components/ServiceList.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
-import { useRoute, useRouter } from 'vue-router/composables';
+import { useRouter } from 'vue-router/composables';
 
 import { makeDistinctValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import type { KeyItemSet, ValueHandlerMap } from '@cloudforet/core-lib/component-util/query-search/type';
@@ -10,6 +10,7 @@ import {
 import type { ToolboxOptions } from '@cloudforet/mirinae/src/controls/toolbox/type';
 import type { QueryTag } from '@cloudforet/mirinae/types/controls/search/query-search-tags/type';
 
+import { useProperRouteLocation } from '@/common/composables/proper-route-location';
 import { useQueryTags } from '@/common/composables/query-tags';
 
 import { red } from '@/styles/colors';
@@ -20,7 +21,8 @@ import { ALERT_MANAGER_V2_ROUTE } from '@/services/alert-manager-v2/routes/route
 const pageSizeOptions = [15, 30, 45];
 
 const router = useRouter();
-const route = useRoute();
+
+const { getProperRouteLocation } = useProperRouteLocation();
 
 const handlerState = reactive({
     keyItemSets: computed<KeyItemSet[]>(() => [{
@@ -54,16 +56,15 @@ const handleChangeToolbox = async (options: ToolboxOptions) => {
 };
 
 const handleClickServiceItem = (id: string) => {
-    router.push({
+    router.push(getProperRouteLocation({
         name: ALERT_MANAGER_V2_ROUTE.SERVICE.DETAIL._NAME,
         params: {
-            ...route.params,
             serviceId: id,
         },
         query: {
             tab: SERVICE_DETAIL_TABS.OVERVIEW,
         },
-    });
+    }));
 };
 const handleClickEscalationPolicy = () => {
     console.log('TODO: handleClickEscalationPolicy');

--- a/apps/web/src/services/alert-manager-v2/components/ServiceList.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceList.vue
@@ -14,6 +14,7 @@ import { useQueryTags } from '@/common/composables/query-tags';
 
 import { red } from '@/styles/colors';
 
+import { SERVICE_DETAIL_TABS } from '@/services/alert-manager-v2/constants/alert-manager-constant';
 import { ALERT_MANAGER_V2_ROUTE } from '@/services/alert-manager-v2/routes/route-constant';
 
 const pageSizeOptions = [15, 30, 45];
@@ -56,6 +57,9 @@ const handleClickServiceItem = (id: string) => {
         name: ALERT_MANAGER_V2_ROUTE.SERVICE.DETAIL._NAME,
         params: {
             serviceId: id,
+        },
+        query: {
+            tab: SERVICE_DETAIL_TABS.OVERVIEW,
         },
     });
 };

--- a/apps/web/src/services/alert-manager-v2/components/ServiceList.vue
+++ b/apps/web/src/services/alert-manager-v2/components/ServiceList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
-import { useRouter } from 'vue-router/composables';
+import { useRoute, useRouter } from 'vue-router/composables';
 
 import { makeDistinctValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import type { KeyItemSet, ValueHandlerMap } from '@cloudforet/core-lib/component-util/query-search/type';
@@ -20,6 +20,7 @@ import { ALERT_MANAGER_V2_ROUTE } from '@/services/alert-manager-v2/routes/route
 const pageSizeOptions = [15, 30, 45];
 
 const router = useRouter();
+const route = useRoute();
 
 const handlerState = reactive({
     keyItemSets: computed<KeyItemSet[]>(() => [{
@@ -56,6 +57,7 @@ const handleClickServiceItem = (id: string) => {
     router.push({
         name: ALERT_MANAGER_V2_ROUTE.SERVICE.DETAIL._NAME,
         params: {
+            ...route.params,
             serviceId: id,
         },
         query: {

--- a/apps/web/src/services/alert-manager-v2/store/service-detail-page-store.ts
+++ b/apps/web/src/services/alert-manager-v2/store/service-detail-page-store.ts
@@ -1,0 +1,30 @@
+import { reactive } from 'vue';
+
+import { defineStore } from 'pinia';
+
+import { SERVICE_DETAIL_TABS } from '@/services/alert-manager-v2/constants/alert-manager-constant';
+import type { ServiceDetailTabsType } from '@/services/alert-manager-v2/types/alert-manager-type';
+
+interface ServiceFormStoreState {
+    currentTab: ServiceDetailTabsType;
+}
+
+export const useServiceDetailPageStore = defineStore('page-service-detail', () => {
+    const state = reactive<ServiceFormStoreState>({
+        currentTab: SERVICE_DETAIL_TABS.OVERVIEW,
+    });
+
+    const actions = {
+        initState() {
+            state.currentTab = SERVICE_DETAIL_TABS.OVERVIEW;
+        },
+        setCurrentTab(currentTab: ServiceDetailTabsType) {
+            state.currentTab = currentTab;
+        },
+    };
+
+    return {
+        state,
+        ...actions,
+    };
+});

--- a/apps/web/src/services/workspace-home/components/WorkspaceInfo.vue
+++ b/apps/web/src/services/workspace-home/components/WorkspaceInfo.vue
@@ -22,6 +22,7 @@ import { useUserWorkspaceStore } from '@/store/app-context/workspace/user-worksp
 import type { PageAccessMap } from '@/lib/access-control/config';
 import { MENU_ID } from '@/lib/menu/config';
 
+import { useProperRouteLocation } from '@/common/composables/proper-route-location';
 import FavoriteButton from '@/common/modules/favorites/favorite-button/FavoriteButton.vue';
 import { FAVORITE_TYPE } from '@/common/modules/favorites/favorite-button/type';
 import WorkspaceLogoIcon from '@/common/modules/navigations/top-bar/modules/top-bar-header/WorkspaceLogoIcon.vue';
@@ -55,6 +56,8 @@ const workspaceHomePageStore = useWorkspaceHomePageStore();
 const workspaceHomePageState = workspaceHomePageStore.state;
 
 const router = useRouter();
+
+const { getProperRouteLocation } = useProperRouteLocation();
 
 const storeState = reactive({
     currentWorkspace: computed<WorkspaceModel|undefined>(() => userWorkspaceGetters.currentWorkspace),
@@ -97,7 +100,7 @@ const actionWorkspace = (type: string, workspaceId: string) => {
     });
 };
 const routerToCreateApp = (isOpenModal: boolean) => {
-    router.push({ name: IAM_ROUTE.APP._NAME });
+    router.push(getProperRouteLocation({ name: IAM_ROUTE.APP._NAME }));
     if (isOpenModal) {
         appPageStore.$patch((_state) => {
             _state.modal.type = APP_DROPDOWN_MODAL_TYPE.CREATE;
@@ -108,7 +111,7 @@ const routerToCreateApp = (isOpenModal: boolean) => {
     }
 };
 const routerToWorkspaceUser = (isOpenModal: boolean) => {
-    router.push({ name: IAM_ROUTE.USER._NAME });
+    router.push(getProperRouteLocation({ name: IAM_ROUTE.USER._NAME }));
     if (isOpenModal) {
         userPageStore.$patch((_state) => {
             _state.state.modal.type = USER_MODAL_TYPE.INVITE;


### PR DESCRIPTION
### To Reviewers
- [ ] Self-reviewed (coding conventions, bug-free, functionality verified, tests checked, documentation updated)
- [ ] Minor change, review optional (`style`, `chore`, `ci`, straightforward changes, etc.)
- [ ] Previously reviewed in feature branch, no further review needed
- [ ] Need review or discussion

### Description (optional)
I implemented it by using the query string to replace the tab since clicking the details button in the overview tab needs to navigate to the corresponding tab.
<img width="1083" alt="스크린샷 2024-12-04 20 15 05" src="https://github.com/user-attachments/assets/9f29903b-204e-4e38-ac92-62be71d04e58">

### Things to Talk About (optional)
