### PR TITLE
build: update turbo to version 2.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint-config-custom": "*",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.0",
-        "turbo": "^1.13.4"
+        "turbo": "^2.3.4"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -31527,26 +31527,26 @@
       "dev": true
     },
     "node_modules/turbo": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.4.tgz",
-      "integrity": "sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.3.4.tgz",
+      "integrity": "sha512-1kiLO5C0Okh5ay1DbHsxkPsw9Sjsbjzm6cF85CpWjR0BIyBFNDbKqtUyqGADRS1dbbZoQanJZVj4MS5kk8J42Q==",
       "dev": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.13.4",
-        "turbo-darwin-arm64": "1.13.4",
-        "turbo-linux-64": "1.13.4",
-        "turbo-linux-arm64": "1.13.4",
-        "turbo-windows-64": "1.13.4",
-        "turbo-windows-arm64": "1.13.4"
+        "turbo-darwin-64": "2.3.4",
+        "turbo-darwin-arm64": "2.3.4",
+        "turbo-linux-64": "2.3.4",
+        "turbo-linux-arm64": "2.3.4",
+        "turbo-windows-64": "2.3.4",
+        "turbo-windows-arm64": "2.3.4"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.4.tgz",
-      "integrity": "sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.3.4.tgz",
+      "integrity": "sha512-uOi/cUIGQI7uakZygH+cZQ5D4w+aMLlVCN2KTGot+cmefatps2ZmRRufuHrEM0Rl63opdKD8/JIu+54s25qkfg==",
       "cpu": [
         "x64"
       ],
@@ -31557,9 +31557,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.4.tgz",
-      "integrity": "sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.3.4.tgz",
+      "integrity": "sha512-IIM1Lq5R+EGMtM1YFGl4x8Xkr0MWb4HvyU8N4LNoQ1Be5aycrOE+VVfH+cDg/Q4csn+8bxCOxhRp5KmUflrVTQ==",
       "cpu": [
         "arm64"
       ],
@@ -31570,9 +31570,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.4.tgz",
-      "integrity": "sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.3.4.tgz",
+      "integrity": "sha512-1aD2EfR7NfjFXNH3mYU5gybLJEFi2IGOoKwoPLchAFRQ6OEJQj201/oNo9CDL75IIrQo64/NpEgVyZtoPlfhfA==",
       "cpu": [
         "x64"
       ],
@@ -31583,9 +31583,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.4.tgz",
-      "integrity": "sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.3.4.tgz",
+      "integrity": "sha512-MxTpdKwxCaA5IlybPxgGLu54fT2svdqTIxRd0TQmpRJIjM0s4kbM+7YiLk0mOh6dGqlWPUsxz/A0Mkn8Xr5o7Q==",
       "cpu": [
         "arm64"
       ],
@@ -31596,9 +31596,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.4.tgz",
-      "integrity": "sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.3.4.tgz",
+      "integrity": "sha512-yyCrWqcRGu1AOOlrYzRnizEtdkqi+qKP0MW9dbk9OsMDXaOI5jlWtTY/AtWMkLw/czVJ7yS9Ex1vi9DB6YsFvw==",
       "cpu": [
         "x64"
       ],
@@ -31609,9 +31609,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.4.tgz",
-      "integrity": "sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.3.4.tgz",
+      "integrity": "sha512-PggC3qH+njPfn1PDVwKrQvvQby8X09ufbqZ2Ha4uSu+5TvPorHHkAbZVHKYj2Y+tvVzxRzi4Sv6NdHXBS9Be5w==",
       "cpu": [
         "arm64"
       ],
@@ -57978,58 +57978,58 @@
       }
     },
     "turbo": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.4.tgz",
-      "integrity": "sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.3.4.tgz",
+      "integrity": "sha512-1kiLO5C0Okh5ay1DbHsxkPsw9Sjsbjzm6cF85CpWjR0BIyBFNDbKqtUyqGADRS1dbbZoQanJZVj4MS5kk8J42Q==",
       "dev": true,
       "requires": {
-        "turbo-darwin-64": "1.13.4",
-        "turbo-darwin-arm64": "1.13.4",
-        "turbo-linux-64": "1.13.4",
-        "turbo-linux-arm64": "1.13.4",
-        "turbo-windows-64": "1.13.4",
-        "turbo-windows-arm64": "1.13.4"
+        "turbo-darwin-64": "2.3.4",
+        "turbo-darwin-arm64": "2.3.4",
+        "turbo-linux-64": "2.3.4",
+        "turbo-linux-arm64": "2.3.4",
+        "turbo-windows-64": "2.3.4",
+        "turbo-windows-arm64": "2.3.4"
       }
     },
     "turbo-darwin-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.4.tgz",
-      "integrity": "sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.3.4.tgz",
+      "integrity": "sha512-uOi/cUIGQI7uakZygH+cZQ5D4w+aMLlVCN2KTGot+cmefatps2ZmRRufuHrEM0Rl63opdKD8/JIu+54s25qkfg==",
       "dev": true,
       "optional": true
     },
     "turbo-darwin-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.4.tgz",
-      "integrity": "sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.3.4.tgz",
+      "integrity": "sha512-IIM1Lq5R+EGMtM1YFGl4x8Xkr0MWb4HvyU8N4LNoQ1Be5aycrOE+VVfH+cDg/Q4csn+8bxCOxhRp5KmUflrVTQ==",
       "dev": true,
       "optional": true
     },
     "turbo-linux-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.4.tgz",
-      "integrity": "sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.3.4.tgz",
+      "integrity": "sha512-1aD2EfR7NfjFXNH3mYU5gybLJEFi2IGOoKwoPLchAFRQ6OEJQj201/oNo9CDL75IIrQo64/NpEgVyZtoPlfhfA==",
       "dev": true,
       "optional": true
     },
     "turbo-linux-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.4.tgz",
-      "integrity": "sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.3.4.tgz",
+      "integrity": "sha512-MxTpdKwxCaA5IlybPxgGLu54fT2svdqTIxRd0TQmpRJIjM0s4kbM+7YiLk0mOh6dGqlWPUsxz/A0Mkn8Xr5o7Q==",
       "dev": true,
       "optional": true
     },
     "turbo-windows-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.4.tgz",
-      "integrity": "sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.3.4.tgz",
+      "integrity": "sha512-yyCrWqcRGu1AOOlrYzRnizEtdkqi+qKP0MW9dbk9OsMDXaOI5jlWtTY/AtWMkLw/czVJ7yS9Ex1vi9DB6YsFvw==",
       "dev": true,
       "optional": true
     },
     "turbo-windows-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.4.tgz",
-      "integrity": "sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.3.4.tgz",
+      "integrity": "sha512-PggC3qH+njPfn1PDVwKrQvvQby8X09ufbqZ2Ha4uSu+5TvPorHHkAbZVHKYj2Y+tvVzxRzi4Sv6NdHXBS9Be5w==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-config-custom": "*",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.0",
-    "turbo": "^1.13.4"
+    "turbo": "^2.3.4"
   },
   "engines": {
     "npm": ">=10.2.3",

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "globalDependencies": [
     "turbo.json", "package.json", "package-lock.json"
   ],
-  "pipeline": {
+  "tasks": {
     "@cloudforet/utils#build": {
       "outputs": ["./dist/**"],
       "inputs": [
@@ -75,6 +75,7 @@
       "cache": true
     },
     "dev": {
+      "persistent": true,
       "cache": false
     },
     "lint": {


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)

<details>
<summary>Turbo 2.3.4 Breaking changes</summary>

##### Configuration
- Ignore turbo field in package.json ([PR](https://github.com/vercel/turbo/pull/8023))
- Turborepo’s default disk cache location moved to .turbo/cache from node_modules/.cache ([PR](https://github.com/vercel/turbo/pull/8126))
- pipeline key in turbo.json renamed to tasks ([PR](https://github.com/vercel/turbo/pull/8157))
- File globs for directories in inputs/outputs include the directory's contents (e.g. dist anddist/ equal dist/**) ([PR](https://github.com/vercel/turbo/pull/8180))
- outputMode key renamed to outputLogs for clarity and to match the --output-logs flag ([PR](https://github.com/vercel/turbo/pull/8149))
- This change will be reflected in Run Summaries in resolvedTaskConfig
- Error on environment variable syntax in dependsOn and globalDependencies (deprecated since 1.4) ([PR](https://github.com/vercel/turbo/pull/8026))
- globalDotEnv and dotEnv removed in favor of including .env files in inputs ([PR](https://github.com/vercel/turbo/pull/8181))
- --ignore removed in favor of --filter and graph correctness changes below ([PR](https://github.com/vercel/turbo/pull/8201))

##### Correctness
- Strict Mode for environment variables is now the default, moving from Loose Mode ([PR](https://github.com/vercel/turbo/pull/8182))
- Workspace root directory is now an implicit dependency of all packages ([PR](https://github.com/vercel/turbo/pull/8202))
- Removed --scope flag (deprecated since 1.2) ([PR](https://github.com/vercel/turbo/pull/7970))
- Packages must have a name in package.json ([PR](https://github.com/vercel/turbo/pull/8152))
- packageManager field in root package.json is now required ([PR](https://github.com/vercel/turbo/pull/8017))
- engines field in root package.json is now used in hashing ([PR](https://github.com/vercel/turbo/pull/8173))
- --filter no longer infers namespaces for package names ([PR](https://github.com/vercel/turbo/pull/8137))
- --filter now errors when no package names or directories are matched ([PR](https://github.com/vercel/turbo/pull/8142))
- --only restricts task dependencies instead of only package dependencies ([PR](https://github.com/vercel/turbo/pull/8163))


</details>

### Things to Talk About (optional)
