### PR TITLE
ci: enhance pull request review state labeler permissions and behavior

### DIFF
--- a/.github/workflows/pull_request_review_state_labeler.yaml
+++ b/.github/workflows/pull_request_review_state_labeler.yaml
@@ -1,5 +1,9 @@
 name: "[Pull Request] Review State Labeler"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   pull_request_review:
     types: [submitted, edited, dismissed]

--- a/.github/workflows/pull_request_review_state_labeler.yaml
+++ b/.github/workflows/pull_request_review_state_labeler.yaml
@@ -14,8 +14,8 @@ jobs:
   update-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR information
-        id: pr_info
+      - name: Check if it is self approved review PR
+        id: check_self_approved
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -23,29 +23,17 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            
-            // Get current labels
             const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
               owner,
               repo,
               issue_number: prNumber
             });
-            
-            const hasSelfApprovedReview = currentLabels.some(label => label.name === 'self_approved/review');
-            
-            // Check reviewers only for pull_request_target event
-            const hasReviewers = github.event_name === 'pull_request_target' ? 
-              (context.payload.pull_request.requested_reviewers && 
-               context.payload.pull_request.requested_reviewers.length > 0) : false;
-            
-            core.setOutput('hasSelfApprovedReview', hasSelfApprovedReview);
-            core.setOutput('hasReviewers', hasReviewers);
 
-      - name: Add pending review label on PR creation or update
-        if: |
-          github.event_name == 'pull_request_target' && 
-          steps.pr_info.outputs.hasSelfApprovedReview == 'false' && 
-          steps.pr_info.outputs.hasReviewers == 'false'
+            const hasSelfApprovedReview = currentLabels.some(label => label.name === 'self_approved/review');
+            core.setOutput('isSelfApprovedPR', hasSelfApprovedReview);
+
+      - name: Add 'pending/review' label based on PR label on pull_request_target event
+        if: github.event_name == 'pull_request_target' && steps.check_self_approved.outputs.isSelfApprovedPR == 'false'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,13 +41,10 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-
-            // Double check if the PR has self approved review label
             const hasSelfApprovedReview = context.payload.pull_request.labels.some(label => label.name === 'self_approved/review');
             if(hasSelfApprovedReview) {
               return;
             }
-
             await github.rest.issues.addLabels({
               owner,
               repo,
@@ -67,10 +52,8 @@ jobs:
               labels: ['pending/review']
             });
 
-      - name: Update labels based on review state
-        if: |
-          github.event_name == 'pull_request_review' && 
-          steps.pr_info.outputs.hasSelfApprovedReview == 'false'
+      - name: Add or remove labels based on review state on pull_request_review event
+        if: github.event_name == 'pull_request_review' && steps.check_self_approved.outputs.isSelfApprovedPR == 'false'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -106,7 +89,7 @@ jobs:
                 }
               }
 
-              // Add new review state label
+              // Add 'approved/review' or 'changes_requested/review' label
               await github.rest.issues.addLabels({
                 owner,
                 repo,

--- a/.github/workflows/pull_request_review_state_labeler.yaml
+++ b/.github/workflows/pull_request_review_state_labeler.yaml
@@ -14,8 +14,8 @@ jobs:
   update-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if it is self approved review PR
-        id: check_self_approved
+      - name: Get PR information
+        id: pr_info
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -23,17 +23,29 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            
+            // Get current labels
             const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
               owner,
               repo,
               issue_number: prNumber
             });
-
+            
             const hasSelfApprovedReview = currentLabels.some(label => label.name === 'self_approved/review');
-            core.setOutput('isSelfApprovedPR', hasSelfApprovedReview);
+            
+            // Check reviewers only for pull_request_target event
+            const hasReviewers = github.event_name === 'pull_request_target' ? 
+              (context.payload.pull_request.requested_reviewers && 
+               context.payload.pull_request.requested_reviewers.length > 0) : false;
+            
+            core.setOutput('hasSelfApprovedReview', hasSelfApprovedReview);
+            core.setOutput('hasReviewers', hasReviewers);
 
-      - name: Add 'pending/review' label based on PR label on pull_request_target event
-        if: github.event_name == 'pull_request_target' && steps.check_self_approved.outputs.isSelfApprovedPR == 'false'
+      - name: Add pending review label on PR creation or update
+        if: |
+          github.event_name == 'pull_request_target' && 
+          steps.pr_info.outputs.hasSelfApprovedReview == 'false' && 
+          steps.pr_info.outputs.hasReviewers == 'false'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,10 +53,13 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+
+            // Double check if the PR has self approved review label
             const hasSelfApprovedReview = context.payload.pull_request.labels.some(label => label.name === 'self_approved/review');
             if(hasSelfApprovedReview) {
               return;
             }
+
             await github.rest.issues.addLabels({
               owner,
               repo,
@@ -52,8 +67,10 @@ jobs:
               labels: ['pending/review']
             });
 
-      - name: Add or remove labels based on review state on pull_request_review event
-        if: github.event_name == 'pull_request_review' && steps.check_self_approved.outputs.isSelfApprovedPR == 'false'
+      - name: Update labels based on review state
+        if: |
+          github.event_name == 'pull_request_review' && 
+          steps.pr_info.outputs.hasSelfApprovedReview == 'false'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +106,7 @@ jobs:
                 }
               }
 
-              // Add 'approved/review' or 'changes_requested/review' label
+              // Add new review state label
               await github.rest.issues.addLabels({
                 owner,
                 repo,


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)

This pull request includes changes to the pull request review state labeler. 
The first commit updates the pull request review state labeler permissions to allow writing issues and pull requests. 
The second commit enhances the pull request review behavior by not adding the pending label when a reviewer is already selected. 
The changes ensure that the labeler functions correctly and improves the overall pull request review process.

### Things to Talk About (optional)
