### PR TITLE
ci: update PR review labeler workflow token name

### DIFF
--- a/.github/workflows/pull_request_review_state_labeler.yaml
+++ b/.github/workflows/pull_request_review_state_labeler.yaml
@@ -18,7 +18,7 @@ jobs:
         id: check_self_approved
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.PAT_FOR_PR_LABELER }}
+          github-token: ${{ secrets.CONSOLE_PR_PAT_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
@@ -36,7 +36,7 @@ jobs:
         if: github.event_name == 'pull_request_target' && steps.check_self_approved.outputs.isSelfApprovedPR == 'false'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.PAT_FOR_PR_LABELER }}
+          github-token: ${{ secrets.CONSOLE_PR_PAT_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name == 'pull_request_review' && steps.check_self_approved.outputs.isSelfApprovedPR == 'false'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.PAT_FOR_PR_LABELER }}
+          github-token: ${{ secrets.CONSOLE_PR_PAT_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;

--- a/.github/workflows/pull_request_review_state_labeler.yaml
+++ b/.github/workflows/pull_request_review_state_labeler.yaml
@@ -18,7 +18,7 @@ jobs:
         id: check_self_approved
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_FOR_PR_LABELER }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
@@ -36,7 +36,7 @@ jobs:
         if: github.event_name == 'pull_request_target' && steps.check_self_approved.outputs.isSelfApprovedPR == 'false'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_FOR_PR_LABELER }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name == 'pull_request_review' && steps.check_self_approved.outputs.isSelfApprovedPR == 'false'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_FOR_PR_LABELER }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;


### PR DESCRIPTION
### Skip Review (optional)
- [x] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)

GITHUB_TOKEN doesn't have write permission for issue label for the pr review event.
So changed to use FGPT.

### Things to Talk About (optional)
