### PR TITLE
feat: update pairsForm & pairsInputGroup component

### DIFF
--- a/apps/web/src/common/components/forms/pairs-form/PairsForm.vue
+++ b/apps/web/src/common/components/forms/pairs-form/PairsForm.vue
@@ -15,14 +15,14 @@ const props = withDefaults(defineProps<{
     loading?: boolean;
     pairConfig?: PairConfig;
     i18nLabels?: I18nLabels;
-    isLongValue?: boolean;
+    isBlock?: boolean;
 }>(), {
     title: undefined,
     pairs: () => ({}),
     loading: false,
     pairConfig: undefined,
     i18nLabels: undefined,
-    isLongValue: false,
+    isBlock: false,
 });
 
 const emit = defineEmits<{(e: 'confirm', pairs: Pair): void;
@@ -73,7 +73,7 @@ onMounted(() => {
                 <pairs-input-group :pairs="state.newPairs"
                                    :disabled="props.loading"
                                    show-validation
-                                   :is-long-value="props.isLongValue"
+                                   :is-block="props.isBlock"
                                    :is-valid.sync="state.isPairsValid"
                                    :show-header="state.showHeader"
                                    :i18n-labels="props.i18nLabels"

--- a/apps/web/src/common/components/forms/pairs-form/PairsForm.vue
+++ b/apps/web/src/common/components/forms/pairs-form/PairsForm.vue
@@ -15,12 +15,14 @@ const props = withDefaults(defineProps<{
     loading?: boolean;
     pairConfig?: PairConfig;
     i18nLabels?: I18nLabels;
+    isLongValue?: boolean;
 }>(), {
     title: undefined,
     pairs: () => ({}),
     loading: false,
     pairConfig: undefined,
     i18nLabels: undefined,
+    isLongValue: false,
 });
 
 const emit = defineEmits<{(e: 'confirm', pairs: Pair): void;
@@ -71,6 +73,7 @@ onMounted(() => {
                 <pairs-input-group :pairs="state.newPairs"
                                    :disabled="props.loading"
                                    show-validation
+                                   :is-long-value="props.isLongValue"
                                    :is-valid.sync="state.isPairsValid"
                                    :show-header="state.showHeader"
                                    :i18n-labels="props.i18nLabels"

--- a/apps/web/src/common/components/forms/pairs-input-group/PairsInputGroup.vue
+++ b/apps/web/src/common/components/forms/pairs-input-group/PairsInputGroup.vue
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<{
     isAdministration?: boolean;
     pairConfig?: PairConfig;
     i18nLabels?: I18nLabels;
-    isLongValue?: boolean;
+    isBlock?: boolean;
 }>(), {
     pairs: () => ({}),
     disabled: false,
@@ -45,7 +45,7 @@ const props = withDefaults(defineProps<{
         KEY_LABEL: i18n.t('COMMON.TAGS.KEY'),
         VALUE_LABEL: i18n.t('COMMON.TAGS.VALUE'),
     }),
-    isLongValue: false,
+    isBlock: false,
 });
 
 const emit = defineEmits<{(e: 'update:is-valid', value: boolean): void;
@@ -153,7 +153,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
         </slot>
         <div v-if="props.showHeader"
              class="pair-header"
-             :class="{ 'is-long': props.isLongValue }"
+             :class="{ 'is-block': props.isBlock }"
         >
             <div class="key">
                 <span>{{ props.i18nLabels?.KEY_LABEL || '' }}</span>
@@ -166,7 +166,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
             <div v-for="(item, idx) in state.items"
                  :key="idx"
                  class="pair-group"
-                 :class="{ 'is-long': props.isLongValue }"
+                 :class="{ 'is-block': props.isBlock }"
             >
                 <p-field-group :invalid-text="state.keyValidations[idx].message"
                                :invalid="props.showValidation && !state.keyValidations[idx].isValid"
@@ -177,7 +177,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
                                       :invalid="invalid"
                                       :placeholder="props.pairConfig.keyLabel"
                                       :disabled="props.disabled"
-                                      :block="props.isLongValue"
+                                      :block="props.isBlock"
                                       @update:value="handleInputKeySection(idx, ...arguments)"
                         />
                     </template>
@@ -192,7 +192,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
                                       :invalid="invalid"
                                       :placeholder="props.pairConfig.valueLabel"
                                       :disabled="props.disabled"
-                                      :block="props.isLongValue"
+                                      :block="props.isBlock"
                                       @update:value="handleInputValueSection(idx, ...arguments)"
                         />
                     </template>
@@ -221,7 +221,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
             @apply inline-block font-bold pl-2;
             width: 20rem;
         }
-        &.is-long {
+        &.is-block {
             .key {
                 width: 49%;
             }
@@ -250,7 +250,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
                 }
             }
         }
-        &.is-long {
+        &.is-block {
             .input-box {
                 &.key {
                     width: 100%;

--- a/apps/web/src/common/components/forms/pairs-input-group/PairsInputGroup.vue
+++ b/apps/web/src/common/components/forms/pairs-input-group/PairsInputGroup.vue
@@ -25,6 +25,7 @@ const props = withDefaults(defineProps<{
     isAdministration?: boolean;
     pairConfig?: PairConfig;
     i18nLabels?: I18nLabels;
+    isLongValue?: boolean;
 }>(), {
     pairs: () => ({}),
     disabled: false,
@@ -44,6 +45,7 @@ const props = withDefaults(defineProps<{
         KEY_LABEL: i18n.t('COMMON.TAGS.KEY'),
         VALUE_LABEL: i18n.t('COMMON.TAGS.VALUE'),
     }),
+    isLongValue: false,
 });
 
 const emit = defineEmits<{(e: 'update:is-valid', value: boolean): void;
@@ -151,6 +153,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
         </slot>
         <div v-if="props.showHeader"
              class="pair-header"
+             :class="{ 'is-long': props.isLongValue }"
         >
             <div class="key">
                 <span>{{ props.i18nLabels?.KEY_LABEL || '' }}</span>
@@ -163,6 +166,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
             <div v-for="(item, idx) in state.items"
                  :key="idx"
                  class="pair-group"
+                 :class="{ 'is-long': props.isLongValue }"
             >
                 <p-field-group :invalid-text="state.keyValidations[idx].message"
                                :invalid="props.showValidation && !state.keyValidations[idx].isValid"
@@ -173,6 +177,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
                                       :invalid="invalid"
                                       :placeholder="props.pairConfig.keyLabel"
                                       :disabled="props.disabled"
+                                      :block="props.isLongValue"
                                       @update:value="handleInputKeySection(idx, ...arguments)"
                         />
                     </template>
@@ -187,6 +192,7 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
                                       :invalid="invalid"
                                       :placeholder="props.pairConfig.valueLabel"
                                       :disabled="props.disabled"
+                                      :block="props.isLongValue"
                                       @update:value="handleInputValueSection(idx, ...arguments)"
                         />
                     </template>
@@ -215,6 +221,14 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
             @apply inline-block font-bold pl-2;
             width: 20rem;
         }
+        &.is-long {
+            .key {
+                width: 49%;
+            }
+            .value {
+                width: 51%;
+            }
+        }
     }
     .pair-group {
         display: flex;
@@ -229,11 +243,20 @@ const stopPairInit = watch(() => props.pairs, (pairs) => {
             &.value {
                 width: 20rem;
             }
-
             .p-text-input {
                 width: 100%;
                 &.invalid {
                     @apply border border-alert;
+                }
+            }
+        }
+        &.is-long {
+            .input-box {
+                &.key {
+                    width: 100%;
+                }
+                &.value {
+                    width: 100%;
                 }
             }
         }

--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsWebhookDetailMessageOverlay.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsWebhookDetailMessageOverlay.vue
@@ -37,7 +37,7 @@ const state = reactive({
                 :pair-config="{ keyLabel: 'from', valueLabel: 'to' }"
                 :i18n-labels="state.i18nLabels"
                 class="service-detail-tabs-webhook-detail-message-overlay"
-                is-long-value
+                is-block
                 @confirm="emit('confirm', $event)"
                 @close="emit('close')"
     >

--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsWebhookDetailMessageOverlay.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsWebhookDetailMessageOverlay.vue
@@ -37,6 +37,7 @@ const state = reactive({
                 :pair-config="{ keyLabel: 'from', valueLabel: 'to' }"
                 :i18n-labels="state.i18nLabels"
                 class="service-detail-tabs-webhook-detail-message-overlay"
+                is-long-value
                 @confirm="emit('confirm', $event)"
                 @close="emit('close')"
     >


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [x] Self-merge allowed for solo developers or urgent changes

### Description (optional)
- Format messages when updating the 'Service' design because the request requires a longer text input width
- common component `PairsForm` & `PairsInputGroup` are used in this page
- All pages using that component will not be affected by this update, except when using the 'is-long-value' prop.
- without `is-longer-value` 
![image](https://github.com/user-attachments/assets/d5df5a75-41a2-46ec-a881-b2c7ba10ee57)
- with `is-longer-value`
![image](https://github.com/user-attachments/assets/c1522732-2247-45f8-a76e-42e75dcdce75)


### Things to Talk About (optional)
