### PR TITLE
fix: fix to prevent string concatenation in data table footer totals

### DIFF
--- a/apps/web/src/services/cost-explorer/components/CostAnalysisDataTable.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisDataTable.vue
@@ -641,14 +641,14 @@ watch(
             >
                 <span v-if="colIndex === 0">Total</span>
                 <span v-else-if="tableState.showFormattedData && field.name !== 'usage_unit'
-                    && (!state.visibleGroupByItems.map(item => lowerCase(item.name)).includes(lowerCase(field.name))
-                        && !state.visibleGroupByItems.map(item => lowerCase(item.label)).includes(lowerCase(field.name)))"
+                    && (!tableState.groupByFields.map(item => lowerCase(item.name)).includes(lowerCase(field.name)))
+                    && (!tableState.groupByFields.map(item => lowerCase(item.label)).includes(lowerCase(field.name)))"
                 >
                     {{ Array.isArray(values) && values.length > 0 ? numberFormatter(reduce(values), {notation: 'compact'}) : 0 }}
                 </span>
                 <span v-else-if="!tableState.showFormattedData && field.name !== 'usage_unit'
-                    && (!state.visibleGroupByItems.map(item => lowerCase(item.name)).includes(lowerCase(field.name))
-                        && !state.visibleGroupByItems.map(item => lowerCase(item.label)).includes(lowerCase(field.name)))"
+                    && (!tableState.groupByFields.map(item => lowerCase(item.name)).includes(lowerCase(field.name))
+                        && !tableState.groupByFields.map(item => lowerCase(item.label)).includes(lowerCase(field.name)))"
                 >
                     {{ Array.isArray(values) && values.length > 0 ? numberFormatter(reduce(values), {minimumFractionDigits: 2}) : 0 }}
                 </span>


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
- cost analysis page > Data Table Total Footer bug
![image](https://github.com/user-attachments/assets/de1829fa-9178-4549-8beb-0e9c424941ee)


### Things to Talk About (optional)
