### PR TITLE
Feat: add data table of most triggered alerts in service

### DIFF
--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewInfo.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewInfo.vue
@@ -7,6 +7,8 @@ import { i18n } from '@/translations';
 
 import ServiceDetailTabsOverviewInfoAlertChart
     from '@/services/alert-manager/components/ServiceDetailTabsOverviewInfoAlertChart.vue';
+import ServiceDetailTabsOverviewMostTriggeredAlertsTable
+    from '@/services/alert-manager/components/ServiceDetailTabsOverviewMostTriggeredAlertsTable.vue';
 import ServiceDetailTabsOverviewWebhook from '@/services/alert-manager/components/ServiceDetailTabsOverviewWebhook.vue';
 import ServiceDetailTabsOverviewWebhookChart
     from '@/services/alert-manager/components/ServiceDetailTabsOverviewWebhookChart.vue';
@@ -26,10 +28,8 @@ const handleChangeDateOption = (dateOption: string) => {
 
 <template>
     <div class="service-detail-tabs-overview-info">
-        <p-pane-layout class="info col-span-1">
-            <p class="title-label">
-                {{ $t('ALERT_MANAGER.SERVICE.MOST_FREQUENTLY_OCCURRED_ALERTS') }}
-            </p>
+        <p-pane-layout class="info left col-span-1">
+            <service-detail-tabs-overview-most-triggered-alerts-table />
         </p-pane-layout>
         <p-pane-layout class="info col-span-1">
             <p class="title-label">
@@ -66,6 +66,8 @@ const handleChangeDateOption = (dateOption: string) => {
     @apply mt-4 grid grid-flow-row-dense grid-cols-2 grid-rows-2 gap-4;
     .info {
         @apply px-4 py-5;
+        max-height: 425px;
+        overflow: hidden;
         .title-label {
             @apply text-[1rem] font-bold mb-5;
         }

--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewInfoAlertChart.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewInfoAlertChart.vue
@@ -194,6 +194,8 @@ watch(() => state.labelInfoList, (labelInfoList) => {
 <style scoped lang="postcss">
 .alert-chart {
     @apply flex;
+    height: 500px;
+    overflow-y: auto;
     .chart {
         width: 50%;
         height: 16.5rem;

--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewInfoAlertChart.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewInfoAlertChart.vue
@@ -11,7 +11,7 @@ import { init } from 'echarts/core';
 import { reduce } from 'lodash';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
-import { PProgressBar } from '@cloudforet/mirinae';
+import { PProgressBar, PEmpty } from '@cloudforet/mirinae';
 import { numberFormatter } from '@cloudforet/utils';
 
 import type { ListResponse } from '@/schema/_common/api-verbs/list';
@@ -160,32 +160,43 @@ watch(() => state.labelInfoList, (labelInfoList) => {
 </script>
 
 <template>
-    <div class="alert-chart">
+    <div>
+        <div v-if="state.chartData.length === 0"
+             class="mt-40"
+        >
+            <p-empty>
+                <span>{{ $t('ALERT_MANAGER.SERVICE.LABELS_WITH_ALERTS_NO_DATA') }}</span>
+            </p-empty>
+        </div>
         <div
-            ref="chartContext"
-            class="chart"
-        />
-        <div class="label-info">
-            <div v-for="(labelInfo, idx) in state.labelInfoList"
-                 :key="`label-${idx}`"
-                 class="mb-5"
-            >
-                <p-progress-bar class="progress-bar"
-                                :percentage="(labelInfo.count / state.totalCount) * 100"
-                                :color="MASSIVE_CHART_COLORS[idx]"
+            class="alert-chart"
+        >
+            <div
+                ref="chartContext"
+                class="chart"
+            />
+            <div class="label-info">
+                <div v-for="(labelInfo, idx) in state.labelInfoList"
+                     :key="`label-${idx}`"
+                     class="mb-5"
                 >
-                    <template #label>
-                        <div class="progress-bar-info">
-                            <p class="progress-bar-label mb-1.5">
-                                {{ labelInfo.label }}
-                            </p>
-                            <p class="progress-bar-per">
-                                <span class="font-medium">{{ (labelInfo.count / state.totalCount) * 100 }}% </span>
-                                <span class="text-gray-700">({{ labelInfo.count }})</span>
-                            </p>
-                        </div>
-                    </template>
-                </p-progress-bar>
+                    <p-progress-bar class="progress-bar"
+                                    :percentage="(labelInfo.count / state.totalCount) * 100"
+                                    :color="MASSIVE_CHART_COLORS[idx]"
+                    >
+                        <template #label>
+                            <div class="progress-bar-info">
+                                <p class="progress-bar-label mb-1.5">
+                                    {{ labelInfo.label }}
+                                </p>
+                                <p class="progress-bar-per">
+                                    <span class="font-medium">{{ (labelInfo.count / state.totalCount) * 100 }}% </span>
+                                    <span class="text-gray-700">({{ labelInfo.count }})</span>
+                                </p>
+                            </div>
+                        </template>
+                    </p-progress-bar>
+                </div>
             </div>
         </div>
     </div>

--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewMostTriggeredAlertsTable.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewMostTriggeredAlertsTable.vue
@@ -160,15 +160,15 @@ watch(() => tableState.refinedItems, () => {
             <template #th-triggered_cnt>
                 <span />
             </template>
-            <template #no-data>
-                <p-empty
-                    :show-image="false"
-                    :show-button="false"
-                >
-                    {{ $t('ALERT_MANAGER.SERVICE.MOST_FREQUENTLY_OCCURRED_ALERTS_NO_DATA') }}
-                </p-empty>
-            </template>
         </p-data-table>
+        <p-empty
+            v-else
+            :show-image="false"
+            :show-button="false"
+            class="mt-36"
+        >
+            {{ $t('ALERT_MANAGER.SERVICE.MOST_FREQUENTLY_OCCURRED_ALERTS_NO_DATA') }}
+        </p-empty>
     </div>
 </template>
 

--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewMostTriggeredAlertsTable.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewMostTriggeredAlertsTable.vue
@@ -1,0 +1,180 @@
+<script lang="ts" setup>
+import type { ComputedRef } from 'vue';
+import {
+    computed, reactive, watch,
+} from 'vue';
+
+import dayjs from 'dayjs';
+
+import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
+import { PDataTable, PEmpty, PSelectDropdown } from '@cloudforet/mirinae';
+
+import { i18n } from '@/translations';
+
+import ErrorHandler from '@/common/composables/error/errorHandler';
+
+import { useServiceDetailPageStore } from '@/services/alert-manager/stores/service-detail-page-store';
+
+const serviceDetailPageStore = useServiceDetailPageStore();
+const serviceDetailPageGetters = serviceDetailPageStore.getters;
+
+interface TableState {
+  fields: { name: string; label: string; }[];
+  items: { title: string; triggered_by: string; triggered_cnt: number }[];
+  refinedItems: ComputedRef<{ triggered_cnt: number; title: string; triggered_by: string; }[]>;
+  loading: boolean;
+}
+
+const serviceId = computed<string>(() => serviceDetailPageGetters.serviceInfo.service_id);
+
+const state = reactive({
+    dateRangeList: [
+        { name: 'this_month', label: i18n.t('ALERT_MANAGER.SERVICE.MOST_TRIGGERED_ALERTS.THIS_MONTH') },
+        { name: 'last_month', label: i18n.t('ALERT_MANAGER.SERVICE.MOST_TRIGGERED_ALERTS.LAST_MONTH') },
+        { name: 'last_three_months', label: i18n.t('ALERT_MANAGER.SERVICE.MOST_TRIGGERED_ALERTS.LAST_THREE_MONTHS') },
+        { name: 'last_six_months', label: i18n.t('ALERT_MANAGER.SERVICE.MOST_TRIGGERED_ALERTS.LAST_SIX_MONTHS') },
+        { name: 'last_twelve_months', label: i18n.t('ALERT_MANAGER.SERVICE.MOST_TRIGGERED_ALERTS.LAST_TWELVE_MONTHS') },
+    ],
+    selectedDateRange: 'this_month',
+    startDate: dayjs.utc().startOf('month').format('YYYY-MM-DD'),
+    endDate: dayjs.utc().endOf('month').format('YYYY-MM-DD'),
+});
+
+const tableState = reactive<TableState>({
+    fields: [
+        { name: 'triggered_cnt', label: '' },
+        { name: 'title', label: 'Title' },
+        { name: 'triggered_by', label: 'Triggered by' },
+    ],
+    items: [],
+    refinedItems: computed<{ triggered_cnt: number; title: string; triggered_by: string; }[]>(() => {
+        if (tableState.items.length > 0) {
+            return tableState.items.map((alert) => ({
+                triggered_cnt: alert.triggered_cnt,
+                title: alert.title,
+                triggered_by: alert.triggered_by,
+            })).sort((a, b) => b.triggered_cnt - a.triggered_cnt);
+        }
+        return [];
+    }),
+    loading: false,
+});
+
+watch(() => state.selectedDateRange, () => {
+    const lastMonth = dayjs.utc().subtract(1, 'month');
+    const threeMonthsAgo = dayjs.utc().subtract(3, 'month');
+    const sixMonthsAgo = dayjs.utc().subtract(6, 'month');
+    const twelveMonthsAgo = dayjs.utc().subtract(12, 'month');
+
+    switch (state.selectedDateRange) {
+    case 'this_month':
+        state.startDate = dayjs.utc().startOf('month').format('YYYY-MM-DD');
+        state.endDate = dayjs.utc().endOf('month').format('YYYY-MM-DD');
+        break;
+    case 'last_month':
+        state.startDate = lastMonth.startOf('month').format('YYYY-MM-DD');
+        state.endDate = lastMonth.endOf('month').format('YYYY-MM-DD');
+        break;
+    case 'last_three_months':
+        state.startDate = threeMonthsAgo.startOf('month').format('YYYY-MM-DD');
+        state.endDate = lastMonth.endOf('month').format('YYYY-MM-DD');
+        break;
+    case 'last_six_months':
+        state.startDate = sixMonthsAgo.startOf('month').format('YYYY-MM-DD');
+        state.endDate = lastMonth.endOf('month').format('YYYY-MM-DD');
+        break;
+    case 'last_twelve_months':
+        state.startDate = twelveMonthsAgo.startOf('month').format('YYYY-MM-DD');
+        state.endDate = lastMonth.endOf('month').format('YYYY-MM-DD');
+        break;
+    default:
+        break;
+    }
+}, { immediate: true, deep: true });
+
+/* API */
+const fetchAlertsAnalyze = async () => {
+    try {
+        const { results } = await SpaceConnector.clientV2.alertManager.alert.analyze({
+            query: {
+                group_by: ['title', 'triggered_by'],
+                fields: {
+                    triggered_cnt: {
+                        key: 'triggered_cnt',
+                        operator: 'count',
+                    },
+                },
+                filter: [
+                    {
+                        k: 'service_id',
+                        v: serviceId.value,
+                        o: 'eq',
+                    },
+                    {
+                        k: 'created_at',
+                        v: state.startDate,
+                        o: 'gt',
+                    },
+                    {
+                        k: 'created_at',
+                        v: state.endDate,
+                        o: 'lt',
+                    },
+                ],
+            },
+        });
+
+        tableState.items = results || [];
+    } catch (error) {
+        ErrorHandler.handleError(error);
+    }
+};
+
+watch([() => serviceId, () => state.startDate, () => state.endDate], async () => {
+    await fetchAlertsAnalyze();
+}, { immediate: true, deep: true });
+
+watch(() => tableState.refinedItems, () => {
+    tableState.loading = tableState.refinedItems.length <= 0;
+}, { immediate: true });
+</script>
+
+<template>
+    <div class="service-detail-tabs-overview-most-triggered-alerts-table">
+        <div class="flex justify-between items-center mb-5">
+            <p class="text-[1rem] font-bold">
+                {{ $t('ALERT_MANAGER.SERVICE.MOST_FREQUENTLY_OCCURRED_ALERTS') }}
+            </p>
+            <p-select-dropdown :menu="state.dateRangeList"
+                               :selected.sync="state.selectedDateRange"
+            />
+        </div>
+        <p-data-table v-if="tableState.items.length > 0"
+                      :fields="tableState.fields"
+                      :items="tableState.refinedItems"
+                      :loading="tableState.loading"
+                      striped
+                      :bordered="false"
+                      class="alert-table"
+        >
+            <template #th-triggered_cnt>
+                <span />
+            </template>
+            <template #no-data>
+                <p-empty
+                    :show-image="false"
+                    :show-button="false"
+                >
+                    {{ $t('ALERT_MANAGER.SERVICE.MOST_FREQUENTLY_OCCURRED_ALERTS_NO_DATA') }}
+                </p-empty>
+            </template>
+        </p-data-table>
+    </div>
+</template>
+
+<style scoped lang="postcss">
+.alert-table {
+    height: 370px;
+    overflow: auto;
+}
+</style>

--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewWebhookBarChartDaily.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewWebhookBarChartDaily.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { ComputedRef } from 'vue';
 import {
-    computed, onMounted, reactive, ref, watch,
+    computed, reactive, ref, watch,
 
 } from 'vue';
 
@@ -29,7 +29,7 @@ const serviceDetailPageStore = useServiceDetailPageStore();
 const serviceDetailPageGetters = serviceDetailPageStore.getters;
 
 const chartContext = ref<HTMLElement | null>(null);
-const serviceId = ref<string>(serviceDetailPageGetters.serviceInfo.service_id);
+const serviceId = computed<string>(() => serviceDetailPageGetters.serviceInfo.service_id);
 
 const WEBHOOK_DAILY = 'webhook_daily';
 
@@ -191,9 +191,9 @@ watch([() => state.chartData, () => chartContext.value], ([, chartCtx]) => {
 const fetchWebhookList = async () => {
     try {
         const { results } = await SpaceConnector.clientV2.alertManager.webhook.list<WebhookListParameters, ListResponse<WebhookModel>>({
-            service_id: serviceId.value,
             query: {
                 sort: [{ key: 'created_at', desc: false }],
+                filter: [{ k: 'service_id', v: serviceId.value, o: 'eq' }],
             },
         });
 
@@ -203,9 +203,9 @@ const fetchWebhookList = async () => {
     }
 };
 
-onMounted(async () => {
+watch(() => serviceId, async () => {
     await fetchWebhookList();
-});
+}, { immediate: true, deep: true });
 </script>
 
 <template>

--- a/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewWebhookBarChartMonthly.vue
+++ b/apps/web/src/services/alert-manager/components/ServiceDetailTabsOverviewWebhookBarChartMonthly.vue
@@ -2,8 +2,7 @@
 
 import type { ComputedRef } from 'vue';
 import {
-    computed,
-    onMounted, reactive, ref, watch,
+    computed, reactive, ref, watch,
 } from 'vue';
 
 import dayjs from 'dayjs';
@@ -28,8 +27,9 @@ import { useServiceDetailPageStore } from '@/services/alert-manager/stores/servi
 const serviceDetailPageStore = useServiceDetailPageStore();
 const serviceDetailPageGetters = serviceDetailPageStore.getters;
 
+const serviceId = computed<string>(() => serviceDetailPageGetters.serviceInfo.service_id);
+
 const chartContext = ref<HTMLElement | null>(null);
-const serviceId = ref<string>(serviceDetailPageGetters.serviceInfo.service_id);
 
 const WEBHOOK_MONTHLY = 'webhook_monthly';
 
@@ -184,9 +184,9 @@ watch(
 const fetchWebhookList = async () => {
     try {
         const { results } = await SpaceConnector.clientV2.alertManager.webhook.list<WebhookListParameters, ListResponse<WebhookModel>>({
-            service_id: serviceId.value,
             query: {
                 sort: [{ key: 'created_at', desc: false }],
+                filter: [{ k: 'service_id', v: serviceId.value, o: 'eq' }],
             },
         });
 
@@ -196,9 +196,9 @@ const fetchWebhookList = async () => {
     }
 };
 
-onMounted(async () => {
+watch(() => serviceId, async () => {
     await fetchWebhookList();
-});
+}, { immediate: true, deep: true });
 </script>
 
 <template>

--- a/packages/language-pack/en.json
+++ b/packages/language-pack/en.json
@@ -265,6 +265,7 @@
 			"INVITE": "Invite",
 			"INVITE_MEMBER": "Invite Member",
 			"INVITE_MEMBER_DESC": "Members with access to this service",
+			"LABELS_WITH_ALERTS_NO_DATA": "No Data",
 			"LABELS_WITH_THE_MOST_ALERTS": "Labels with the Most Alerts",
 			"LABEL_KEY": "Key",
 			"LABEL_KEY_DESC": "The entered key is used to identify each \nservice and cannot be changed once set.",

--- a/packages/language-pack/en.json
+++ b/packages/language-pack/en.json
@@ -277,7 +277,16 @@
 			"MODAL_DELETE_TITLE": "Are you sure you want to delete this service?",
 			"MODAL_EDIT_TITLE": "Update Service",
 			"MODAL_MEMBER_PLACEHOLDER": "Select a member or more",
-			"MOST_FREQUENTLY_OCCURRED_ALERTS": "Most Frequently Occurred Alerts",
+			"MOST_FREQUENTLY_OCCURRED_ALERTS": "Most Frequently Triggered Alerts",
+			"MOST_FREQUENTLY_OCCURRED_ALERTS_NO_DATA": "No Data",
+			"MOST_TRIGGERED_ALERTS": {
+				"CUSTOM": "Custom",
+				"LAST_MONTH": "Last Month",
+				"LAST_SIX_MONTHS": "Last 6 Months",
+				"LAST_THREE_MONTHS": "Last 3 Months",
+				"LAST_TWELVE_MONTHS": "Last 12 Months",
+				"THIS_MONTH": "This Month"
+			},
 			"NO_DATA": "Create a new service.",
 			"NO_DATA_DESC": "Set up alerts for each service and quickly identify any issues.",
 			"OPEN_ALERTS": "All Opened",

--- a/packages/language-pack/ja.json
+++ b/packages/language-pack/ja.json
@@ -265,6 +265,7 @@
 			"INVITE": "招待",
 			"INVITE_MEMBER": "メンバー招待",
 			"INVITE_MEMBER_DESC": "このサービスにアクセス可能なメンバー",
+			"LABELS_WITH_ALERTS_NO_DATA": "データがありません",
 			"LABELS_WITH_THE_MOST_ALERTS": "",
 			"LABEL_KEY": "キー",
 			"LABEL_KEY_DESC": "入力されたキーは各サービスを識別するために使用され、\n一度設定すると変更できません。",

--- a/packages/language-pack/ja.json
+++ b/packages/language-pack/ja.json
@@ -278,6 +278,15 @@
 			"MODAL_EDIT_TITLE": "サービス名を編集",
 			"MODAL_MEMBER_PLACEHOLDER": "メンバーを選択してください",
 			"MOST_FREQUENTLY_OCCURRED_ALERTS": "",
+			"MOST_FREQUENTLY_OCCURRED_ALERTS_NO_DATA": "データがありません",
+			"MOST_TRIGGERED_ALERTS": {
+				"CUSTOM": "",
+				"LAST_MONTH": "",
+				"LAST_SIX_MONTHS": "",
+				"LAST_THREE_MONTHS": "",
+				"LAST_TWELVE_MONTHS": "",
+				"THIS_MONTH": ""
+			},
 			"NO_DATA": "新しいサービスを作成",
 			"NO_DATA_DESC": "各サービスのアラートを設定し、発生するすべての問題を迅速に把握しましょう。",
 			"OPEN_ALERTS": "全てのオープンされたアラート",

--- a/packages/language-pack/ko.json
+++ b/packages/language-pack/ko.json
@@ -265,6 +265,7 @@
 			"INVITE": "초대",
 			"INVITE_MEMBER": "멤버 초대",
 			"INVITE_MEMBER_DESC": "이 서비스에 접근 가능한 멤버",
+			"LABELS_WITH_ALERTS_NO_DATA": "데이터가 없습니다.",
 			"LABELS_WITH_THE_MOST_ALERTS": "",
 			"LABEL_KEY": "키",
 			"LABEL_KEY_DESC": "입력한 키는 각 서비스를 식별하는 데 사용되며, \n한 번 설정하면 변경할 수 없습니다.",

--- a/packages/language-pack/ko.json
+++ b/packages/language-pack/ko.json
@@ -278,6 +278,15 @@
 			"MODAL_EDIT_TITLE": "서비스 이름 수정",
 			"MODAL_MEMBER_PLACEHOLDER": "멤버 선택",
 			"MOST_FREQUENTLY_OCCURRED_ALERTS": "",
+			"MOST_FREQUENTLY_OCCURRED_ALERTS_NO_DATA": "데이터가 없습니다.",
+			"MOST_TRIGGERED_ALERTS": {
+				"CUSTOM": "",
+				"LAST_MONTH": "",
+				"LAST_SIX_MONTHS": "",
+				"LAST_THREE_MONTHS": "",
+				"LAST_TWELVE_MONTHS": "",
+				"THIS_MONTH": ""
+			},
 			"NO_DATA": "새로운 서비스 생성",
 			"NO_DATA_DESC": "서비스별 알림을 설정하고, 발생하는 모든 이슈를 신속하게 파악하세요.",
 			"OPEN_ALERTS": "오픈된 전체 얼럿",


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
#### after update
1.	The data is grouped by “title” and “triggered_by”
2.	It’s sorted in descending order based on “triggered_cnt”
3.	There’s an option to select a time period
![image](https://github.com/user-attachments/assets/f075bddb-d472-4af5-8215-8eaae0634cfc)
![image](https://github.com/user-attachments/assets/fff1391e-98bd-4453-8db2-a09856072b0c)

#### additional information
![image](https://github.com/user-attachments/assets/0952565a-845c-496c-9112-5673238b60af)
- The design has been modified as below, so it needs to be modified later.


### Things to Talk About (optional)
