### PR TITLE
fix: fix initiating service account `secret type` form

### DIFF
--- a/apps/web/src/services/service-account/components/ServiceAccountCredentialsForm.vue
+++ b/apps/web/src/services/service-account/components/ServiceAccountCredentialsForm.vue
@@ -371,7 +371,8 @@ watch([() => storeState.secretSchema, () => state.isTrustedAccount], () => {
                    stretch
             >
                 <template #input>
-                    <p-json-schema-form :form-data.sync="formState.customSchemaForm"
+                    <p-json-schema-form v-if="state.credentialSchema"
+                                        :form-data.sync="formState.customSchemaForm"
                                         :schema="state.credentialSchema"
                                         :language="storeState.language"
                                         class="custom-schema-box"


### PR DESCRIPTION
### Skip Review (optional)
- [x] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
Fixes a bug where the ‘secret type’ field didn't appear in the Service Account form.

![스크린샷 2025-04-17 오후 1 53 36](https://github.com/user-attachments/assets/a827a9b8-6164-4e81-94bf-fb54d2ec074c)

### Things to Talk About (optional)
