### PR TITLE
feat: add spec of `PCard`header color

### DIFF
--- a/packages/mirinae/src/data-display/cards/card/PCard.vue
+++ b/packages/mirinae/src/data-display/cards/card/PCard.vue
@@ -10,7 +10,9 @@
                 {{ header }}
             </slot>
         </header>
-        <div class="body" :class="{ 'no-header': !header.length && !$scopedSlots.header }">
+        <div class="body"
+             :class="{ 'no-header': !header.length && !$scopedSlots.header }"
+        >
             <slot />
         </div>
     </div>
@@ -85,6 +87,9 @@ export default defineComponent<CardProps>({
     }
     &.gray100 {
         @mixin style-type theme('colors.gray.100'), theme('colors.gray.200'), theme('colors.gray.900');
+    }
+    &.gray200 {
+        @mixin style-type theme('colors.gray.200'), theme('colors.gray.200'), theme('colors.gray.900');
     }
     &.yellow100 {
         @mixin style-type theme('colors.yellow.100'), theme('colors.gray.200'), theme('colors.gray.500');

--- a/packages/mirinae/src/data-display/cards/card/config.ts
+++ b/packages/mirinae/src/data-display/cards/card/config.ts
@@ -1,5 +1,6 @@
 export const CARD_STYLE_TYPE = {
     gray100: 'gray100',
+    gray200: 'gray200',
     yellow100: 'yellow100',
     yellow500: 'yellow500',
     indigo400: 'indigo400',


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
- update `PCard` spec (add gray200 at header)
![image](https://github.com/user-attachments/assets/1b96e15f-96fd-4ecc-ae32-ed704381581e)

### Things to Talk About (optional)
