### PR TITLE
fix: reflect the latest changes in composable to the queryInput

### DIFF
--- a/packages/mirinae/src/controls/input/query-input/PQueryInput.vue
+++ b/packages/mirinae/src/controls/input/query-input/PQueryInput.vue
@@ -151,20 +151,23 @@ const emit = defineEmits<{(e: 'update:visible-menu', visibleMenu: boolean): void
 }>();
 
 /* input focusing */
+const targetRef = ref<HTMLElement|null>(null);
+const menuRef = ref<null|typeof PContextMenu>(null);
 const inputRef = ref<HTMLElement|null>(null);
 const { focused: isInputFocused } = useFocus(inputRef);
 
 /* context menu style */
 const proxyVisibleMenu = useProxyValue<boolean>('visibleMenu', props, emit);
 const {
-    targetRef, contextMenuStyle,
+    contextMenuStyle,
 } = useContextMenuStyle({
     useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
+    targetRef,
+    menuRef,
     visibleMenu: proxyVisibleMenu,
 });
 
 /* query search */
-const menuRef = ref<null|typeof PContextMenu>(null);
 const {
     state: querySearchState,
     focus, blur, hideMenu, showMenu,


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
The issue occurred because the changes made to the useContextMenuStyle composable were not reflected in PQueryItem.




### Things to Talk About (optional)
