### PR TITLE
Potential fix for code scanning alert no. 30: Incomplete string escaping or encoding

### DIFF
--- a/apps/web/src/services/asset-inventory/components/CollectorHistoryJobTaskErrorList.vue
+++ b/apps/web/src/services/asset-inventory/components/CollectorHistoryJobTaskErrorList.vue
@@ -84,7 +84,7 @@ const errorMessageFormatter = (message) => {
         .replace(/'/g, '')
         .replace(/(\\r\\n|\\n|\\r)/gm, '\n')
         .replace(/(\\t)/gm, '');
-    if (result.startsWith('\n')) result = result.replace('\n', '');
+    result = result.replace(/^\n+/g, '');
     return result;
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/cloudforet-io/console/security/code-scanning/30](https://github.com/cloudforet-io/console/security/code-scanning/30)

To fix the problem, we need to ensure that all leading newline characters are removed from the string `result`. The best way to achieve this is by using a regular expression with the global flag (`g`) to match all occurrences of the newline character at the beginning of the string. This will ensure that all leading newline characters are removed, regardless of how many there are.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
