### PR TITLE
chore: refactor lodash import (per-method import)

### DIFF
--- a/apps/web/src/common/components/forms/pairs-input-group/PairsInputGroup.vue
+++ b/apps/web/src/common/components/forms/pairs-input-group/PairsInputGroup.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PButton, PFieldGroup, PIconButton, PTextInput,

--- a/apps/web/src/common/components/schedule-setting-form/ScheduleSettingForm.vue
+++ b/apps/web/src/common/components/schedule-setting-form/ScheduleSettingForm.vue
@@ -3,7 +3,8 @@ import {
     computed, onMounted, reactive, watch,
 } from 'vue';
 
-import { range, zipObject } from 'lodash';
+import range from 'lodash/range';
+import zipObject from 'lodash/zipObject';
 
 import {
     PFieldGroup, PRadioGroup, PRadio, PI, PSelectButton, PSelectDropdown,

--- a/apps/web/src/common/components/select/DataSelector.vue
+++ b/apps/web/src/common/components/select/DataSelector.vue
@@ -3,7 +3,7 @@ import {
     ref, toRef, watch,
 } from 'vue';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { PFieldTitle, PContextMenu, useContextMenuItems } from '@cloudforet/mirinae';
 import type { MenuAttachHandler } from '@cloudforet/mirinae/types/hooks/use-context-menu-attach/use-context-menu-attach';

--- a/apps/web/src/common/composables/current-menu-id/index.ts
+++ b/apps/web/src/common/composables/current-menu-id/index.ts
@@ -2,7 +2,7 @@ import type { Ref } from 'vue';
 import { computed, reactive, toRef } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { MENU_ID } from '@/lib/menu/config';
 

--- a/apps/web/src/common/composables/data-source/use-cost-data-source-filter-menu-items.ts
+++ b/apps/web/src/common/composables/data-source/use-cost-data-source-filter-menu-items.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef } from 'vue';
 import { computed, reactive, watch } from 'vue';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';
 

--- a/apps/web/src/common/composables/editor-content-transformer/index.ts
+++ b/apps/web/src/common/composables/editor-content-transformer/index.ts
@@ -4,7 +4,7 @@ import {
     ref, isRef, watch, isReadonly,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 

--- a/apps/web/src/common/composables/proxy-state/index.ts
+++ b/apps/web/src/common/composables/proxy-state/index.ts
@@ -3,7 +3,7 @@ import {
     computed, ref, watch,
 } from 'vue';
 
-import { kebabCase } from 'lodash';
+import kebabCase from 'lodash/kebabCase';
 
 /**
  * @description It detects changes in prop and creates a state that is automatically reflected.

--- a/apps/web/src/common/composables/query-tags/index.ts
+++ b/apps/web/src/common/composables/query-tags/index.ts
@@ -1,7 +1,8 @@
 import type { ComputedRef, Ref } from 'vue';
 import { computed, isRef, reactive } from 'vue';
 
-import { flatten, forEach } from 'lodash';
+import flatten from 'lodash/flatten';
+import forEach from 'lodash/forEach';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import type { ConsoleFilterOperator, ConsoleFilterValue, ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/common/modules/custom-table/custom-field-modal/modules/SelectCloudServiceTagColumns.vue
+++ b/apps/web/src/common/modules/custom-table/custom-field-modal/modules/SelectCloudServiceTagColumns.vue
@@ -17,7 +17,7 @@ import {
     ref, watch,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/common/modules/monitoring/MetricChart.vue
+++ b/apps/web/src/common/modules/monitoring/MetricChart.vue
@@ -10,7 +10,8 @@ import { init } from 'echarts/core';
 import type {
     EChartsType,
 } from 'echarts/core';
-import { isEmpty, throttle } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import throttle from 'lodash/throttle';
 
 import {
     PDataLoader, PSkeleton, PSpinner, PTooltip,

--- a/apps/web/src/common/modules/monitoring/Monitoring.vue
+++ b/apps/web/src/common/modules/monitoring/Monitoring.vue
@@ -109,9 +109,13 @@ import {
 import { useRouter } from 'vue-router/composables';
 
 import dayjs from 'dayjs';
-import {
-    debounce, find, capitalize, chain, range, sortBy, get,
-} from 'lodash';
+import capitalize from 'lodash/capitalize';
+import chain from 'lodash/chain';
+import debounce from 'lodash/debounce';
+import find from 'lodash/find';
+import get from 'lodash/get';
+import range from 'lodash/range';
+import sortBy from 'lodash/sortBy';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/common/modules/navigations/gnb/GNBNavigationRail.vue
+++ b/apps/web/src/common/modules/navigations/gnb/GNBNavigationRail.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PI, screens, PButton, PTextButton, PTooltip,

--- a/apps/web/src/common/modules/navigations/gnb/GNBToolbox.vue
+++ b/apps/web/src/common/modules/navigations/gnb/GNBToolbox.vue
@@ -5,7 +5,8 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { clone, isEmpty } from 'lodash';
+import clone from 'lodash/clone';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PIconButton, PBreadcrumbs, PCopyButton, screens, PTooltip,

--- a/apps/web/src/common/modules/navigations/top-bar/TopBar.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/TopBar.vue
@@ -3,7 +3,7 @@ import {
     reactive, computed, ref,
 } from 'vue';
 
-import { includes } from 'lodash';
+import includes from 'lodash/includes';
 
 import { ROOT_ROUTE } from '@/router/constant';
 

--- a/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-header/TopBarWorkspaces.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-header/TopBarWorkspaces.vue
@@ -5,7 +5,7 @@ import {
 import type { Location } from 'vue-router';
 import { useRouter } from 'vue-router/composables';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import {
     PSelectDropdown, PTooltip, PI, PButton, PTextHighlighting, PEmpty,

--- a/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-search/modules/top-bar-search-dropdown/TopBarSearchDropdown.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-search/modules/top-bar-search-dropdown/TopBarSearchDropdown.vue
@@ -4,7 +4,7 @@ import type Vue from 'vue';
 import { computed, reactive, ref } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import {
     PTab, screens, PLazyImg, PI,

--- a/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-search/modules/top-bar-search-dropdown/modules/TopBarSearchServiceTab.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-search/modules/top-bar-search-dropdown/modules/TopBarSearchServiceTab.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { getTextHighlightRegex, PDataLoader, PDivider } from '@cloudforet/mirinae';
 

--- a/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-search/store.ts
+++ b/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-search/store.ts
@@ -1,6 +1,6 @@
 import { computed, reactive, watch } from 'vue';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { defineStore } from 'pinia';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-toolset/modules/top-bar-admin-toggle-button/TopBarAdminToggleButton.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-toolset/modules/top-bar-admin-toggle-button/TopBarAdminToggleButton.vue
@@ -2,7 +2,7 @@
 import Vue, { computed, reactive } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 
 import type { WorkspaceModel } from '@/api-clients/identity/workspace/schema/model';
 import { i18n } from '@/translations';

--- a/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-toolset/modules/top-bar-favorite/modules/TopBarFavoriteContextMenu.vue
+++ b/apps/web/src/common/modules/navigations/top-bar/modules/top-bar-toolset/modules/top-bar-favorite/modules/TopBarFavoriteContextMenu.vue
@@ -5,7 +5,7 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PButton, PDataLoader, PEmpty, PI, PIconButton,

--- a/apps/web/src/common/modules/project/use-project-tree.ts
+++ b/apps/web/src/common/modules/project/use-project-tree.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { cloneDeep, get } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import type { Query, Sort } from '@cloudforet/core-lib/space-connector/type';

--- a/apps/web/src/common/modules/tags/tags-panel/TagsPanel.vue
+++ b/apps/web/src/common/modules/tags/tags-panel/TagsPanel.vue
@@ -4,7 +4,8 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { get, camelCase } from 'lodash';
+import camelCase from 'lodash/camelCase';
+import get from 'lodash/get';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/common/modules/tags/tags-panel/modules/TagsOverlay.vue
+++ b/apps/web/src/common/modules/tags/tags-panel/modules/TagsOverlay.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import PairsForm from '@/common/components/forms/pairs-form/PairsForm.vue';
 import type { Tag } from '@/common/modules/tags/type';

--- a/apps/web/src/common/modules/user/UserSelectDropdown.vue
+++ b/apps/web/src/common/modules/user/UserSelectDropdown.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import {
     getTextHighlightRegex, PAvatar, PSelectDropdown, PTag,

--- a/apps/web/src/common/modules/widgets/DailyUpdates.vue
+++ b/apps/web/src/common/modules/widgets/DailyUpdates.vue
@@ -144,7 +144,7 @@ import {
 import type { Location } from 'vue-router';
 
 import dayjs from 'dayjs';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/common/modules/widgets/_components/WidgetCustomLegend.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetCustomLegend.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { reactive } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import getRandomId from '@/lib/random-id-generator';
 

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormAssetSecurityDataSourcePopper.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormAssetSecurityDataSourcePopper.vue
@@ -3,7 +3,9 @@ import {
     computed, reactive,
 } from 'vue';
 
-import { sortBy, startCase, toLower } from 'lodash';
+import sortBy from 'lodash/sortBy';
+import startCase from 'lodash/startCase';
+import toLower from 'lodash/toLower';
 
 import {
     PFieldTitle, PContextMenu,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardAddContents.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardAddContents.vue
@@ -4,9 +4,10 @@ import {
 } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import {
-    cloneDeep, isArray, isEqual, uniq,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
+import isEqual from 'lodash/isEqual';
+import uniq from 'lodash/uniq';
 
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';
 import type { SelectDropdownMenuItem } from '@cloudforet/mirinae/types/controls/dropdown/select-dropdown/type';

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardAddForm.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardAddForm.vue
@@ -4,7 +4,8 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { cloneDeep, range } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import range from 'lodash/range';
 
 import {
     makeDistinctValueHandler,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardFilters.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardFilters.vue
@@ -4,12 +4,11 @@ import {
     computed, onMounted, reactive, ref, toRef, watch,
 } from 'vue';
 
-import {
-    cloneDeep,
-    debounce,
-    isArray,
-    isEmpty, unset,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
+import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
+import unset from 'lodash/unset';
 
 import {
     PFieldGroup, PButton, PContextMenu, useContextMenuController,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardFiltersItem.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardFiltersItem.vue
@@ -5,7 +5,7 @@ import {
     computed, onMounted, reactive, ref,
 } from 'vue';
 
-import { isArray } from 'lodash';
+import isArray from 'lodash/isArray';
 
 import {
     PSelectDropdown, PContextMenu, PIconButton, PI, PTextInput,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardHeaderTitle.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardHeaderTitle.vue
@@ -3,7 +3,7 @@
 import { computed, reactive } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PIconButton, PI, PTextInput, PTooltip,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformAddLabels.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformAddLabels.vue
@@ -5,7 +5,8 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { cloneDeep, random } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import random from 'lodash/random';
 
 import {
     PIconButton, PFieldGroup, PTextInput, PButton, PFieldTitle,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformAggregate.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformAggregate.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, ref, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PFieldGroup, PSelectDropdown,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformContents.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformContents.vue
@@ -4,9 +4,10 @@ import {
 } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import {
-    cloneDeep, intersection, isEmpty, isEqual,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import intersection from 'lodash/intersection';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 
 import type { ListResponse } from '@/api-clients/_common/schema/api-verbs/list';
 import type { WidgetModel } from '@/api-clients/dashboard/_types/widget-type';

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformEvaluate.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformEvaluate.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PIconButton, PI, PFieldGroup, PSelectButton, PTextInput, PButton, PTextarea, PButtonModal, PToggleButton, PLink, PFieldTitle,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformJoin.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformJoin.vue
@@ -3,7 +3,7 @@ import {
     computed, onMounted, reactive, ref, watch,
 } from 'vue';
 
-import { random } from 'lodash';
+import random from 'lodash/random';
 
 import {
     PFieldGroup, PI, PSelectDropdown, PFieldTitle, PButton, PIconButton,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformPivotForm.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformPivotForm.vue
@@ -3,7 +3,7 @@ import {
     computed, onMounted, reactive, ref, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PDivider, PFieldGroup, PSelectButton, PTextInput, PSelectDropdown, PRadioGroup, PRadio, PI,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformQuery.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformQuery.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, ref, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButton, PIconButton, PTextInput, PFieldTitle, PLink,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformValueMapping.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormDataTableCardTransformValueMapping.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { random } from 'lodash';
+import random from 'lodash/random';
 
 import {
     PButton, PFieldGroup, PSelectButton, PTextInput, PSelectDropdown, PFieldTitle, PIconButton,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormOverlay.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormOverlay.vue
@@ -5,7 +5,7 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButton, PButtonModal, POverlayLayout, PTextButton,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormOverlayPreviewTable.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormOverlayPreviewTable.vue
@@ -6,7 +6,7 @@ import {
 import { useRoute } from 'vue-router/composables';
 
 import bytes from 'bytes';
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import {
     PToolbox, PI, PSelectDropdown, PEmpty, PSpinner,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormOverlayStep1.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormOverlayStep1.vue
@@ -3,7 +3,7 @@ import {
     computed, onMounted, onUnmounted, reactive, ref,
 } from 'vue';
 
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 import {
     PI, PTooltip, PButton,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormOverlayStep2.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormOverlayStep2.vue
@@ -4,7 +4,8 @@ import {
 } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep, isEqual } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 
 import {
     PDivider, PSelectButton, PButton,

--- a/apps/web/src/common/modules/widgets/_components/WidgetFormOverlayStep2WidgetForm.vue
+++ b/apps/web/src/common/modules/widgets/_components/WidgetFormOverlayStep2WidgetForm.vue
@@ -5,7 +5,8 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep, sortBy } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import sortBy from 'lodash/sortBy';
 
 import {
     PFieldGroup, PSelectDropdown, PButton, PI, PButtonModal, PTooltip,

--- a/apps/web/src/common/modules/widgets/_composables/use-widget-frame.ts
+++ b/apps/web/src/common/modules/widgets/_composables/use-widget-frame.ts
@@ -4,7 +4,7 @@ import type { ComputedRef, UnwrapRef } from 'vue';
 import { computed, reactive } from 'vue';
 import type { Location } from 'vue-router/types/router';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 

--- a/apps/web/src/common/modules/widgets/_composables/use-widget-init-and-refresh.ts
+++ b/apps/web/src/common/modules/widgets/_composables/use-widget-init-and-refresh.ts
@@ -3,7 +3,7 @@ import {
     watch,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import type {
     WidgetProps, WidgetEmit,

--- a/apps/web/src/common/modules/widgets/_constants/data-table-constant.ts
+++ b/apps/web/src/common/modules/widgets/_constants/data-table-constant.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type {
     AddLabelsOptions,

--- a/apps/web/src/common/modules/widgets/_helpers/__tests__/widget-chart-data-helper.test.ts
+++ b/apps/web/src/common/modules/widgets/_helpers/__tests__/widget-chart-data-helper.test.ts
@@ -1,4 +1,4 @@
-import { range } from 'lodash';
+import range from 'lodash/range';
 import { describe, it, expect } from 'vitest';
 
 import { getRefinedXYChartData } from '@/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-chart-data-helper';

--- a/apps/web/src/common/modules/widgets/_helpers/__tests__/widget-inherit-options-helper.test.ts
+++ b/apps/web/src/common/modules/widgets/_helpers/__tests__/widget-inherit-options-helper.test.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { describe, expect, it } from 'vitest';
 
 import type { DashboardVariablesSchema } from '@/api-clients/dashboard/_types/dashboard-type';

--- a/apps/web/src/common/modules/widgets/_helpers/widget-options-helper.ts
+++ b/apps/web/src/common/modules/widgets/_helpers/widget-options-helper.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, isArray } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
 
 import type { WidgetModel } from '@/api-clients/dashboard/_types/widget-type';
 

--- a/apps/web/src/common/modules/widgets/_helpers/widget-width-helper.ts
+++ b/apps/web/src/common/modules/widgets/_helpers/widget-width-helper.ts
@@ -1,4 +1,5 @@
-import { sum, max } from 'lodash';
+import max from 'lodash/max';
+import sum from 'lodash/sum';
 
 import { WIDGET_SIZE } from '@/api-clients/dashboard/_constants/widget-constant';
 import type { WidgetSize } from '@/api-clients/dashboard/_types/widget-type';

--- a/apps/web/src/common/modules/widgets/_widget-field-value-manager/constant/default-value-registry.ts
+++ b/apps/web/src/common/modules/widgets/_widget-field-value-manager/constant/default-value-registry.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { DATA_TABLE_OPERATOR } from '@/common/modules/widgets/_constants/data-table-constant';
 import {

--- a/apps/web/src/common/modules/widgets/_widget-field-value-manager/constant/validator-registry.ts
+++ b/apps/web/src/common/modules/widgets/_widget-field-value-manager/constant/validator-registry.ts
@@ -1,4 +1,4 @@
-import { every } from 'lodash';
+import every from 'lodash/every';
 
 import { DATA_TABLE_OPERATOR } from '@/common/modules/widgets/_constants/data-table-constant';
 import { FORMAT_RULE_TYPE } from '@/common/modules/widgets/_constants/widget-field-constant';

--- a/apps/web/src/common/modules/widgets/_widget-field-value-manager/index.ts
+++ b/apps/web/src/common/modules/widgets/_widget-field-value-manager/index.ts
@@ -2,7 +2,7 @@
 // @ts-nocheck
 import { ref } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type { PrivateDataTableModel } from '@/api-clients/dashboard/private-data-table/schema/model';
 import type { PublicDataTableModel } from '@/api-clients/dashboard/public-data-table/schema/model';

--- a/apps/web/src/common/modules/widgets/_widget-fields/format-rules/WidgetFieldFormatRules.vue
+++ b/apps/web/src/common/modules/widgets/_widget-fields/format-rules/WidgetFieldFormatRules.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButton, PFieldGroup, PIconButton, PTextInput, PSelectDropdown,

--- a/apps/web/src/common/modules/widgets/_widgets/clustered-column-chart/ClusteredColumnChart.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/clustered-column-chart/ClusteredColumnChart.vue
@@ -10,9 +10,9 @@ import { init } from 'echarts/core';
 import type {
     EChartsType,
 } from 'echarts/core';
-import {
-    isEmpty, sortBy, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/modules/widgets/_widgets/color-coded-heatmap/ColorCodedHeatmap.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/color-coded-heatmap/ColorCodedHeatmap.vue
@@ -3,7 +3,7 @@ import {
     computed, defineExpose, onMounted, reactive, watch,
 } from 'vue';
 
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 import {
     PEmpty,

--- a/apps/web/src/common/modules/widgets/_widgets/color-coded-table-heatmap/ColorCodedTableHeatmap.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/color-coded-table-heatmap/ColorCodedTableHeatmap.vue
@@ -4,7 +4,8 @@ import {
     computed, defineExpose, onMounted, reactive, ref, watch,
 } from 'vue';
 
-import { cloneDeep, throttle } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import throttle from 'lodash/throttle';
 
 import { PTooltip } from '@cloudforet/mirinae';
 import { getContrastingColor, numberFormatter } from '@cloudforet/utils';

--- a/apps/web/src/common/modules/widgets/_widgets/gauge/Gauge.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/gauge/Gauge.vue
@@ -9,7 +9,9 @@ import type {
     EChartsType,
 } from 'echarts/core';
 import { init } from 'echarts/core';
-import { isEmpty, orderBy, throttle } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import throttle from 'lodash/throttle';
 
 
 import type { WidgetLoadResponse } from '@/api-clients/dashboard/_types/widget-type';

--- a/apps/web/src/common/modules/widgets/_widgets/geo-map/GeoMap.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/geo-map/GeoMap.vue
@@ -10,7 +10,7 @@ import { init, registerMap } from 'echarts/core';
 import type {
     EChartsType,
 } from 'echarts/core';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/modules/widgets/_widgets/heatmap/Heatmap.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/heatmap/Heatmap.vue
@@ -8,7 +8,9 @@ import dayjs from 'dayjs';
 import type { HeatmapSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import { isEmpty, max, throttle } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import max from 'lodash/max';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/modules/widgets/_widgets/line-chart/LineChart.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/line-chart/LineChart.vue
@@ -10,9 +10,8 @@ import { init } from 'echarts/core';
 import type {
     EChartsType,
 } from 'echarts/core';
-import {
-    isEmpty, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/modules/widgets/_widgets/number-card/NumberCard.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/number-card/NumberCard.vue
@@ -4,7 +4,8 @@ import {
     computed, defineExpose, onMounted, reactive, ref,
 } from 'vue';
 
-import { debounce, throttle } from 'lodash';
+import debounce from 'lodash/debounce';
+import throttle from 'lodash/throttle';
 
 import {
     PI,

--- a/apps/web/src/common/modules/widgets/_widgets/pie-chart/PieChart.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/pie-chart/PieChart.vue
@@ -12,9 +12,9 @@ import type {
     EChartsType,
 } from 'echarts/core';
 import type { LegendOption, EChartsOption } from 'echarts/types/dist/shared';
-import {
-    isEmpty, orderBy, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/modules/widgets/_widgets/sankey-chart/SankeyChart.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/sankey-chart/SankeyChart.vue
@@ -12,9 +12,8 @@ import type {
     EChartsType,
 } from 'echarts/core';
 import type { EChartsOption } from 'echarts/types/dist/shared';
-import {
-    isEmpty, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/modules/widgets/_widgets/stacked-column-chart/StackedColumnChart.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/stacked-column-chart/StackedColumnChart.vue
@@ -10,9 +10,8 @@ import { init } from 'echarts/core';
 import type {
     EChartsType,
 } from 'echarts/core';
-import {
-    isEmpty, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/modules/widgets/_widgets/stacked-horizontal-bar-chart/StackedHorizontalBarChart.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/stacked-horizontal-bar-chart/StackedHorizontalBarChart.vue
@@ -8,9 +8,8 @@ import dayjs from 'dayjs';
 import type { BarSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import {
-    isEmpty, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/modules/widgets/_widgets/table/Table.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/table/Table.vue
@@ -3,7 +3,7 @@ import {
     defineExpose, reactive, computed, onMounted,
 } from 'vue';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import type { Sort } from '@cloudforet/core-lib/space-connector/type';
 import { PPagination } from '@cloudforet/mirinae';

--- a/apps/web/src/common/modules/widgets/_widgets/treemap/Treemap.vue
+++ b/apps/web/src/common/modules/widgets/_widgets/treemap/Treemap.vue
@@ -10,9 +10,9 @@ import { init } from 'echarts/core';
 import type {
     EChartsType,
 } from 'echarts/core';
-import {
-    isEmpty, orderBy, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/common/pages/AlertPublicDetailPage.vue
+++ b/apps/web/src/common/pages/AlertPublicDetailPage.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router/composables';
 
 import axios from 'axios';
 import dayjs from 'dayjs';
-import { map } from 'lodash';
+import map from 'lodash/map';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/common/pages/CostReportDetailPage.vue
+++ b/apps/web/src/common/pages/CostReportDetailPage.vue
@@ -5,9 +5,8 @@ import { useRouter } from 'vue-router/composables';
 import dayjs from 'dayjs';
 import type { PieSeriesOption } from 'echarts/charts';
 import { init } from 'echarts/core';
-import {
-    sortBy, sum,
-} from 'lodash';
+import sortBy from 'lodash/sortBy';
+import sum from 'lodash/sum';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { PLink, PDataTable, PIconButton } from '@cloudforet/mirinae';

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@vercel/edge-config';
 import type { AxiosInstance } from 'axios';
 import axios from 'axios';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 class Config {
     config: any;

--- a/apps/web/src/lib/excel-export/index.ts
+++ b/apps/web/src/lib/excel-export/index.ts
@@ -1,4 +1,4 @@
-import { forEach } from 'lodash';
+import forEach from 'lodash/forEach';
 
 import type { DynamicFieldOptions, ListOptions, DynamicField } from '@cloudforet/mirinae/types/data-display/dynamic/dynamic-field/type/field-schema';
 

--- a/apps/web/src/lib/helper/asset-helper.ts
+++ b/apps/web/src/lib/helper/asset-helper.ts
@@ -1,4 +1,5 @@
-import { isEmpty, some } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import some from 'lodash/some';
 
 import config from '@/lib/config';
 

--- a/apps/web/src/lib/helper/color-convert-helper.ts
+++ b/apps/web/src/lib/helper/color-convert-helper.ts
@@ -1,4 +1,5 @@
-import { parseInt, replace } from 'lodash';
+import parseInt from 'lodash/parseInt';
+import replace from 'lodash/replace';
 
 type RgbaString = string; // e.g. 'rgba(255, 255, 255, 1)'
 

--- a/apps/web/src/lib/helper/config-data-helper.ts
+++ b/apps/web/src/lib/helper/config-data-helper.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { cloneDeep, find } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import find from 'lodash/find';
 
 import type { CostQuerySetModel } from '@/api-clients/cost-analysis/cost-query-set/schema/model';
 import type { DashboardModel } from '@/api-clients/dashboard/_types/dashboard-type';

--- a/apps/web/src/lib/helper/copy-helper.ts
+++ b/apps/web/src/lib/helper/copy-helper.ts
@@ -1,4 +1,5 @@
-import { toString } from 'lodash';
+import toString from 'lodash/toString';
+
 /** @function
  * @name copyTextToClipboard
  * @description copy given text to clipboard

--- a/apps/web/src/lib/router-query-string/index.ts
+++ b/apps/web/src/lib/router-query-string/index.ts
@@ -1,6 +1,6 @@
 import type { Location } from 'vue-router';
 
-import { forEach } from 'lodash';
+import forEach from 'lodash/forEach';
 
 import { SpaceRouter } from '@/router';
 

--- a/apps/web/src/lib/variable-models/_base/resource-variable-model.ts
+++ b/apps/web/src/lib/variable-models/_base/resource-variable-model.ts
@@ -1,6 +1,5 @@
-import {
-    camelCase, get,
-} from 'lodash';
+import camelCase from 'lodash/camelCase';
+import get from 'lodash/get';
 
 import type { ConsoleFilterOperator } from '@cloudforet/core-lib/query/type';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/router/composables/use-reference-router.ts
+++ b/apps/web/src/router/composables/use-reference-router.ts
@@ -1,7 +1,7 @@
 import type { Location } from 'vue-router';
 import { useRouter } from 'vue-router/composables';
 
-import { concat } from 'lodash';
+import concat from 'lodash/concat';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 

--- a/apps/web/src/router/helpers/route-helper.ts
+++ b/apps/web/src/router/helpers/route-helper.ts
@@ -2,7 +2,7 @@ import type { Route, NavigationGuardNext } from 'vue-router';
 
 import type { JwtPayload } from 'jwt-decode';
 import { jwtDecode } from 'jwt-decode';
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import type { NavigationGuardNext, Route, RouteConfig } from 'vue-router';
 import VueRouter from 'vue-router';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { LocalStorageAccessor } from '@cloudforet/core-lib/local-storage-accessor';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/_shared/dashboard/core/helpers/dashboard-layout-template-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/core/helpers/dashboard-layout-template-helper.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { cloneDeep, flattenDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import flattenDeep from 'lodash/flattenDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-create/components/DashboardCreateStep1SearchFilter.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-create/components/DashboardCreateStep1SearchFilter.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { uniq } from 'lodash';
+import uniq from 'lodash/uniq';
 
 import {
     PFieldTitle, PCheckboxGroup, PCheckbox, PLazyImg, PSelectDropdown,

--- a/apps/web/src/services/_shared/dashboard/dashboard-create/contextual-components/DashboardCreateStep1.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-create/contextual-components/DashboardCreateStep1.vue
@@ -2,7 +2,8 @@
 import { computed, reactive } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { flatMapDeep, uniq } from 'lodash';
+import flatMapDeep from 'lodash/flatMapDeep';
+import uniq from 'lodash/uniq';
 
 import {
     PEmpty, PSearch, PFieldTitle, PButton,

--- a/apps/web/src/services/_shared/dashboard/dashboard-create/contextual-components/DashboardCreateStep2BundleCase.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-create/contextual-components/DashboardCreateStep2BundleCase.vue
@@ -5,7 +5,7 @@ import {
 import { useRouter } from 'vue-router/composables';
 
 import { useQueryClient } from '@tanstack/vue-query';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PDataTable, PI, PToggleButton,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterEnum.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterEnum.vue
@@ -4,9 +4,10 @@
 import { computed, reactive, watch } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import {
-    cloneDeep, flattenDeep, isEqual, xor,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import flattenDeep from 'lodash/flattenDeep';
+import isEqual from 'lodash/isEqual';
+import xor from 'lodash/xor';
 
 import { PSelectDropdown } from '@cloudforet/mirinae';
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterNumberInput.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterNumberInput.vue
@@ -6,7 +6,8 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 import { useRoute } from 'vue-router/composables';
 
-import { cloneDeep, isEqual } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 
 import {
     PIconButton, PTextInput, PPopover, PButton, PI,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterNumberSlider.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterNumberSlider.vue
@@ -5,7 +5,9 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { cloneDeep, debounce, isEqual } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 
 import { PTag, PSlider } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterReference.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterReference.vue
@@ -4,9 +4,10 @@
 import { computed, reactive, watch } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import {
-    cloneDeep, flattenDeep, isEqual, xor,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import flattenDeep from 'lodash/flattenDeep';
+import isEqual from 'lodash/isEqual';
+import xor from 'lodash/xor';
 
 import { PSelectDropdown } from '@cloudforet/mirinae';
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterTextInput.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardGlobalVariableFilterTextInput.vue
@@ -5,7 +5,8 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { cloneDeep, isEqual } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 
 import { PButton, PTag, PTextInput } from '@cloudforet/mirinae';
 import type { InputItem } from '@cloudforet/mirinae/types/controls/input/text-input/type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardManageVariableImportModal.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardManageVariableImportModal.vue
@@ -2,7 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButton, PButtonModal, PCheckbox, PSearch, PScopedNotification,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardManageVariableOverlay.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardManageVariableOverlay.vue
@@ -4,7 +4,7 @@ import type { TranslateResult } from 'vue-i18n';
 import { useRouter } from 'vue-router/composables';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButton, PIconButton, POverlayLayout, PToggleButton, PToolboxTable, PScopedNotification,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardToolsetDateDropdown.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardToolsetDateDropdown.vue
@@ -6,7 +6,8 @@ import { useRoute } from 'vue-router/composables';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
 import dayjs from 'dayjs';
-import { cloneDeep, range } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import range from 'lodash/range';
 
 import { PSelectDropdown } from '@cloudforet/mirinae';
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardToolsetScope.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardToolsetScope.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup="">
 import { computed, reactive, watch } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardVariablesFormDynamic.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardVariablesFormDynamic.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, reactive, watch } from 'vue';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import {
     PContextMenu, PDivider, PFieldGroup, PFieldTitle, PRadio, PRadioGroup, PSelectDropdown,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardVariablesFormModal.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardVariablesFormModal.vue
@@ -2,7 +2,8 @@
 import { computed, reactive, watch } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PButtonModal, PFieldGroup, PTextInput, PRadioGroup, PRadio, PScopedNotification,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardVariablesMoreButton.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardVariablesMoreButton.vue
@@ -7,9 +7,8 @@ import {
 import { useRouter } from 'vue-router/composables';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import {
-    cloneDeep, debounce,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
 
 import { PButton, PContextMenu, useContextMenuController } from '@cloudforet/mirinae';
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardWidgetContainerV2.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/components/DashboardWidgetContainerV2.vue
@@ -5,7 +5,9 @@ import {
 } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep, debounce, flattenDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
+import flattenDeep from 'lodash/flattenDeep';
 
 import {
     PDataLoader, PEmpty, PButton,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/composables/use-reformed-widget-info-list.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/composables/use-reformed-widget-info-list.ts
@@ -1,7 +1,7 @@
 import type { Ref, AsyncComponent } from 'vue';
 import { computed, reactive, toRef } from 'vue';
 
-import { flattenDeep } from 'lodash';
+import flattenDeep from 'lodash/flattenDeep';
 
 import type { DashboardLayoutWidgetInfo } from '@/api-clients/dashboard/_types/dashboard-type';
 import type { WidgetConfig, WidgetSize } from '@/api-clients/dashboard/_types/widget-type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/contextual-components/DashboardVariablesV2.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/contextual-components/DashboardVariablesV2.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { PI, PTextButton, PDivider } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/contextual-composables/use-dashboard-refined-vars.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/contextual-composables/use-dashboard-refined-vars.ts
@@ -1,7 +1,8 @@
 import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
 
-import { cloneDeep, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 
 import type { DashboardVars } from '@/api-clients/dashboard/_types/dashboard-type';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/helpers/dashboard-global-variables-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/helpers/dashboard-global-variables-helper.ts
@@ -1,4 +1,4 @@
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 import type { DashboardGlobalVariable } from '@/api-clients/dashboard/_types/dashboard-global-variable-type';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/helpers/dashboard-widget-info-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/helpers/dashboard-widget-info-helper.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { cloneDeep, isEmpty, isEqual } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 
 import { isObjectEqual } from '@cloudforet/utils';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/helpers/widget-width-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/helpers/widget-width-helper.ts
@@ -1,4 +1,5 @@
-import { sum, max } from 'lodash';
+import max from 'lodash/max';
+import sum from 'lodash/sum';
 
 import { WIDGET_SIZE } from '@/api-clients/dashboard/_constants/widget-constant';
 import type { WidgetSize } from '@/api-clients/dashboard/_types/widget-type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/DashboardVariableDropdown.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/DashboardVariableDropdown.vue
@@ -3,9 +3,8 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import {
-    cloneDeep, flattenDeep,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import flattenDeep from 'lodash/flattenDeep';
 
 import {
     PSelectDropdown,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/DashboardVariables.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/DashboardVariables.vue
@@ -2,7 +2,8 @@
 import { computed, reactive } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { isEqual, xor } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import xor from 'lodash/xor';
 
 import { PI, PTextButton, PDivider } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/DashboardWidgetContainer.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/DashboardWidgetContainer.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { PDataLoader } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/WidgetFullModeModal.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/WidgetFullModeModal.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButton, PBadge, PI,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_base-widgets/base-count-of-findings/BaseCountOfFindingsWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_base-widgets/base-count-of-findings/BaseCountOfFindingsWidget.vue
@@ -5,7 +5,7 @@ import {
 
 import { percent, array } from '@amcharts/amcharts5';
 import type * as am5xy from '@amcharts/amcharts5/xy';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_base-widgets/base-trend/BaseTrendWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_base-widgets/base-trend/BaseTrendWidget.vue
@@ -8,7 +8,9 @@ import type { Location } from 'vue-router/types/router';
 import type { Series } from '@amcharts/amcharts5';
 import type { XYChart } from '@amcharts/amcharts5/xy';
 import dayjs from 'dayjs';
-import { cloneDeep, sortBy, uniqBy } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
 
 import { getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_components/WidgetDataTable.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_components/WidgetDataTable.vue
@@ -5,7 +5,7 @@ import {
     defineProps, reactive, ref, watch,
 } from 'vue';
 
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 
 import {
     PI, PDataLoader, PTooltip, PStatus, PEmpty, PPopover, PTextPagination,

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_composables/use-widget-lifecycle.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_composables/use-widget-lifecycle.ts
@@ -6,10 +6,8 @@ import {
     watch,
 } from 'vue';
 
-import {
-    debounce,
-    isEqual,
-} from 'lodash';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 
 import type { DashboardVariables } from '@/api-clients/dashboard/_types/dashboard-type';
 import type { InheritOptions } from '@/api-clients/dashboard/_types/widget-type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_composables/use-widget/use-widget-console-filters.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_composables/use-widget/use-widget-console-filters.ts
@@ -1,7 +1,8 @@
 import type { ComputedRef, UnwrapRef } from 'vue';
 import { computed, isRef, reactive } from 'vue';
 
-import { flattenDeep, isEmpty } from 'lodash';
+import flattenDeep from 'lodash/flattenDeep';
+import isEmpty from 'lodash/isEmpty';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_composables/use-widget/use-widget-location.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_composables/use-widget/use-widget-location.ts
@@ -2,7 +2,7 @@ import type { ComputedRef, UnwrapRef } from 'vue';
 import { computed, isRef, reactive } from 'vue';
 import type { Location } from 'vue-router/types/router';
 
-import { flattenDeep } from 'lodash';
+import flattenDeep from 'lodash/flattenDeep';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/__tests__/widget-chart-data-helper.test.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/__tests__/widget-chart-data-helper.test.ts
@@ -1,4 +1,4 @@
-import { range } from 'lodash';
+import range from 'lodash/range';
 import { describe, it, expect } from 'vitest';
 
 import { getRefinedXYChartData } from '@/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-chart-data-helper';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/__tests__/widget-inherit-options-helper.test.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/__tests__/widget-inherit-options-helper.test.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { describe, expect, it } from 'vitest';
 
 import type { DashboardVariablesSchema } from '@/api-clients/dashboard/_types/dashboard-type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-chart-data-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-chart-data-helper.ts
@@ -1,6 +1,7 @@
-import {
-    keyBy, merge, sortBy, values,
-} from 'lodash';
+import keyBy from 'lodash/keyBy';
+import merge from 'lodash/merge';
+import sortBy from 'lodash/sortBy';
+import values from 'lodash/values';
 
 import type { AllReferenceTypeInfo } from '@/services/dashboards/stores/all-reference-type-info-store';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-config-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-config-helper.ts
@@ -1,4 +1,4 @@
-import { mergeWith } from 'lodash';
+import mergeWith from 'lodash/mergeWith';
 
 import type { WidgetConfig, BaseConfigInfo } from '@/api-clients/dashboard/_types/widget-type';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-location-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-location-helper.ts
@@ -1,6 +1,6 @@
 import type { Location } from 'vue-router/types/router';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-options-filters-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-options-filters-helper.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { cloneDeep, union } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import union from 'lodash/union';
 
 import type { WidgetFiltersMap, WidgetFilterKey } from '@/api-clients/dashboard/_types/widget-type';
 

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-options-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-options-helper.ts
@@ -1,4 +1,5 @@
-import { isEqual, merge } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import merge from 'lodash/merge';
 
 import type { DashboardVariables } from '@/api-clients/dashboard/_types/dashboard-type';
 import type {

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-schema-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-schema-helper.ts
@@ -1,4 +1,6 @@
-import { chain, get, union } from 'lodash';
+import chain from 'lodash/chain';
+import get from 'lodash/get';
+import union from 'lodash/union';
 
 import type { DashboardVariablesSchema } from '@/api-clients/dashboard/_types/dashboard-type';
 import type {

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-table-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-table-helper.ts
@@ -1,6 +1,7 @@
 import type { TimeUnit } from '@amcharts/amcharts5/.internal/core/util/Time';
 import dayjs from 'dayjs';
-import { cloneDeep, sortBy } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import sortBy from 'lodash/sortBy';
 
 import { GRANULARITY } from '@/api-clients/dashboard/_constants/widget-constant';
 import type { DateRange } from '@/api-clients/dashboard/_types/dashboard-type';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-validation-helper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/_helpers/widget-validation-helper.ts
@@ -1,6 +1,7 @@
-import {
-    cloneDeep, isEmpty, isEqual, union,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import union from 'lodash/union';
 
 import type { DashboardLayoutWidgetInfo, DashboardVariablesSchema } from '@/api-clients/dashboard/_types/dashboard-type';
 import type {

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/compliance-status/ComplianceStatusWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/compliance-status/ComplianceStatusWidget.vue
@@ -5,7 +5,8 @@ import {
 
 import { color, percent } from '@amcharts/amcharts5';
 import type { Color } from '@amcharts/amcharts5/.internal/core/util/Color';
-import { isEmpty, sum } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import sum from 'lodash/sum';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/severity-status-by-service/SeverityStatusByServiceWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/severity-status-by-service/SeverityStatusByServiceWidget.vue
@@ -3,7 +3,7 @@ import {
     computed, defineProps, reactive,
 } from 'vue';
 
-import { min } from 'lodash';
+import min from 'lodash/min';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/total-fail-findings-history/TotalFailFindingsHistoryWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/total-fail-findings-history/TotalFailFindingsHistoryWidget.vue
@@ -5,7 +5,7 @@ import {
 
 import type { TimeUnit } from '@amcharts/amcharts5/.internal/core/util/Time';
 import dayjs from 'dayjs';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/total-fail-findings-status/TotalFailFindingsStatusWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/total-fail-findings-status/TotalFailFindingsStatusWidget.vue
@@ -3,7 +3,7 @@ import {
     computed, defineProps, reactive, toRef,
 } from 'vue';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/trend-of-pass-and-fail-findings/TrendOfPassAndFailFindingsWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/asset-widgets/trend-of-pass-and-fail-findings/TrendOfPassAndFailFindingsWidget.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 
 import dayjs from 'dayjs';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/budget-status/BudgetStatusWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/budget-status/BudgetStatusWidget.vue
@@ -3,7 +3,7 @@ import {
     computed, defineProps, reactive,
 } from 'vue';
 
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/budget-usage-summary/BudgetUsageSummaryWidget.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 
 import dayjs from 'dayjs';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/cost-by-region-multi-fields/CostByRegionMultiFieldsWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/cost-by-region-multi-fields/CostByRegionMultiFieldsWidget.vue
@@ -6,7 +6,7 @@ import { useRouter } from 'vue-router/composables';
 
 import type { Circle } from '@amcharts/amcharts5';
 import { Template } from '@amcharts/amcharts5';
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 
 import { getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/cost-by-region/CostByRegionWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/cost-by-region/CostByRegionWidget.vue
@@ -4,9 +4,8 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import {
-    isEqual, uniqWith,
-} from 'lodash';
+import isEqual from 'lodash/isEqual';
+import uniqWith from 'lodash/uniqWith';
 
 import { getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/cost-by-region/cost-by-region-data-hleper.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/cost-by-region/cost-by-region-data-hleper.ts
@@ -1,5 +1,5 @@
-import { groupBy, sum } from 'lodash';
-
+import groupBy from 'lodash/groupBy';
+import sum from 'lodash/sum';
 
 import type { ProviderReferenceMap } from '@/store/reference/provider-reference-store';
 import type { RegionReferenceMap } from '@/store/reference/region-reference-store';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/cost-summary-multi-fields/CostSummaryMultiFieldsWidget.vue
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/legacy/widgets/cost-widgets/cost-summary-multi-fields/CostSummaryMultiFieldsWidget.vue
@@ -7,7 +7,8 @@ import { useRouter } from 'vue-router/composables';
 import { Root } from '@amcharts/amcharts5';
 import type { IRootSettings } from '@amcharts/amcharts5/.internal/core/Root';
 import type * as am5xy from '@amcharts/amcharts5/xy';
-import { cloneDeep, uniqBy } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import uniqBy from 'lodash/uniqBy';
 
 import { getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/stores/dashboard-detail-info-store.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/stores/dashboard-detail-info-store.ts
@@ -2,7 +2,9 @@
 // @ts-nocheck
 import { computed, reactive } from 'vue';
 
-import { cloneDeep, isEmpty, isEqual } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import { defineStore } from 'pinia';
 
 import type {

--- a/apps/web/src/services/_shared/dashboard/dashboard-detail/stores/widget-form-store.ts
+++ b/apps/web/src/services/_shared/dashboard/dashboard-detail/stores/widget-form-store.ts
@@ -3,7 +3,8 @@
 import type { ComputedRef, UnwrapRef } from 'vue';
 import { computed, reactive } from 'vue';
 
-import { flattenDeep, union } from 'lodash';
+import flattenDeep from 'lodash/flattenDeep';
+import union from 'lodash/union';
 import { defineStore } from 'pinia';
 
 import type { DashboardLayoutWidgetInfo } from '@/api-clients/dashboard/_types/dashboard-type';

--- a/apps/web/src/services/advanced/components/BookmarkDetailContainer.vue
+++ b/apps/web/src/services/advanced/components/BookmarkDetailContainer.vue
@@ -6,7 +6,7 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { at } from 'lodash';
+import at from 'lodash/at';
 
 import {
     PHeading, PButton, PContextMenu, PI, PIconButton, PStatus, PHeadingLayout,

--- a/apps/web/src/services/advanced/composables/use-select-drop-down-list.ts
+++ b/apps/web/src/services/advanced/composables/use-select-drop-down-list.ts
@@ -4,7 +4,7 @@ import {
     computed, reactive, toRefs, watch,
 } from 'vue';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/advanced/pages/admin/AdminBookmarkPage.vue
+++ b/apps/web/src/services/advanced/pages/admin/AdminBookmarkPage.vue
@@ -4,7 +4,7 @@ import {
     computed, reactive,
 } from 'vue';
 
-import { at } from 'lodash';
+import at from 'lodash/at';
 
 import {
     PHeading, PButton, PContextMenu, PHeadingLayout,

--- a/apps/web/src/services/advanced/pages/admin/AdminDomainSettingsDomainInformationPage.vue
+++ b/apps/web/src/services/advanced/pages/admin/AdminDomainSettingsDomainInformationPage.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, reactive, watch } from 'vue';
 
-import { map } from 'lodash';
+import map from 'lodash/map';
 
 import {
     PPaneLayout, PFieldTitle, PButton, PSelectDropdown, PCopyButton,

--- a/apps/web/src/services/advanced/store/bookmark-page-store.ts
+++ b/apps/web/src/services/advanced/store/bookmark-page-store.ts
@@ -1,8 +1,10 @@
 import { computed, reactive } from 'vue';
 
-import {
-    at, filter, forEach, indexOf, sortBy,
-} from 'lodash';
+import at from 'lodash/at';
+import filter from 'lodash/filter';
+import forEach from 'lodash/forEach';
+import indexOf from 'lodash/indexOf';
+import sortBy from 'lodash/sortBy';
 import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/alert-manager/v1/components/AlertDashboardAlertHistoryWidget.vue
+++ b/apps/web/src/services/alert-manager/v1/components/AlertDashboardAlertHistoryWidget.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 
 import dayjs from 'dayjs';
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/alert-manager/v1/components/AlertDashboardAlertHistoryWidgetChart.vue
+++ b/apps/web/src/services/alert-manager/v1/components/AlertDashboardAlertHistoryWidgetChart.vue
@@ -6,7 +6,7 @@ import {
 import type { Series } from '@amcharts/amcharts5';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { PDataLoader, PSkeleton } from '@cloudforet/mirinae';

--- a/apps/web/src/services/alert-manager/v1/components/AlertDashboardAlertStateWidget.vue
+++ b/apps/web/src/services/alert-manager/v1/components/AlertDashboardAlertStateWidget.vue
@@ -3,7 +3,8 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { find, sum } from 'lodash';
+import find from 'lodash/find';
+import sum from 'lodash/sum';
 
 import { getAllPage, getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/alert-manager/v1/components/AlertDashboardTop5ProjectActivityWidget.vue
+++ b/apps/web/src/services/alert-manager/v1/components/AlertDashboardTop5ProjectActivityWidget.vue
@@ -5,7 +5,7 @@ import {
 import { useRouter } from 'vue-router/composables';
 
 import dayjs from 'dayjs';
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/alert-manager/v1/components/AlertDetailTabsDetails.vue
+++ b/apps/web/src/services/alert-manager/v1/components/AlertDetailTabsDetails.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { map } from 'lodash';
+import map from 'lodash/map';
 
 import { PDefinitionTable } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/alert-manager/v1/components/AlertMainDataTable.vue
+++ b/apps/web/src/services/alert-manager/v1/components/AlertMainDataTable.vue
@@ -3,7 +3,7 @@ import { computed, reactive } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 
 import dayjs from 'dayjs';
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { makeDistinctValueHandler, makeReferenceValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import { QueryHelper } from '@cloudforet/core-lib/query';

--- a/apps/web/src/services/alert-manager/v1/components/EscalationPolicyFormRulesInput.vue
+++ b/apps/web/src/services/alert-manager/v1/components/EscalationPolicyFormRulesInput.vue
@@ -3,7 +3,7 @@ import {
     reactive, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/alert-manager/v1/components/ProjectChannelList.vue
+++ b/apps/web/src/services/alert-manager/v1/components/ProjectChannelList.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { get, filter } from 'lodash';
+import filter from 'lodash/filter';
+import get from 'lodash/get';
 
 import { PI } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/alert-manager/v1/composables/alert-info.ts
+++ b/apps/web/src/services/alert-manager/v1/composables/alert-info.ts
@@ -1,6 +1,6 @@
 import { reactive } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type { AlertUpdateParameters } from '@/schema/monitoring/alert/api-verbs/update';
 import { i18n } from '@/translations';

--- a/apps/web/src/services/alert-manager/v2/components/AlertDetailTabsDetails.vue
+++ b/apps/web/src/services/alert-manager/v2/components/AlertDetailTabsDetails.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { map } from 'lodash';
+import map from 'lodash/map';
 
 import { PDefinitionTable, PHeading, PHeadingLayout } from '@cloudforet/mirinae';
 import type { DefinitionField } from '@cloudforet/mirinae/types/data-display/tables/definition-table/type';

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailMemberModal.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailMemberModal.vue
@@ -3,7 +3,9 @@ import { useWindowSize } from '@vueuse/core';
 import { computed, reactive } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { partition, reject, map } from 'lodash';
+import map from 'lodash/map';
+import partition from 'lodash/partition';
+import reject from 'lodash/reject';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsNotifications.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsNotifications.vue
@@ -30,7 +30,7 @@ import {
 import type { ServiceChannelModel } from '@/schema/alert-manager/service-channel/model';
 import type { ServiceChannelDataType } from '@/schema/alert-manager/service-channel/type';
 import type { ServiceModel } from '@/schema/alert-manager/service/model';
-import { i18n, i18n as _i18n } from '@/translations';
+import { i18n } from '@/translations';
 
 import { FILE_NAME_PREFIX } from '@/lib/excel-export/constant';
 import { assetUrlConverter } from '@/lib/helper/asset-helper';
@@ -80,26 +80,26 @@ const tableState = reactive({
         {
             type: 'item',
             name: 'ENABLE',
-            label: _i18n.t('ALERT_MANAGER.ENABLE'),
+            label: i18n.t('ALERT_MANAGER.ENABLE'),
             disabled: !state.selectedItem || state.selectedItem?.state === SERVICE_CHANNEL_STATE.ENABLED,
         },
         {
             type: 'item',
             name: 'DISABLE',
-            label: _i18n.t('ALERT_MANAGER.DISABLED'),
+            label: i18n.t('ALERT_MANAGER.DISABLED'),
             disabled: !state.selectedItem || state.selectedItem?.state === SERVICE_CHANNEL_STATE.DISABLED,
         },
         { type: 'divider' },
         {
             type: 'item',
             name: 'UPDATE',
-            label: _i18n.t('ALERT_MANAGER.UPDATE'),
+            label: i18n.t('ALERT_MANAGER.UPDATE'),
             disabled: !state.selectedItem,
         },
         {
             type: 'item',
             name: 'DELETE',
-            label: _i18n.t('ALERT_MANAGER.DELETE'),
+            label: i18n.t('ALERT_MANAGER.DELETE'),
             disabled: !state.selectedItem,
         },
     ])),

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsNotificationsUpdateModal.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsNotificationsUpdateModal.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { mapValues } from 'lodash';
+import mapValues from 'lodash/mapValues';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEscalationPolicyForm.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEscalationPolicyForm.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import draggable from 'vuedraggable';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PBadge, PIconButton, PI, PTextInput, PFieldGroup, PTextButton,

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEscalationPolicyFormChannelDropdown.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEscalationPolicyFormChannelDropdown.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEventRuleActionForm.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEventRuleActionForm.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { reactive, watch } from 'vue';
 
-import { isUndefined, omitBy } from 'lodash';
+import isUndefined from 'lodash/isUndefined';
+import omitBy from 'lodash/omitBy';
 
 import type { EventRuleActionsType } from '@/schema/alert-manager/event-rule/type';
 

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEventRuleCard.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEventRuleCard.vue
@@ -3,7 +3,7 @@ import { useWindowSize } from '@vueuse/core';
 import { computed, reactive } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PCard, PFieldTitle, PFieldGroup, PDataLoader, PDivider, PLazyImg, PI, PIconButton, screens,

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEventRuleScopeModal.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEventRuleScopeModal.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEventRuleSidebar.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsSettingsEventRuleSidebar.vue
@@ -4,7 +4,7 @@ import { computed, reactive, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 import draggable from 'vuedraggable';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsWebhookDetail.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceDetailTabsWebhookDetail.vue
@@ -4,7 +4,7 @@ import {
     computed, reactive, ref, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/alert-manager/v2/components/ServiceList.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceList.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, reactive } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { makeDistinctValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/alert-manager/v2/components/WebhookCreateSuccessMode.vue
+++ b/apps/web/src/services/alert-manager/v2/components/WebhookCreateSuccessMode.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PDefinitionTable, PButton, PStatus, PMarkdown, PLazyImg, PLink,

--- a/apps/web/src/services/alert-manager/v2/pages/ServiceDetailPage.vue
+++ b/apps/web/src/services/alert-manager/v2/pages/ServiceDetailPage.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { Route } from '@cloudforet/mirinae/types/navigation/breadcrumbs/type';
 

--- a/apps/web/src/services/asset-inventory/AssetInventoryLSB.vue
+++ b/apps/web/src/services/asset-inventory/AssetInventoryLSB.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { MENU_ID } from '@/lib/menu/config.js';
 

--- a/apps/web/src/services/asset-inventory/components/CloudServiceDetail.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceDetail.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import { isTableTypeInDynamicLayoutType } from '@cloudforet/core-lib/component-util/dynamic-layout';
 import { QueryHelper } from '@cloudforet/core-lib/query';

--- a/apps/web/src/services/asset-inventory/components/CloudServiceDetailExcelExportOptionModal.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceDetailExcelExportOptionModal.vue
@@ -3,7 +3,7 @@ import {
     defineProps, defineEmits, reactive, computed, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { isTableTypeInDynamicLayoutType } from '@cloudforet/core-lib/component-util/dynamic-layout';
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/asset-inventory/components/CloudServiceDetailMultipleSelectedData.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceDetailMultipleSelectedData.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/asset-inventory/components/CloudServiceDetailTabs.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceDetailTabs.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/asset-inventory/components/CloudServiceHistoryDateSelectDropdown.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceHistoryDateSelectDropdown.vue
@@ -16,7 +16,7 @@
 import { computed, reactive, toRefs } from 'vue';
 
 import dayjs from 'dayjs';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import {
     PSelectDropdown,

--- a/apps/web/src/services/asset-inventory/components/CloudServiceHistoryDetailNoteTab.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceHistoryDetailNoteTab.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/asset-inventory/components/CloudServiceLSB.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceLSB.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 import {
     PRadioGroup, PRadio, PLazyImg,

--- a/apps/web/src/services/asset-inventory/components/CloudServiceListCard.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceListCard.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { Location } from 'vue-router';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/asset-inventory/components/CloudServiceLogTab.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServiceLogTab.vue
@@ -76,7 +76,8 @@ import type { TranslateResult } from 'vue-i18n';
 
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
-import { debounce, isEmpty } from 'lodash';
+import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/asset-inventory/components/CloudServices.vue
+++ b/apps/web/src/services/asset-inventory/components/CloudServices.vue
@@ -105,7 +105,7 @@
 <script lang="ts">
 import { computed, reactive, toRefs } from 'vue';
 
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/asset-inventory/components/CollectorAdditionalRuleForm.vue
+++ b/apps/web/src/services/asset-inventory/components/CollectorAdditionalRuleForm.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/asset-inventory/components/CollectorFormOptions.vue
+++ b/apps/web/src/services/asset-inventory/components/CollectorFormOptions.vue
@@ -61,7 +61,7 @@ import {
     defineProps, computed, reactive, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/asset-inventory/components/CollectorFormSchedule.vue
+++ b/apps/web/src/services/asset-inventory/components/CollectorFormSchedule.vue
@@ -48,7 +48,8 @@ import {
 } from 'vue';
 
 import dayjs from 'dayjs';
-import { range, size } from 'lodash';
+import range from 'lodash/range';
+import size from 'lodash/size';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/asset-inventory/components/CollectorMainContents.vue
+++ b/apps/web/src/services/asset-inventory/components/CollectorMainContents.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { makeDistinctValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import { QueryHelper } from '@cloudforet/core-lib/query';

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerChart.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerChart.vue
@@ -4,7 +4,9 @@ import { useRoute } from 'vue-router/composables';
 
 import type * as am5percent from '@amcharts/amcharts5/percent';
 import type { XYChart } from '@amcharts/amcharts5/xy';
-import { cloneDeep, debounce, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerChartLegends.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerChartLegends.vue
@@ -3,7 +3,7 @@ import {
     computed, defineEmits, reactive, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PTextButton, PSelectDropdown, PStatus, PDataLoader,

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerDonutChart.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerDonutChart.vue
@@ -7,7 +7,9 @@ import {
 import type { PieSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import { isEmpty, orderBy, throttle } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerFiltersPopper.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerFiltersPopper.vue
@@ -2,7 +2,8 @@
 import { computed, reactive, watch } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { cloneDeep, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 
 import { PSelectDropdown, PTextButton } from '@cloudforet/mirinae';
 import type {

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerGroupBy.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerGroupBy.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, reactive } from 'vue';
 
-import { xor } from 'lodash';
+import xor from 'lodash/xor';
 
 import {
     PSelectButton,

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerHeader.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerHeader.vue
@@ -4,7 +4,7 @@ import { computed, reactive, ref } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerHorizontalColumnChart.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerHorizontalColumnChart.vue
@@ -7,9 +7,10 @@ import {
 import type { LineSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import {
-    isEmpty, orderBy, sum, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import sum from 'lodash/sum';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerLSB.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerLSB.vue
@@ -5,7 +5,9 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { isEmpty, startCase, toLower } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import startCase from 'lodash/startCase';
+import toLower from 'lodash/toLower';
 
 import {
     PI, PSearch, PTextHighlighting, PDataLoader, PEmpty, PPopover, PButton, PCheckbox, PTooltip, PLazyImg,

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerLSBMetric.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerLSBMetric.vue
@@ -4,7 +4,8 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { clone, isEmpty } from 'lodash';
+import clone from 'lodash/clone';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PDataLoader, PIconButton, PLazyImg, PSearch, PEmpty, PTooltip,

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerLineChart.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerLineChart.vue
@@ -8,9 +8,10 @@ import dayjs from 'dayjs';
 import type { LineSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import {
-    isEmpty, orderBy, throttle, zipWith,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import throttle from 'lodash/throttle';
+import zipWith from 'lodash/zipWith';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerMapChart.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerMapChart.vue
@@ -7,9 +7,9 @@ import {
 import type { TreemapSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import {
-    isEmpty, orderBy, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/services/asset-inventory/components/MetricExplorerPeriodDropdown.vue
+++ b/apps/web/src/services/asset-inventory/components/MetricExplorerPeriodDropdown.vue
@@ -5,7 +5,9 @@ import {
 import { useRoute } from 'vue-router/composables';
 
 import dayjs from 'dayjs';
-import { isEmpty, isEqual, range } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import range from 'lodash/range';
 
 import { PSelectDropdown, PBadge } from '@cloudforet/mirinae';
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';

--- a/apps/web/src/services/asset-inventory/components/ProviderList.vue
+++ b/apps/web/src/services/asset-inventory/components/ProviderList.vue
@@ -33,7 +33,7 @@
 import { useElementSize } from '@vueuse/core';
 import { computed, reactive, ref } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { PLazyImg, PButton } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/asset-inventory/helpers/asset-analysis-data-table-helper.ts
+++ b/apps/web/src/services/asset-inventory/helpers/asset-analysis-data-table-helper.ts
@@ -2,7 +2,9 @@
 // @ts-nocheck
 import type { OpUnitType } from 'dayjs';
 import dayjs from 'dayjs';
-import { cloneDeep, find, sortBy } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import find from 'lodash/find';
+import sortBy from 'lodash/sortBy';
 
 import type { DataTableFieldType } from '@cloudforet/mirinae/types/data-display/tables/data-table/type';
 

--- a/apps/web/src/services/asset-inventory/pages/CloudServiceDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/pages/CloudServiceDetailPage.vue
@@ -3,7 +3,9 @@ import { debouncedWatch } from '@vueuse/core';
 import { reactive, computed, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { isEmpty, get, cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 
 import type { ToolboxOptions } from '@cloudforet/core-lib/component-util/toolbox/type';
 import { QueryHelper } from '@cloudforet/core-lib/query';

--- a/apps/web/src/services/asset-inventory/pages/CloudServicePage.vue
+++ b/apps/web/src/services/asset-inventory/pages/CloudServicePage.vue
@@ -3,7 +3,7 @@ import {
     computed, onUnmounted, reactive, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     makeDistinctValueHandler,

--- a/apps/web/src/services/asset-inventory/pages/CloudServiceSearchPage.vue
+++ b/apps/web/src/services/asset-inventory/pages/CloudServiceSearchPage.vue
@@ -4,7 +4,7 @@
 <script lang="ts">
 import type { Vue } from 'vue/types/vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/asset-inventory/pages/CloudServiceTypeSearchPage.vue
+++ b/apps/web/src/services/asset-inventory/pages/CloudServiceTypeSearchPage.vue
@@ -5,7 +5,7 @@
 <script lang="ts">
 import type { Vue } from 'vue/types/vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 

--- a/apps/web/src/services/asset-inventory/pages/CollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/pages/CollectorDetailPage.vue
@@ -27,7 +27,7 @@ import {
 import type { Location } from 'vue-router';
 import { useRoute } from 'vue-router/composables';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/asset-inventory/pages/MetricExplorerDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/pages/MetricExplorerDetailPage.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PDivider,

--- a/apps/web/src/services/asset-inventory/pages/admin/AdminCollectorDetailPage.vue
+++ b/apps/web/src/services/asset-inventory/pages/admin/AdminCollectorDetailPage.vue
@@ -107,7 +107,7 @@ import {
 import type { Location } from 'vue-router';
 import { useRoute } from 'vue-router/composables';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/asset-inventory/routes/admin/routes.ts
+++ b/apps/web/src/services/asset-inventory/routes/admin/routes.ts
@@ -1,6 +1,6 @@
 import type { RouteConfig } from 'vue-router';
 
-import { upperCase } from 'lodash';
+import upperCase from 'lodash/upperCase';
 
 import { MENU_ID } from '@/lib/menu/config';
 import { MENU_INFO_MAP } from '@/lib/menu/menu-info';

--- a/apps/web/src/services/asset-inventory/routes/routes.ts
+++ b/apps/web/src/services/asset-inventory/routes/routes.ts
@@ -1,6 +1,6 @@
 import type { RouteConfig } from 'vue-router';
 
-import { upperCase } from 'lodash';
+import upperCase from 'lodash/upperCase';
 
 import { getRedirectRouteByPagePermission } from '@/lib/access-control/redirect-route-helper';
 import { MENU_ID } from '@/lib/menu/config';

--- a/apps/web/src/services/asset-inventory/stores/cloud-service-detail-page-store.ts
+++ b/apps/web/src/services/asset-inventory/stores/cloud-service-detail-page-store.ts
@@ -1,4 +1,5 @@
-import { find, uniqBy } from 'lodash';
+import find from 'lodash/find';
+import uniqBy from 'lodash/uniqBy';
 import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/asset-inventory/stores/metric-explorer-page-store.ts
+++ b/apps/web/src/services/asset-inventory/stores/metric-explorer-page-store.ts
@@ -2,7 +2,8 @@
 // @ts-nocheck
 import { computed, reactive } from 'vue';
 
-import { cloneDeep, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/asset-inventory/stores/security-page-store.ts
+++ b/apps/web/src/services/asset-inventory/stores/security-page-store.ts
@@ -1,8 +1,9 @@
 import { computed, reactive } from 'vue';
 
-import {
-    find, flatMap, groupBy, uniqBy,
-} from 'lodash';
+import find from 'lodash/find';
+import flatMap from 'lodash/flatMap';
+import groupBy from 'lodash/groupBy';
+import uniqBy from 'lodash/uniqBy';
 import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/cost-explorer/components/AnomalyDetectionConfigurationTrend.vue
+++ b/apps/web/src/services/cost-explorer/components/AnomalyDetectionConfigurationTrend.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 
 import dayjs from 'dayjs';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { PSelectDropdown } from '@cloudforet/mirinae';
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';

--- a/apps/web/src/services/cost-explorer/components/AnomalyDetectionHistoryTable.vue
+++ b/apps/web/src/services/cost-explorer/components/AnomalyDetectionHistoryTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 
 import {
     PToolboxTable, PLink, PLazyImg, PI,

--- a/apps/web/src/services/cost-explorer/components/BudgetCreateProviderSelect.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetCreateProviderSelect.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/cost-explorer/components/BudgetCreateTargetSelect.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetCreateTargetSelect.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, reactive, watch } from 'vue';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { PFieldGroup, PSelectDropdown, PStatus } from '@cloudforet/mirinae';

--- a/apps/web/src/services/cost-explorer/components/BudgetDetailNotificationsConditionSettingModal.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetDetailNotificationsConditionSettingModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButtonModal, PTextInput, PButton, PSelectDropdown, PIconButton, PRadioGroup, PRadio,

--- a/apps/web/src/services/cost-explorer/components/BudgetDetailSummaryChart.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetDetailSummaryChart.vue
@@ -8,7 +8,7 @@ import dayjs from 'dayjs';
 import type { BarSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 
 import { PDataLoader, PSkeleton } from '@cloudforet/mirinae';
 import { numberFormatter } from '@cloudforet/utils';

--- a/apps/web/src/services/cost-explorer/components/BudgetLastThreeMonthCostTrendBarChart.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetLastThreeMonthCostTrendBarChart.vue
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import type { BarSeriesOption } from 'echarts/charts';
 import { init } from 'echarts/core';
 import type { EChartsType } from 'echarts/core';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { PPaneLayout } from '@cloudforet/mirinae';

--- a/apps/web/src/services/cost-explorer/components/BudgetUsageTrendMonthlyChart.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetUsageTrendMonthlyChart.vue
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import type { BarSeriesOption } from 'echarts/charts';
 import { init } from 'echarts/core';
 import type { EChartsType } from 'echarts/core';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 

--- a/apps/web/src/services/cost-explorer/components/BudgetUsageTrendTotalChart.vue
+++ b/apps/web/src/services/cost-explorer/components/BudgetUsageTrendTotalChart.vue
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import type { BarSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { Currency } from '@/store/display/type';
 

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisChart.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisChart.vue
@@ -5,7 +5,9 @@ import {
 
 import type { XYChart } from '@amcharts/amcharts5/xy';
 import dayjs from 'dayjs';
-import { cloneDeep, debounce, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { getCancellableFetcher } from '@cloudforet/core-lib/space-connector/cancellable-fetcher';

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisChartLegends.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisChartLegends.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PTextButton, PSelectDropdown, PStatus, PDataLoader,

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisDataTable.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisDataTable.vue
@@ -5,9 +5,10 @@ import {
 import { useRouter } from 'vue-router/composables';
 
 import dayjs from 'dayjs';
-import {
-    cloneDeep, find, lowerCase, sortBy,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import find from 'lodash/find';
+import lowerCase from 'lodash/lowerCase';
+import sortBy from 'lodash/sortBy';
 
 import { getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { setApiQueryWithToolboxOptions } from '@cloudforet/core-lib/component-util/toolbox';

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisFiltersAddMoreButton.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisFiltersAddMoreButton.vue
@@ -4,7 +4,8 @@ import {
     computed, reactive, ref, toRef, watch,
 } from 'vue';
 
-import { cloneDeep, debounce } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
 
 import {
     PButton, PContextMenu, useContextMenuController,

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisFiltersPopper.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisFiltersPopper.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import {

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisGroupBy.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisGroupBy.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, reactive, watch } from 'vue';
 
-import { xor } from 'lodash';
+import xor from 'lodash/xor';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisPeriodSelectDropdown.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisPeriodSelectDropdown.vue
@@ -5,7 +5,8 @@ import {
 import { useRoute, useRouter } from 'vue-router/composables';
 
 import dayjs from 'dayjs';
-import { isEqual, range } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import range from 'lodash/range';
 
 import { PSelectDropdown } from '@cloudforet/mirinae';
 import type { MenuItem } from '@cloudforet/mirinae/types/controls/context-menu/type';

--- a/apps/web/src/services/cost-explorer/components/CostAnalysisStackedColumnChart.vue
+++ b/apps/web/src/services/cost-explorer/components/CostAnalysisStackedColumnChart.vue
@@ -8,9 +8,8 @@ import dayjs from 'dayjs';
 import type { BarSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import {
-    isEmpty, throttle,
-} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import throttle from 'lodash/throttle';
 
 import {
     PDataLoader, PSkeleton,

--- a/apps/web/src/services/cost-explorer/components/CostReportMonthlyTotalAmountSummaryCard.vue
+++ b/apps/web/src/services/cost-explorer/components/CostReportMonthlyTotalAmountSummaryCard.vue
@@ -9,9 +9,11 @@ import dayjs from 'dayjs';
 import type { PieSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import {
-    debounce, isEmpty, sum, sumBy, throttle,
-} from 'lodash';
+import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
+import sum from 'lodash/sum';
+import sumBy from 'lodash/sumBy';
+import throttle from 'lodash/throttle';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/cost-explorer/components/CostReportOverviewCostTrendCard.vue
+++ b/apps/web/src/services/cost-explorer/components/CostReportOverviewCostTrendCard.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 
 import dayjs from 'dayjs';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/cost-explorer/components/CostReportOverviewCostTrendChart.vue
+++ b/apps/web/src/services/cost-explorer/components/CostReportOverviewCostTrendChart.vue
@@ -9,9 +9,11 @@ import dayjs from 'dayjs';
 import type { BarSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import {
-    cloneDeep, find, isEmpty, sortBy, throttle,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import find from 'lodash/find';
+import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
+import throttle from 'lodash/throttle';
 
 import {
     PCollapsibleToggle, PDataTable,

--- a/apps/web/src/services/cost-explorer/components/CostReportSettingsModal.vue
+++ b/apps/web/src/services/cost-explorer/components/CostReportSettingsModal.vue
@@ -2,7 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 
 import dayjs from 'dayjs';
-import { map } from 'lodash';
+import map from 'lodash/map';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/cost-explorer/components/DataSourceManagementTabLinkedAccountTable.vue
+++ b/apps/web/src/services/cost-explorer/components/DataSourceManagementTabLinkedAccountTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { isObject } from 'lodash';
+import isObject from 'lodash/isObject';
 
 import { makeDistinctValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/cost-explorer/composables/data-source-handler.ts
+++ b/apps/web/src/services/cost-explorer/composables/data-source-handler.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, map } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import map from 'lodash/map';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import type { ApiFilter } from '@cloudforet/core-lib/space-connector/type';

--- a/apps/web/src/services/cost-explorer/helpers/budget-usage-analyze-api-query-helper.ts
+++ b/apps/web/src/services/cost-explorer/helpers/budget-usage-analyze-api-query-helper.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { Query } from '@cloudforet/core-lib/space-connector/type';
 

--- a/apps/web/src/services/cost-explorer/pages/AnomalyDetectionHistoryPage.vue
+++ b/apps/web/src/services/cost-explorer/pages/AnomalyDetectionHistoryPage.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 
 import dayjs from 'dayjs';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import {
     PHeading, PSelectDropdown, PBadge, PHeadingLayout,

--- a/apps/web/src/services/cost-explorer/pages/admin/AdminAdvancedSettingsAnomalyDetectionConfigurationPage.vue
+++ b/apps/web/src/services/cost-explorer/pages/admin/AdminAdvancedSettingsAnomalyDetectionConfigurationPage.vue
@@ -4,7 +4,7 @@ import {
     computed, onMounted, reactive, watch,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/cost-explorer/stores/cost-analysis-page-store.ts
+++ b/apps/web/src/services/cost-explorer/stores/cost-analysis-page-store.ts
@@ -1,7 +1,8 @@
 import { computed, reactive } from 'vue';
 
 import dayjs from 'dayjs';
-import { cloneDeep, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 import { defineStore } from 'pinia';
 
 import type { ConsoleFilter, ConsoleFilterValue } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/dashboards/components/dashboard-detail/DashboardManageVariableImportModal.vue
+++ b/apps/web/src/services/dashboards/components/dashboard-detail/DashboardManageVariableImportModal.vue
@@ -2,7 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButton, PButtonModal, PCheckbox, PSearch, PScopedNotification,

--- a/apps/web/src/services/dashboards/components/dashboard-main/DashboardBundleCloneModal.vue
+++ b/apps/web/src/services/dashboards/components/dashboard-main/DashboardBundleCloneModal.vue
@@ -3,7 +3,7 @@ import { computed, reactive, watch } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
 import { useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PDataTable, PI, PToggleButton, PButtonModal, PTextInput, PFieldGroup, PFieldTitle, PRadioGroup, PRadio, PSelectDropdown,

--- a/apps/web/src/services/dashboards/composables/use-dashboard-search-query.ts
+++ b/apps/web/src/services/dashboards/composables/use-dashboard-search-query.ts
@@ -3,7 +3,7 @@ import {
 } from 'vue';
 
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/dashboards/pages/DashboardsMainPage.vue
+++ b/apps/web/src/services/dashboards/pages/DashboardsMainPage.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { makeDistinctValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/iam/components/AppManagementDoubleCheckModal.vue
+++ b/apps/web/src/services/iam/components/AppManagementDoubleCheckModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PDoubleCheckModal,

--- a/apps/web/src/services/iam/components/AppManagementFormModal.vue
+++ b/apps/web/src/services/iam/components/AppManagementFormModal.vue
@@ -2,7 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/iam/components/AppManagementStatusModal.vue
+++ b/apps/web/src/services/iam/components/AppManagementStatusModal.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButtonModal, PDefinitionTable, PI, PStatus,

--- a/apps/web/src/services/iam/components/AppManagementTable.vue
+++ b/apps/web/src/services/iam/components/AppManagementTable.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import { computed, reactive, watch } from 'vue';
 
-import { cloneDeep, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 
 import { makeDistinctValueHandler, makeEnumValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import { getApiQueryWithToolboxOptions } from '@cloudforet/core-lib/component-util/toolbox';

--- a/apps/web/src/services/iam/components/RoleManagementTabDetail.vue
+++ b/apps/web/src/services/iam/components/RoleManagementTabDetail.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/iam/components/RoleUpdateForm.vue
+++ b/apps/web/src/services/iam/components/RoleUpdateForm.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { ROLE_TYPE } from '@/api-clients/identity/role/constant';
 import type { RoleCreateParameters } from '@/api-clients/identity/role/schema/api-verbs/create';

--- a/apps/web/src/services/iam/components/RoleUpdateFormAccess.vue
+++ b/apps/web/src/services/iam/components/RoleUpdateFormAccess.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { filter } from 'lodash';
+import filter from 'lodash/filter';
 
 import {
     PI, PToggleButton, PDataTable, PSelectDropdown, PCheckboxGroup, PCheckbox, PHeading,

--- a/apps/web/src/services/iam/components/RoleUpdateFormPermissionForm.vue
+++ b/apps/web/src/services/iam/components/RoleUpdateFormPermissionForm.vue
@@ -3,7 +3,8 @@ import {
     computed, reactive, ref, watch,
 } from 'vue';
 
-import { find, isEqual } from 'lodash';
+import find from 'lodash/find';
+import isEqual from 'lodash/isEqual';
 
 import { PPaneLayout } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/iam/components/UserAssignToGroupModal.vue
+++ b/apps/web/src/services/iam/components/UserAssignToGroupModal.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { reactive, watch } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/iam/components/UserManagementAddModal.vue
+++ b/apps/web/src/services/iam/components/UserManagementAddModal.vue
@@ -4,7 +4,8 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { cloneDeep, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { PButtonModal } from '@cloudforet/mirinae';

--- a/apps/web/src/services/iam/components/UserManagementFormAdminRole.vue
+++ b/apps/web/src/services/iam/components/UserManagementFormAdminRole.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/iam/components/UserManagementFormModal.vue
+++ b/apps/web/src/services/iam/components/UserManagementFormModal.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { cloneDeep, isEmpty } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { PButtonModal } from '@cloudforet/mirinae';

--- a/apps/web/src/services/iam/components/UserManagementRemoveModal/UserManagementOnlyRemoveWorkspaceGroupTypeModal.vue
+++ b/apps/web/src/services/iam/components/UserManagementRemoveModal/UserManagementOnlyRemoveWorkspaceGroupTypeModal.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PStatus, PButtonModal, PDataTable, PI, PLink, PBadge,

--- a/apps/web/src/services/iam/components/UserManagementRemoveModal/UserManagementRemoveMixedTypeModal.vue
+++ b/apps/web/src/services/iam/components/UserManagementRemoveModal/UserManagementRemoveMixedTypeModal.vue
@@ -4,7 +4,7 @@ import {
     reactive,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PStatus, PButtonModal, PDataTable, PButton, PBadge,

--- a/apps/web/src/services/iam/components/UserManagementStatusModal.vue
+++ b/apps/web/src/services/iam/components/UserManagementStatusModal.vue
@@ -3,7 +3,8 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { cloneDeep, map } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import map from 'lodash/map';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/iam/components/UserManagementTabTag.vue
+++ b/apps/web/src/services/iam/components/UserManagementTabTag.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/iam/composables/user-data-helper.ts
+++ b/apps/web/src/services/iam/composables/user-data-helper.ts
@@ -1,6 +1,7 @@
-import {
-    cloneDeep, flatMap, flatten, uniq,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import flatMap from 'lodash/flatMap';
+import flatten from 'lodash/flatten';
+import uniq from 'lodash/uniq';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import type { ApiFilter } from '@cloudforet/core-lib/space-connector/type';

--- a/apps/web/src/services/iam/pages/AppMainPage.vue
+++ b/apps/web/src/services/iam/pages/AppMainPage.vue
@@ -3,7 +3,7 @@ import {
     computed, onMounted, onUnmounted, reactive,
 } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PHorizontalLayout, PHeading, PButton, PTab, PHeadingLayout,

--- a/apps/web/src/services/iam/store/user-group-page-store.ts
+++ b/apps/web/src/services/iam/store/user-group-page-store.ts
@@ -2,7 +2,7 @@
 // @ts-nocheck
 import { computed, reactive } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/iam/store/user-group-users-page-store.ts
+++ b/apps/web/src/services/iam/store/user-group-users-page-store.ts
@@ -1,6 +1,6 @@
 import { computed, reactive } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/iam/store/user-page-store.ts
+++ b/apps/web/src/services/iam/store/user-page-store.ts
@@ -2,7 +2,7 @@
 // @ts-nocheck
 import { computed, reactive } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { defineStore } from 'pinia';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/info/components/NoticeForm.vue
+++ b/apps/web/src/services/info/components/NoticeForm.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch, toRef, ref,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import {
     PButton,

--- a/apps/web/src/services/landing/components/workspace-landing/LandingAllWorkspaces.vue
+++ b/apps/web/src/services/landing/components/workspace-landing/LandingAllWorkspaces.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { partition, sortBy } from 'lodash';
+import partition from 'lodash/partition';
+import sortBy from 'lodash/sortBy';
 
 import type { WorkspaceModel } from '@/api-clients/identity/workspace/schema/model';
 

--- a/apps/web/src/services/landing/components/workspace-landing/LandingContents.vue
+++ b/apps/web/src/services/landing/components/workspace-landing/LandingContents.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import {
     PButton, PDataLoader, PDivider, screens,

--- a/apps/web/src/services/landing/components/workspace-landing/landing-group-workspaces/LandingGroupWorkspaces.vue
+++ b/apps/web/src/services/landing/components/workspace-landing/landing-group-workspaces/LandingGroupWorkspaces.vue
@@ -2,7 +2,8 @@
 import { computed, reactive, watch } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { partition, sortBy } from 'lodash';
+import partition from 'lodash/partition';
+import sortBy from 'lodash/sortBy';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/landing/components/workspace-landing/landing-group-workspaces/LandingWorkspaceGroupAddUsersModal.vue
+++ b/apps/web/src/services/landing/components/workspace-landing/landing-group-workspaces/LandingWorkspaceGroupAddUsersModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/my-page/components/NotificationAddSchedule.vue
+++ b/apps/web/src/services/my-page/components/NotificationAddSchedule.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import {
     PRadio, PSelectButton, PSelectDropdown, PRadioGroup,

--- a/apps/web/src/services/my-page/components/NotificationChannelItemData.vue
+++ b/apps/web/src/services/my-page/components/NotificationChannelItemData.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PBadge, PButton, PI, PJsonSchemaForm, PRadio, PRadioGroup,

--- a/apps/web/src/services/my-page/components/UserAccountBaseInformation.vue
+++ b/apps/web/src/services/my-page/components/UserAccountBaseInformation.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { map } from 'lodash';
+import map from 'lodash/map';
 
 import {
     PButton, PFieldGroup, PSelectDropdown, PTextInput, PFieldTitle, PDefinitionTable,

--- a/apps/web/src/services/my-page/components/UserAccountMultiFactorAuthFormModal.vue
+++ b/apps/web/src/services/my-page/components/UserAccountMultiFactorAuthFormModal.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButtonModal, PFieldGroup, PTextInput,

--- a/apps/web/src/services/my-page/composables/notification-item.ts
+++ b/apps/web/src/services/my-page/composables/notification-item.ts
@@ -2,7 +2,7 @@
 // @ts-nocheck
 import { computed, reactive } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 

--- a/apps/web/src/services/my-page/stores/multi-factor-auth-store.ts
+++ b/apps/web/src/services/my-page/stores/multi-factor-auth-store.ts
@@ -1,6 +1,7 @@
 import { reactive } from 'vue';
 
-import { constant, mapValues } from 'lodash';
+import constant from 'lodash/constant';
+import mapValues from 'lodash/mapValues';
 import { defineStore } from 'pinia';
 
 import { MULTI_FACTOR_AUTH_TYPE } from '@/api-clients/identity/user-profile/schema/constant';

--- a/apps/web/src/services/ops-flow/OpsFlowLSB.vue
+++ b/apps/web/src/services/ops-flow/OpsFlowLSB.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import type { MenuId } from '@/lib/menu/config';
 import { MENU_ID } from '@/lib/menu/config';

--- a/apps/web/src/services/ops-flow/components/BoardTaskFilters.vue
+++ b/apps/web/src/services/ops-flow/components/BoardTaskFilters.vue
@@ -3,7 +3,7 @@ import {
     toRef, computed, ref, watch,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { PSelectDropdown, PBadge } from '@cloudforet/mirinae';
 import type { SelectDropdownMenuItem } from '@cloudforet/mirinae/types/controls/dropdown/select-dropdown/type';

--- a/apps/web/src/services/ops-flow/components/PackageForm.vue
+++ b/apps/web/src/services/ops-flow/components/PackageForm.vue
@@ -4,7 +4,7 @@ import {
     computed,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import {
     POverlayLayout, PFieldGroup, PTextInput, PTextarea, PSelectDropdown, PButton, PRadioGroup, PRadio,

--- a/apps/web/src/services/ops-flow/components/TaskContentBaseForm.vue
+++ b/apps/web/src/services/ops-flow/components/TaskContentBaseForm.vue
@@ -2,7 +2,7 @@
 import { computed, watch } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import {
     PFieldTitle, PFieldGroup, PSelectDropdown, PPaneLayout, PButton, PBadge, PSkeleton,

--- a/apps/web/src/services/ops-flow/components/TaskStatusDeleteModal.vue
+++ b/apps/web/src/services/ops-flow/components/TaskStatusDeleteModal.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { PButtonModal } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/ops-flow/components/TaskStatusSetDefaultModal.vue
+++ b/apps/web/src/services/ops-flow/components/TaskStatusSetDefaultModal.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { PButtonModal } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/ops-flow/components/TaskTypeForm.vue
+++ b/apps/web/src/services/ops-flow/components/TaskTypeForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { nextTick, watch, computed } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     POverlayLayout, PFieldGroup, PTextInput, PButton, PTextarea, PRadioGroup, PRadio,

--- a/apps/web/src/services/ops-flow/composables/use-mention.ts
+++ b/apps/web/src/services/ops-flow/composables/use-mention.ts
@@ -3,7 +3,8 @@ import {
     reactive, ref, onMounted, onUnmounted, computed,
 } from 'vue';
 
-import { debounce, throttle } from 'lodash';
+import debounce from 'lodash/debounce';
+import throttle from 'lodash/throttle';
 
 import { useIgnoreWindowArrowKeydownEvents } from '@cloudforet/mirinae';
 import type { SelectDropdownMenuItem } from '@cloudforet/mirinae/types/controls/dropdown/select-dropdown/type';

--- a/apps/web/src/services/ops-flow/composables/use-status-option-form-mutations.ts
+++ b/apps/web/src/services/ops-flow/composables/use-status-option-form-mutations.ts
@@ -2,7 +2,7 @@
 import { computed, type Ref } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { useTaskCategoryApi } from '@/api-clients/opsflow/task-category/composables/use-task-category-api';
 import type { TaskStatusOption, TaskStatusOptions, TaskStatusType } from '@/api-clients/opsflow/task/schema/type';

--- a/apps/web/src/services/ops-flow/composables/use-task-fields-form.ts
+++ b/apps/web/src/services/ops-flow/composables/use-task-fields-form.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue';
 import { computed, ref } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import type { TaskField } from '@/api-clients/opsflow/_types/task-field-type';
 import type { TaskModel } from '@/api-clients/opsflow/task/schema/model';

--- a/apps/web/src/services/ops-flow/composables/use-task-type-form-mutations.ts
+++ b/apps/web/src/services/ops-flow/composables/use-task-type-form-mutations.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { useTaskTypeApi } from '@/api-clients/opsflow/task-type/composables/use-task-type-api';
 import type { TaskTypeModel } from '@/api-clients/opsflow/task-type/schema/model';

--- a/apps/web/src/services/ops-flow/pages/TaskCreatePage.vue
+++ b/apps/web/src/services/ops-flow/pages/TaskCreatePage.vue
@@ -27,7 +27,7 @@ import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router/composables'
 
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PHeadingLayout, PHeading, PButton, PPaneLayout, PSkeleton,

--- a/apps/web/src/services/ops-flow/pages/TaskDetailPage.vue
+++ b/apps/web/src/services/ops-flow/pages/TaskDetailPage.vue
@@ -32,7 +32,7 @@ import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router/composables'
 
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import type { APIError } from '@cloudforet/core-lib/space-connector/error';
 import {

--- a/apps/web/src/services/ops-flow/stores/task-content-form-store.ts
+++ b/apps/web/src/services/ops-flow/stores/task-content-form-store.ts
@@ -1,6 +1,6 @@
 import { reactive, computed } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { defineStore } from 'pinia';
 
 import { APIError } from '@cloudforet/core-lib/space-connector/error';

--- a/apps/web/src/services/ops-flow/task-fields-configuration/TaskFieldGenerator.vue
+++ b/apps/web/src/services/ops-flow/task-fields-configuration/TaskFieldGenerator.vue
@@ -3,7 +3,8 @@ import {
     defineAsyncComponent, computed, onBeforeMount, ref, watch,
 } from 'vue';
 
-import { isEqual, cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 
 import {
     PFieldGroup, PTextInput, PToggleButton, PCheckbox, PButton, PSelectButton, PCodeEditor,

--- a/apps/web/src/services/ops-flow/task-fields-configuration/options-generator-templates/DropdownOptionsGenerator.vue
+++ b/apps/web/src/services/ops-flow/task-fields-configuration/options-generator-templates/DropdownOptionsGenerator.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import draggable from 'vuedraggable';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import {
     PFieldTitle, PButton, PIconButton, PI,

--- a/apps/web/src/services/ops-flow/task-fields-form/composables/use-task-field-validation.ts
+++ b/apps/web/src/services/ops-flow/task-fields-form/composables/use-task-field-validation.ts
@@ -1,7 +1,7 @@
 import type { Ref, UnwrapRef } from 'vue';
 import { watch } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import type { TaskField, TaskFieldType } from '@/api-clients/opsflow/_types/task-field-type';
 import { i18n } from '@/translations';

--- a/apps/web/src/services/ops-flow/task-fields-form/field-templates/ServiceAccountTaskField.vue
+++ b/apps/web/src/services/ops-flow/task-fields-form/field-templates/ServiceAccountTaskField.vue
@@ -4,7 +4,7 @@ import {
     computed, toRef, onMounted,
 } from 'vue';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { PFieldGroup, PSelectDropdown, getTextHighlightRegex } from '@cloudforet/mirinae';
 import type { AutocompleteHandler, SelectDropdownMenuItem } from '@cloudforet/mirinae/types/controls/dropdown/select-dropdown/type';

--- a/apps/web/src/services/project/v-shared/components/ProjectTagsInputGroup.vue
+++ b/apps/web/src/services/project/v-shared/components/ProjectTagsInputGroup.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PButton, PFieldGroup, PIconButton, PTextInput,

--- a/apps/web/src/services/project/v1/ProjectLSB.vue
+++ b/apps/web/src/services/project/v1/ProjectLSB.vue
@@ -4,7 +4,7 @@ import { computed, reactive, ref } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
 
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import {
     PTextInput, PTextHighlighting, PEmpty, PBadge, PContextMenu, PIconButton,

--- a/apps/web/src/services/project/v1/components/ProjectAlertSettingsEscalationPolicy.vue
+++ b/apps/web/src/services/project/v1/components/ProjectAlertSettingsEscalationPolicy.vue
@@ -5,7 +5,7 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 import type { Location } from 'vue-router';
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/project/v1/components/ProjectAlertSettingsTab.vue
+++ b/apps/web/src/services/project/v1/components/ProjectAlertSettingsTab.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/project/v1/components/ProjectAlertTab.vue
+++ b/apps/web/src/services/project/v1/components/ProjectAlertTab.vue
@@ -4,7 +4,7 @@ import {
     computed, onMounted, reactive, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PBadge, PLazyImg, PDefinitionTable, PHeading, PHorizontalLayout, PMarkdown, PStatus, PTab,

--- a/apps/web/src/services/project/v1/components/ProjectAlertWebhookCreateStep1.vue
+++ b/apps/web/src/services/project/v1/components/ProjectAlertWebhookCreateStep1.vue
@@ -2,7 +2,7 @@
 import { onMounted, reactive } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PSelectCard, PButton, PLink, PLazyImg, PDataLoader,

--- a/apps/web/src/services/project/v1/components/ProjectAlertWebhookCreatedModal.vue
+++ b/apps/web/src/services/project/v1/components/ProjectAlertWebhookCreatedModal.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PIconModal, PDefinitionTable, PButton, PStatus, PMarkdown,

--- a/apps/web/src/services/project/v1/components/ProjectDetailTab.vue
+++ b/apps/web/src/services/project/v1/components/ProjectDetailTab.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import { PTab, PBadge } from '@cloudforet/mirinae';
 import type { TabItem } from '@cloudforet/mirinae/types/navigation/tabs/tab/type';

--- a/apps/web/src/services/project/v1/components/ProjectFormModal.vue
+++ b/apps/web/src/services/project/v1/components/ProjectFormModal.vue
@@ -2,7 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/project/v1/components/ProjectGroupMemberManagementModal.vue
+++ b/apps/web/src/services/project/v1/components/ProjectGroupMemberManagementModal.vue
@@ -4,7 +4,8 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { cloneDeep, difference } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import difference from 'lodash/difference';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/project/v1/components/ProjectMain.vue
+++ b/apps/web/src/services/project/v1/components/ProjectMain.vue
@@ -3,7 +3,7 @@
 import { computed, onMounted, reactive } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { uniq } from 'lodash';
+import uniq from 'lodash/uniq';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/project/v1/components/ProjectMainTree.vue
+++ b/apps/web/src/services/project/v1/components/ProjectMainTree.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { PI, PTreeView } from '@cloudforet/mirinae';
 import type { TreeData, TreeDisplayMap, TreeNode } from '@cloudforet/mirinae/types/data-display/tree/tree-view/type';

--- a/apps/web/src/services/project/v1/components/ProjectSummaryAlertWidget.vue
+++ b/apps/web/src/services/project/v1/components/ProjectSummaryAlertWidget.vue
@@ -5,7 +5,7 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 import type { Location } from 'vue-router';
 
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import { getAllPage, getPageStart } from '@cloudforet/core-lib/component-util/pagination';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/project/v1/components/ProjectSummaryAllSummaryWidget.vue
+++ b/apps/web/src/services/project/v1/components/ProjectSummaryAllSummaryWidget.vue
@@ -9,9 +9,10 @@ import type { TimeUnit } from '@amcharts/amcharts5/.internal/core/util/Time';
 import type { XYChart } from '@amcharts/amcharts5/xy';
 import type { Unit } from 'bytes';
 import dayjs from 'dayjs';
-import {
-    cloneDeep, forEach, orderBy, range,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import forEach from 'lodash/forEach';
+import orderBy from 'lodash/orderBy';
+import range from 'lodash/range';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/project/v1/components/ProjectSummaryAllSummaryWidgetRegionService.vue
+++ b/apps/web/src/services/project/v1/components/ProjectSummaryAllSummaryWidgetRegionService.vue
@@ -7,7 +7,9 @@ import type { Location } from 'vue-router';
 import type { PieSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import { range, orderBy, isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import range from 'lodash/range';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/project/v1/components/ProjectSummaryBillingWidget.vue
+++ b/apps/web/src/services/project/v1/components/ProjectSummaryBillingWidget.vue
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import type { LineSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/services/project/v1/components/ProjectSummaryServiceAccountsWidget.vue
+++ b/apps/web/src/services/project/v1/components/ProjectSummaryServiceAccountsWidget.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { Location } from 'vue-router';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { PDataTable } from '@cloudforet/mirinae';

--- a/apps/web/src/services/project/v1/components/ProjectSummaryTrustedAdvisorWidget.vue
+++ b/apps/web/src/services/project/v1/components/ProjectSummaryTrustedAdvisorWidget.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive,
 } from 'vue';
 
-import { findKey } from 'lodash';
+import findKey from 'lodash/findKey';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/project/v1/components/ProjectTagsModal.vue
+++ b/apps/web/src/services/project/v1/components/ProjectTagsModal.vue
@@ -3,7 +3,7 @@ import {
     reactive, computed, onMounted,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PButtonModal,

--- a/apps/web/src/services/project/v1/composables/use-project-tree-data.ts
+++ b/apps/web/src/services/project/v1/composables/use-project-tree-data.ts
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import type { Location } from 'vue-router';
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 import type { TreeDisplayMap, TreeNode } from '@cloudforet/mirinae/types/data-display/tree/tree-view/type';
 

--- a/apps/web/src/services/project/v1/pages/ProjectDetailPageLegacy.vue
+++ b/apps/web/src/services/project/v1/pages/ProjectDetailPageLegacy.vue
@@ -5,7 +5,8 @@ import {
 import type { TranslateResult } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { find, isEmpty } from 'lodash';
+import find from 'lodash/find';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/project/v1/pages/ProjectDetailTabPage.vue
+++ b/apps/web/src/services/project/v1/pages/ProjectDetailTabPage.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PDataLoader,

--- a/apps/web/src/services/project/v1/stores/project-tree-store.ts
+++ b/apps/web/src/services/project/v1/stores/project-tree-store.ts
@@ -1,6 +1,6 @@
 import { nextTick, reactive } from 'vue';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { defineStore } from 'pinia';
 
 import type { TreeDisplayMap } from '@cloudforet/mirinae/types/data-display/tree/tree-view/type';

--- a/apps/web/src/services/project/v2/components/ProjectAndGroupListPanel.vue
+++ b/apps/web/src/services/project/v2/components/ProjectAndGroupListPanel.vue
@@ -4,7 +4,7 @@ import {
     computed, ref,
 } from 'vue';
 
-import { uniq } from 'lodash';
+import uniq from 'lodash/uniq';
 
 import {
     PFieldTitle, PEmpty, PPaneLayout, PI, PButton,

--- a/apps/web/src/services/project/v2/components/ProjectDashboardBundleCloneModal.vue
+++ b/apps/web/src/services/project/v2/components/ProjectDashboardBundleCloneModal.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PDataTable, PI, PToggleButton, PButtonModal, PTextInput, PFieldGroup, PFieldTitle, PRadioGroup, PRadio, PSelectDropdown,

--- a/apps/web/src/services/project/v2/components/ProjectDashboardEditListOverlay.vue
+++ b/apps/web/src/services/project/v2/components/ProjectDashboardEditListOverlay.vue
@@ -7,7 +7,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { makeDistinctValueHandler } from '@cloudforet/core-lib/component-util/query-search';
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';

--- a/apps/web/src/services/project/v2/components/ProjectGroupMemberManagementModal.vue
+++ b/apps/web/src/services/project/v2/components/ProjectGroupMemberManagementModal.vue
@@ -4,7 +4,8 @@ import {
 } from 'vue';
 
 import { useMutation } from '@tanstack/vue-query';
-import { cloneDeep, difference } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import difference from 'lodash/difference';
 
 import {
     PButtonModal, PDataLoader, PEmpty, PFieldGroup, PTextInput, PIconButton,

--- a/apps/web/src/services/project/v2/components/ProjectTagsModal.vue
+++ b/apps/web/src/services/project/v2/components/ProjectTagsModal.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 
 import { useMutation } from '@tanstack/vue-query';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButtonModal,

--- a/apps/web/src/services/project/v2/composables/queries/use-project-dashboard-search-query.ts
+++ b/apps/web/src/services/project/v2/composables/queries/use-project-dashboard-search-query.ts
@@ -3,7 +3,7 @@ import {
 } from 'vue';
 
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/service-account/components/ServiceAccountAutoSyncDetail.vue
+++ b/apps/web/src/services/service-account/components/ServiceAccountAutoSyncDetail.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 
 import dayjs from 'dayjs';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { PFieldGroup, PFieldTitle } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/service-account/components/ServiceAccountAutoSyncForm.vue
+++ b/apps/web/src/services/service-account/components/ServiceAccountAutoSyncForm.vue
@@ -2,7 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 
 import dayjs from 'dayjs';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import {
     PJsonSchemaForm, PFieldTitle, PPaneLayout, PToggleButton, PFieldGroup,

--- a/apps/web/src/services/service-account/components/ServiceAccountBaseInformationForm.vue
+++ b/apps/web/src/services/service-account/components/ServiceAccountBaseInformationForm.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { isEmpty, isEqual } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/service-account/components/ServiceAccountCredentials.vue
+++ b/apps/web/src/services/service-account/components/ServiceAccountCredentials.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/service-account/components/ServiceAccountCredentialsForm.vue
+++ b/apps/web/src/services/service-account/components/ServiceAccountCredentialsForm.vue
@@ -4,7 +4,7 @@ import {
     computed, reactive, watch, onMounted,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { ApiQueryHelper } from '@cloudforet/core-lib/space-connector/helper';

--- a/apps/web/src/services/service-account/components/WorkspaceDropdown.vue
+++ b/apps/web/src/services/service-account/components/WorkspaceDropdown.vue
@@ -2,7 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import { PButton, PSelectDropdown, PStatus } from '@cloudforet/mirinae';

--- a/apps/web/src/services/service-account/pages/ServiceAccountDetailPage.vue
+++ b/apps/web/src/services/service-account/pages/ServiceAccountDetailPage.vue
@@ -5,7 +5,7 @@ import {
 import { useRoute, useRouter } from 'vue-router/composables';
 
 import { render } from 'ejs';
-import { clone } from 'lodash';
+import clone from 'lodash/clone';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';
 import {

--- a/apps/web/src/services/workspace-home/components/BookmarkHeader.vue
+++ b/apps/web/src/services/workspace-home/components/BookmarkHeader.vue
@@ -6,7 +6,7 @@ import {
 } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { sumBy } from 'lodash';
+import sumBy from 'lodash/sumBy';
 
 import {
     PButton,

--- a/apps/web/src/services/workspace-home/components/WorkspaceInfo.vue
+++ b/apps/web/src/services/workspace-home/components/WorkspaceInfo.vue
@@ -4,7 +4,7 @@ import Vue, {
 } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
     PButton, PHeading, PI, PTextButton, PHeadingLayout,

--- a/apps/web/src/services/workspace-home/composables/use-workspace-home.ts
+++ b/apps/web/src/services/workspace-home/composables/use-workspace-home.ts
@@ -1,4 +1,4 @@
-import { mapKeys } from 'lodash';
+import mapKeys from 'lodash/mapKeys';
 
 import type { MetricDataAnalyzeResult } from '@/services/asset-inventory/types/asset-analysis-type';
 import {

--- a/apps/web/src/services/workspace-home/pages/WorkspaceHomePage.vue
+++ b/apps/web/src/services/workspace-home/pages/WorkspaceHomePage.vue
@@ -3,7 +3,7 @@ import {
     computed, reactive, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { UserConfigModel } from '@/api-clients/config/user-config/schema/model';
 import { ROLE_TYPE } from '@/api-clients/identity/role/constant';

--- a/apps/web/src/services/workspace-home/shared/components/AccountSummary.vue
+++ b/apps/web/src/services/workspace-home/shared/components/AccountSummary.vue
@@ -6,7 +6,9 @@ import {
 import type { PieSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import { countBy, isEmpty, map } from 'lodash';
+import countBy from 'lodash/countBy';
+import isEmpty from 'lodash/isEmpty';
+import map from 'lodash/map';
 
 import { QueryHelper } from '@cloudforet/core-lib/query';
 import {

--- a/apps/web/src/services/workspace-home/shared/components/AssetSummary.vue
+++ b/apps/web/src/services/workspace-home/shared/components/AssetSummary.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, toRef } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {
     PDivider, PFieldTitle, PLink, PSpinner,

--- a/apps/web/src/services/workspace-home/shared/components/AssetSummaryDailyUpdateItem.vue
+++ b/apps/web/src/services/workspace-home/shared/components/AssetSummaryDailyUpdateItem.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { PLazyImg, PI } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/workspace-home/shared/components/AssetSummaryProvider.vue
+++ b/apps/web/src/services/workspace-home/shared/components/AssetSummaryProvider.vue
@@ -4,7 +4,7 @@ import {
     computed, reactive, ref,
 } from 'vue';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import { PIconButton } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/workspace-home/shared/components/AssetSummaryProviderItem.vue
+++ b/apps/web/src/services/workspace-home/shared/components/AssetSummaryProviderItem.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { PLazyImg, PTextButton } from '@cloudforet/mirinae';
 import { byteFormatter, numberFormatter } from '@cloudforet/utils';

--- a/apps/web/src/services/workspace-home/shared/components/CostSummary.vue
+++ b/apps/web/src/services/workspace-home/shared/components/CostSummary.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 
 import dayjs from 'dayjs';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 import {

--- a/apps/web/src/services/workspace-home/shared/components/CostSummaryChart.vue
+++ b/apps/web/src/services/workspace-home/shared/components/CostSummaryChart.vue
@@ -8,7 +8,7 @@ import dayjs from 'dayjs';
 import type { LineSeriesOption } from 'echarts/charts';
 import type { EChartsType } from 'echarts/core';
 import { init } from 'echarts/core';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 
 import { numberFormatter } from '@cloudforet/utils';
 

--- a/apps/web/src/services/workspace-home/shared/components/EmptySummaryData.vue
+++ b/apps/web/src/services/workspace-home/shared/components/EmptySummaryData.vue
@@ -2,7 +2,7 @@
 import { computed, reactive } from 'vue';
 import { useRouter } from 'vue-router/composables';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { PI, PTextButton } from '@cloudforet/mirinae';
 

--- a/apps/web/src/services/workspace-home/shared/composables/use-asset-daily-updates.ts
+++ b/apps/web/src/services/workspace-home/shared/composables/use-asset-daily-updates.ts
@@ -2,9 +2,9 @@ import type { Ref } from 'vue';
 import { computed } from 'vue';
 
 import dayjs from 'dayjs';
-import {
-    groupBy, map, sumBy,
-} from 'lodash';
+import groupBy from 'lodash/groupBy';
+import map from 'lodash/map';
+import sumBy from 'lodash/sumBy';
 
 import { useMetricDataApi } from '@/api-clients/inventory/metric-data/composables/use-metric-data-api';
 import { useScopedQuery } from '@/query/composables/use-scoped-query';

--- a/apps/web/src/services/workspace-home/shared/composables/use-cost-chart-data.ts
+++ b/apps/web/src/services/workspace-home/shared/composables/use-cost-chart-data.ts
@@ -2,7 +2,7 @@ import type { Ref } from 'vue';
 import { computed } from 'vue';
 
 import dayjs from 'dayjs';
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import { useUnifiedCostApi } from '@/api-clients/cost-analysis/unified-cost/composables/use-unified-cost-api';
 import type { UnifiedCostAnalyzeParameters } from '@/api-clients/cost-analysis/unified-cost/schema/api-verbs/analyze';

--- a/apps/web/src/services/workspace-home/store/workspace-home-page-store.ts
+++ b/apps/web/src/services/workspace-home/store/workspace-home-page-store.ts
@@ -1,7 +1,7 @@
 import { computed, reactive } from 'vue';
 import type { TranslateResult } from 'vue-i18n';
 
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 import { defineStore } from 'pinia';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/store/authorization/authorization-store.ts
+++ b/apps/web/src/store/authorization/authorization-store.ts
@@ -2,7 +2,7 @@ import { computed, reactive } from 'vue';
 
 import type { AxiosRequestConfig } from 'axios';
 import { jwtDecode } from 'jwt-decode';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { defineStore } from 'pinia';
 
 import { SpaceConnector } from '@cloudforet/core-lib/space-connector';

--- a/apps/web/src/store/menu/menu-store.ts
+++ b/apps/web/src/store/menu/menu-store.ts
@@ -1,6 +1,6 @@
 import { computed, reactive } from 'vue';
 
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import { defineStore } from 'pinia';
 
 import { useAppContextStore } from '@/store/app-context/app-context-store';

--- a/apps/web/src/store/pinia.ts
+++ b/apps/web/src/store/pinia.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { createPinia } from 'pinia';
 
 const resetStore = ({ store }) => {

--- a/packages/core-lib/src/component-util/dynamic-layout/index.ts
+++ b/packages/core-lib/src/component-util/dynamic-layout/index.ts
@@ -7,7 +7,7 @@ import type {
     DynamicLayoutType,
     SearchSchema,
 } from '@cloudforet/mirinae/types/data-display/dynamic/dynamic-layout/type/layout-schema';
-import { forEach } from 'lodash';
+import forEach from 'lodash/forEach';
 
 import {
     makeDistinctValueHandler,

--- a/packages/core-lib/src/component-util/query-search/index.ts
+++ b/packages/core-lib/src/component-util/query-search/index.ts
@@ -5,9 +5,12 @@ import type {
     ValueItem,
 } from '@cloudforet/mirinae/types/controls/search/query-search/type';
 import type { SearchEnums, SearchEnumItem } from '@cloudforet/mirinae/types/data-display/dynamic/dynamic-layout/type/layout-schema';
-import {
-    map, size, flatMap, flatten, uniq, cloneDeep,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import flatMap from 'lodash/flatMap';
+import flatten from 'lodash/flatten';
+import map from 'lodash/map';
+import size from 'lodash/size';
+import uniq from 'lodash/uniq';
 
 import { SpaceConnector } from '@/space-connector';
 import type { ApiFilter } from '@/space-connector/type';

--- a/packages/core-lib/src/query/index.ts
+++ b/packages/core-lib/src/query/index.ts
@@ -8,7 +8,8 @@ import type {
 import dayjs from 'dayjs';
 import tz from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
-import { flatten, forEach } from 'lodash';
+import flatten from 'lodash/flatten';
+import forEach from 'lodash/forEach';
 
 import {
     datetimeRawQueryOperatorToQueryTagOperatorMap, rawQueryOperatorToApiQueryOperatorMap,

--- a/packages/core-lib/src/space-connector/index.ts
+++ b/packages/core-lib/src/space-connector/index.ts
@@ -1,7 +1,7 @@
 import type { InternalAxiosRequestConfig, CreateAxiosDefaults, Axios } from 'axios';
 import axios from 'axios';
 import type { CustomAxiosRequestConfig } from 'axios-auth-refresh/dist/utils';
-import { camelCase } from 'lodash';
+import camelCase from 'lodash/camelCase';
 
 import type {
     APIInfo, MockConfig, AxiosPostResponse, AuthConfig, DevConfig,

--- a/packages/mirinae-foundation/colors.cjs
+++ b/packages/mirinae-foundation/colors.cjs
@@ -1,6 +1,7 @@
 // const { colors } = require('tailwindcss/defaultTheme');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { kebabCase, forEach } = require('lodash');
+const kebabCase = require('lodash/kebabCase');
+const forEach = require('lodash/forEach');
 
 const palette = {
     black: '#000000',

--- a/packages/mirinae/package.json
+++ b/packages/mirinae/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "vite build && npm run css",
+    "build": "vite build --debug && npm run css",
     "transpile": "npm run vue-tsc && npm run tsc-alias",
     "dev": "concurrently \"npm run build:watch\" \"npm run tsc:watch\"",
     "build:watch": "vite build --watch",

--- a/packages/mirinae/src/controls/code-editor/PCodeEditor.vue
+++ b/packages/mirinae/src/controls/code-editor/PCodeEditor.vue
@@ -14,7 +14,9 @@ import {
 
 import type { EditorConfiguration } from 'codemirror';
 import CodeMirror from 'codemirror';
-import { forEach, isEqual, debounce } from 'lodash';
+import debounce from 'lodash/debounce';
+import forEach from 'lodash/forEach';
+import isEqual from 'lodash/isEqual';
 
 import PDataLoader from '@/feedbacks/loading/data-loader/PDataLoader.vue';
 

--- a/packages/mirinae/src/controls/context-menu/PContextMenu.vue
+++ b/packages/mirinae/src/controls/context-menu/PContextMenu.vue
@@ -3,7 +3,7 @@ import {
     computed, onUnmounted, reactive, ref, useSlots, watch,
 } from 'vue';
 
-import { reduce } from 'lodash';
+import reduce from 'lodash/reduce';
 
 import PButton from '@/controls/buttons/button/PButton.vue';
 import PTextButton from '@/controls/buttons/text-button/PTextButton.vue';

--- a/packages/mirinae/src/controls/dropdown/filterable-query-dropdown/mock.ts
+++ b/packages/mirinae/src/controls/dropdown/filterable-query-dropdown/mock.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import type {
     KeyItemSet,

--- a/packages/mirinae/src/controls/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/packages/mirinae/src/controls/dropdown/select-dropdown/PSelectDropdown.vue
@@ -4,7 +4,8 @@ import {
 } from 'vue';
 
 import { onClickOutside, useFocus } from '@vueuse/core';
-import { debounce, reduce } from 'lodash';
+import debounce from 'lodash/debounce';
+import reduce from 'lodash/reduce';
 
 import PContextMenu from '@/controls/context-menu/PContextMenu.vue';
 import type { ContextMenuType } from '@/controls/context-menu/type';

--- a/packages/mirinae/src/controls/dropdown/select-dropdown/mock.ts
+++ b/packages/mirinae/src/controls/dropdown/select-dropdown/mock.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import type { SelectDropdownMenuItem } from '@/controls/dropdown/select-dropdown/type';
 import { getTextHighlightRegex } from '@/utils';

--- a/packages/mirinae/src/controls/forms/json-schema-form/PJsonSchemaForm.vue
+++ b/packages/mirinae/src/controls/forms/json-schema-form/PJsonSchemaForm.vue
@@ -164,7 +164,7 @@ import {
 
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import PToggleButton from '@/controls/buttons/toggle-button/PToggleButton.vue';
 import PCodeEditor from '@/controls/code-editor/PCodeEditor.vue';

--- a/packages/mirinae/src/controls/forms/json-schema-form/composables/validation.ts
+++ b/packages/mirinae/src/controls/forms/json-schema-form/composables/validation.ts
@@ -6,7 +6,7 @@ import {
 import type { ErrorObject, ValidateFunction } from 'ajv';
 import type Ajv from 'ajv';
 import type { Localize } from 'ajv-i18n/localize/types';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { JsonSchemaFormProps, InnerJsonSchema, CustomErrorMap } from '@/controls/forms/json-schema-form/type';
 

--- a/packages/mirinae/src/controls/forms/json-schema-form/helpers/inner-schema-helper.ts
+++ b/packages/mirinae/src/controls/forms/json-schema-form/helpers/inner-schema-helper.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { AutocompleteHandler, SelectDropdownMenuItem } from '@/controls/dropdown/select-dropdown/type';
 import { NUMERIC_TYPES } from '@/controls/forms/json-schema-form/helpers/form-data-refine-helper';

--- a/packages/mirinae/src/controls/forms/json-schema-form/helpers/raw-form-data-helper.ts
+++ b/packages/mirinae/src/controls/forms/json-schema-form/helpers/raw-form-data-helper.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax,no-await-in-loop */
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { getComponentNameBySchemaProperty } from '@/controls/forms/json-schema-form/helpers/inner-schema-helper';
 import type { JsonSchema, ReferenceHandler } from '@/controls/forms/json-schema-form/type';

--- a/packages/mirinae/src/controls/forms/json-schema-form/mock.ts
+++ b/packages/mirinae/src/controls/forms/json-schema-form/mock.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import Fuse from 'fuse.js';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import type { SelectDropdownMenuItem } from '@/controls/dropdown/select-dropdown/type';
 import type { ReferenceHandler } from '@/controls/forms/json-schema-form/type';

--- a/packages/mirinae/src/controls/input/query-input/PQueryInput.vue
+++ b/packages/mirinae/src/controls/input/query-input/PQueryInput.vue
@@ -98,7 +98,7 @@ import {
 
 import { vOnClickOutside } from '@vueuse/components';
 import { useFocus } from '@vueuse/core';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import PContextMenu from '@/controls/context-menu/PContextMenu.vue';

--- a/packages/mirinae/src/controls/input/query-input/mock.ts
+++ b/packages/mirinae/src/controls/input/query-input/mock.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import type {
     KeyItem,

--- a/packages/mirinae/src/controls/input/text-input/PTextInput.vue
+++ b/packages/mirinae/src/controls/input/text-input/PTextInput.vue
@@ -128,7 +128,7 @@ import {
 
 import { vOnClickOutside } from '@vueuse/components';
 import { useFocus } from '@vueuse/core';
-import { unionBy } from 'lodash';
+import unionBy from 'lodash/unionBy';
 import type { TranslateResult } from 'vue-i18n';
 
 import PButton from '@/controls/buttons/button/PButton.vue';

--- a/packages/mirinae/src/controls/input/text-input/mock.ts
+++ b/packages/mirinae/src/controls/input/text-input/mock.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import type { MenuItem } from '@/controls/context-menu/type';
 

--- a/packages/mirinae/src/controls/search/query-search/PQuerySearch.vue
+++ b/packages/mirinae/src/controls/search/query-search/PQuerySearch.vue
@@ -95,9 +95,7 @@ import {
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
-import {
-    reduce,
-} from 'lodash';
+import reduce from 'lodash/reduce';
 import vClickOutside from 'v-click-outside';
 import { focus as vFocus } from 'vue-focus';
 

--- a/packages/mirinae/src/controls/search/query-search/helper.ts
+++ b/packages/mirinae/src/controls/search/query-search/helper.ts
@@ -1,4 +1,4 @@
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 import type {
     KeyItem, KeyItemSet, KeyMenuItem, ValueHandler, ValueItem, ValueMenuItem, MenuFormatterArgs,

--- a/packages/mirinae/src/controls/search/query-search/mock.ts
+++ b/packages/mirinae/src/controls/search/query-search/mock.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import type {
     KeyItemSet,

--- a/packages/mirinae/src/controls/search/search/PSearch.vue
+++ b/packages/mirinae/src/controls/search/search/PSearch.vue
@@ -67,7 +67,7 @@ import {
 
 import { vOnClickOutside } from '@vueuse/components';
 import { useFocus } from '@vueuse/core';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import type { MenuItem } from '@/controls/context-menu/type';
 import type { SelectDropdownMenuItem } from '@/controls/dropdown/select-dropdown/type';

--- a/packages/mirinae/src/controls/select-button/PSelectButton.stories.ts
+++ b/packages/mirinae/src/controls/select-button/PSelectButton.stories.ts
@@ -1,7 +1,7 @@
 import { reactive, toRefs } from 'vue';
 
 import type { Meta, StoryObj } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 

--- a/packages/mirinae/src/controls/select-card/PSelectCard.stories.ts
+++ b/packages/mirinae/src/controls/select-card/PSelectCard.stories.ts
@@ -1,7 +1,7 @@
 import { reactive, toRefs } from 'vue';
 
 import type { Meta, StoryObj } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 import { getSelectCardParameters, getSelectCardArgs, getSelectCardArgTypes } from '@/controls/select-card/story-helper';

--- a/packages/mirinae/src/controls/select-status/PSelectStatus.stories.ts
+++ b/packages/mirinae/src/controls/select-status/PSelectStatus.stories.ts
@@ -2,7 +2,7 @@ import { reactive, toRefs } from 'vue';
 
 import { faker } from '@faker-js/faker';
 import type { Meta, StoryObj } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 

--- a/packages/mirinae/src/controls/toolbox/PToolbox.vue
+++ b/packages/mirinae/src/controls/toolbox/PToolbox.vue
@@ -106,7 +106,7 @@ import {
     computed, defineComponent, nextTick, reactive, toRefs,
 } from 'vue';
 
-import { groupBy } from 'lodash';
+import groupBy from 'lodash/groupBy';
 
 import PIconButton from '@/controls/buttons/icon-button/PIconButton.vue';
 import PSelectDropdown from '@/controls/dropdown/select-dropdown/PSelectDropdown.vue';

--- a/packages/mirinae/src/controls/toolbox/mock.ts
+++ b/packages/mirinae/src/controls/toolbox/mock.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { getQuerySearchTags } from '@/controls/search/query-search-tags/mock';
 

--- a/packages/mirinae/src/data-display/badge/PBadge.vue
+++ b/packages/mirinae/src/data-display/badge/PBadge.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 import type {
     BadgeFontWeight,

--- a/packages/mirinae/src/data-display/cards/list-card/PListCard.stories.ts
+++ b/packages/mirinae/src/data-display/cards/list-card/PListCard.stories.ts
@@ -4,7 +4,7 @@ import { reactive, toRefs } from 'vue';
 import { faker } from '@faker-js/faker';
 import type { Meta, StoryObj } from '@storybook/vue';
 import dayjs from 'dayjs';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 import PButton from '@/controls/buttons/button/PButton.vue';

--- a/packages/mirinae/src/data-display/cards/list-card/story-helper.ts
+++ b/packages/mirinae/src/data-display/cards/list-card/story-helper.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import type { SBType } from '@storybook/types';
 import type { ArgTypes, Parameters, Args } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { CARD_STYLE_TYPE, CARD_SIZE } from '@/data-display/cards/card/config';
 import { getCardArgTypes } from '@/data-display/cards/card/story-helper';

--- a/packages/mirinae/src/data-display/collapsible/collapsible-list/PCollapsibleList.stories.ts
+++ b/packages/mirinae/src/data-display/collapsible/collapsible-list/PCollapsibleList.stories.ts
@@ -2,7 +2,7 @@ import { reactive, toRefs } from 'vue';
 
 import { faker } from '@faker-js/faker';
 import type { Meta, StoryObj } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 import { getCollapsibleListArgTypes, getCollapsibleListParameters, getCollapsibleListArgs } from '@/data-display/collapsible/collapsible-list/story-helper';

--- a/packages/mirinae/src/data-display/collapsible/collapsible-list/story-helper.ts
+++ b/packages/mirinae/src/data-display/collapsible/collapsible-list/story-helper.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import type { SBType } from '@storybook/types';
 import type { ArgTypes, Parameters, Args } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import {
     COLLAPSIBLE_LIST_THEME,

--- a/packages/mirinae/src/data-display/dynamic/dynamic-field/templates/state/index.vue
+++ b/packages/mirinae/src/data-display/dynamic/dynamic-field/templates/state/index.vue
@@ -16,7 +16,7 @@
 import type { PropType } from 'vue';
 import { computed, defineComponent } from 'vue';
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 import type { TranslateResult } from 'vue-i18n';
 
 import type { StateTypeOptions } from '@/data-display/dynamic/dynamic-field/templates/state/type';

--- a/packages/mirinae/src/data-display/dynamic/dynamic-layout/PDynamicLayout.vue
+++ b/packages/mirinae/src/data-display/dynamic/dynamic-layout/PDynamicLayout.vue
@@ -26,7 +26,7 @@ import {
 import type { ImportedComponent } from 'vue/types/options';
 import type { PropType } from 'vue/types/v3-component-props';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import type { DynamicLayoutType } from '@/data-display/dynamic/dynamic-layout/type/layout-schema';
 import { dynamicLayoutTypes } from '@/data-display/dynamic/dynamic-layout/type/layout-schema';

--- a/packages/mirinae/src/data-display/dynamic/dynamic-layout/templates/html/style.ts
+++ b/packages/mirinae/src/data-display/dynamic/dynamic-layout/templates/html/style.ts
@@ -1,4 +1,5 @@
-import { forEach, map } from 'lodash';
+import forEach from 'lodash/forEach';
+import map from 'lodash/map';
 
 import colors from '@/styles/colors.cjs';
 

--- a/packages/mirinae/src/data-display/dynamic/dynamic-layout/templates/list/index.vue
+++ b/packages/mirinae/src/data-display/dynamic/dynamic-layout/templates/list/index.vue
@@ -36,7 +36,8 @@ import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
-import { map, replace } from 'lodash';
+import map from 'lodash/map';
+import replace from 'lodash/replace';
 
 import PDynamicLayout from '@/data-display/dynamic/dynamic-layout/PDynamicLayout.vue';
 import type { DynamicLayoutFetchOptions, DynamicLayoutFieldHandler, DynamicLayoutTypeOptions } from '@/data-display/dynamic/dynamic-layout/type';

--- a/packages/mirinae/src/data-display/dynamic/dynamic-layout/templates/query-search-table/query-search-table.stories.ts
+++ b/packages/mirinae/src/data-display/dynamic/dynamic-layout/templates/query-search-table/query-search-table.stories.ts
@@ -2,7 +2,7 @@ import { reactive, toRefs } from 'vue';
 
 import { faker } from '@faker-js/faker';
 import type { Meta, StoryObj } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 import PDynamicLayout from '@/data-display/dynamic/dynamic-layout/PDynamicLayout.vue';

--- a/packages/mirinae/src/data-display/dynamic/helper.ts
+++ b/packages/mirinae/src/data-display/dynamic/helper.ts
@@ -1,4 +1,4 @@
-import { flatten } from 'lodash';
+import flatten from 'lodash/flatten';
 
 const getObjectValue = (target: Record<string, any>|Array<any>, currentPath: string) => {
     if (Array.isArray(target)) {

--- a/packages/mirinae/src/data-display/markdown/PMarkdown.vue
+++ b/packages/mirinae/src/data-display/markdown/PMarkdown.vue
@@ -10,7 +10,7 @@
 import { computed, defineComponent } from 'vue';
 
 import { render } from 'ejs';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 import { useMarkdown } from '@/hooks/use-markdown/use-markdown';
 

--- a/packages/mirinae/src/data-display/tables/data-table/PDataTable.vue
+++ b/packages/mirinae/src/data-display/tables/data-table/PDataTable.vue
@@ -265,7 +265,8 @@ import {
     defineComponent,
 } from 'vue';
 
-import { get, range } from 'lodash';
+import get from 'lodash/get';
+import range from 'lodash/range';
 
 import {
     DATA_TABLE_CELL_TEXT_ALIGN,

--- a/packages/mirinae/src/data-display/tables/data-table/mock.ts
+++ b/packages/mirinae/src/data-display/tables/data-table/mock.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 const getUser = () => ({
     name: faker.name.firstName(),

--- a/packages/mirinae/src/data-display/tables/definition-table/PDefinitionTable.vue
+++ b/packages/mirinae/src/data-display/tables/definition-table/PDefinitionTable.vue
@@ -68,8 +68,9 @@ import {
     computed, defineComponent, reactive, toRefs, watch,
 } from 'vue';
 
-import { every, get, range } from 'lodash';
-
+import every from 'lodash/every';
+import get from 'lodash/get';
+import range from 'lodash/range';
 
 import { getValueByPath } from '@/data-display/dynamic/helper';
 import { DEFINITION_TABLE_STYLE_TYPE } from '@/data-display/tables/definition-table/config';

--- a/packages/mirinae/src/data-display/text-list/PTextList.vue
+++ b/packages/mirinae/src/data-display/text-list/PTextList.vue
@@ -31,7 +31,7 @@ import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 import type { TextListItem } from '@/data-display/text-list/type';
 import PLink from '@/navigation/link/PLink.vue';

--- a/packages/mirinae/src/data-display/tooltips/PTooltip.stories.ts
+++ b/packages/mirinae/src/data-display/tooltips/PTooltip.stories.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import type { Meta, StoryObj } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 import PBadge from '@/data-display/badge/PBadge.vue';

--- a/packages/mirinae/src/data-display/tooltips/PTooltip.vue
+++ b/packages/mirinae/src/data-display/tooltips/PTooltip.vue
@@ -13,7 +13,7 @@ import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import { VTooltip } from 'v-tooltip';
 import type { TranslateResult } from 'vue-i18n';
 

--- a/packages/mirinae/src/data-display/tree/PTree.vue
+++ b/packages/mirinae/src/data-display/tree/PTree.vue
@@ -99,7 +99,7 @@ import {
     defineComponent, computed, onMounted, reactive, toRefs, watch,
 } from 'vue';
 
-import { unionBy } from 'lodash';
+import unionBy from 'lodash/unionBy';
 import { focus } from 'vue-focus';
 
 import PTextInput from '@/controls/input/text-input/PTextInput.vue';

--- a/packages/mirinae/src/data-display/tree/mock.ts
+++ b/packages/mirinae/src/data-display/tree/mock.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { faker } from '@faker-js/faker';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 export const getTreeData = () => {
     const res = {

--- a/packages/mirinae/src/feedbacks/loading/data-loader/PDataLoader.stories.ts
+++ b/packages/mirinae/src/feedbacks/loading/data-loader/PDataLoader.stories.ts
@@ -2,7 +2,7 @@ import { reactive, toRefs } from 'vue';
 
 import { faker } from '@faker-js/faker';
 import type { Meta, StoryObj } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 import PButton from '@/controls/buttons/button/PButton.vue';

--- a/packages/mirinae/src/feedbacks/loading/data-loader/PDataLoader.vue
+++ b/packages/mirinae/src/feedbacks/loading/data-loader/PDataLoader.vue
@@ -56,7 +56,7 @@ import {
     computed, defineComponent, reactive, toRefs, watch,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { LOADER_TYPES } from '@/feedbacks/loading/data-loader/config';
 import PSkeleton from '@/feedbacks/loading/skeleton/PSkeleton.vue';

--- a/packages/mirinae/src/feedbacks/loading/data-loader/story-helper.ts
+++ b/packages/mirinae/src/feedbacks/loading/data-loader/story-helper.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import type { SBType } from '@storybook/types';
 import type { Args, ArgTypes, Parameters } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { LOADER_TYPES } from '@/feedbacks/loading/data-loader/config';
 import { SPINNER_SIZE } from '@/feedbacks/loading/spinner/type';

--- a/packages/mirinae/src/feedbacks/modals/advanced/table-check-modal/PTableCheckModal.vue
+++ b/packages/mirinae/src/feedbacks/modals/advanced/table-check-modal/PTableCheckModal.vue
@@ -47,7 +47,7 @@ import {
     reactive, computed, toRefs, defineComponent,
 } from 'vue';
 
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import type { TranslateResult } from 'vue-i18n';
 
 import PDataTable from '@/data-display/tables/data-table/PDataTable.vue';

--- a/packages/mirinae/src/hooks/use-context-menu-items/use-context-menu-items.ts
+++ b/packages/mirinae/src/hooks/use-context-menu-items/use-context-menu-items.ts
@@ -3,7 +3,7 @@ import {
     computed, isRef, reactive, ref, toRef,
 } from 'vue';
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import type { MenuItem } from '@/controls/context-menu/type';
 import { getTextHighlightRegex } from '@/utils/helpers';

--- a/packages/mirinae/src/hooks/use-context-menu-style/use-context-menu-style.ts
+++ b/packages/mirinae/src/hooks/use-context-menu-style/use-context-menu-style.ts
@@ -7,7 +7,7 @@ import type Vue from 'vue';
 import {
     computePosition, autoUpdate, offset, flip, size, hide, shift,
 } from '@floating-ui/dom';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 
 // HACK: This is the type definition of the context menu. Only defined exposed methods. This is to prevent type error due to vue2-vue3 incompatibility.
 export interface ISimpleContextMenu {

--- a/packages/mirinae/src/hooks/use-proxy-state/use-proxy-state.ts
+++ b/packages/mirinae/src/hooks/use-proxy-state/use-proxy-state.ts
@@ -3,7 +3,7 @@ import {
     computed, ref, watch,
 } from 'vue';
 
-import { kebabCase } from 'lodash';
+import kebabCase from 'lodash/kebabCase';
 
 /**
  * @name useProxyValue

--- a/packages/mirinae/src/hooks/use-query-search/use-query-search.ts
+++ b/packages/mirinae/src/hooks/use-query-search/use-query-search.ts
@@ -3,9 +3,10 @@ import {
     computed, onMounted, onUnmounted, reactive, ref, watch,
 } from 'vue';
 
-import {
-    cloneDeep, debounce, find, throttle,
-} from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
+import find from 'lodash/find';
+import throttle from 'lodash/throttle';
 
 import {
     defaultHandlerMap, formatterMap,

--- a/packages/mirinae/src/hooks/use-select/use-select.ts
+++ b/packages/mirinae/src/hooks/use-select/use-select.ts
@@ -3,7 +3,8 @@ import {
     computed, reactive, toRefs,
 } from 'vue';
 
-import { pull, remove } from 'lodash';
+import pull from 'lodash/pull';
+import remove from 'lodash/remove';
 
 export interface SelectionPredicate {
     (value: any, current: any): boolean;

--- a/packages/mirinae/src/navigation/tabs/ballon-tab/PBalloonTab.stories.ts
+++ b/packages/mirinae/src/navigation/tabs/ballon-tab/PBalloonTab.stories.ts
@@ -2,7 +2,7 @@ import { reactive, toRefs } from 'vue';
 
 import { faker } from '@faker-js/faker';
 import type { Meta, StoryObj } from '@storybook/vue';
-import { range } from 'lodash';
+import range from 'lodash/range';
 import type { ComponentProps } from 'vue-component-type-helpers';
 
 import { useProxyValue } from '@/hooks';

--- a/packages/mirinae/src/navigation/tabs/tab/PTab.vue
+++ b/packages/mirinae/src/navigation/tabs/tab/PTab.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 
 import { onClickOutside, useResizeObserver } from '@vueuse/core';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 
 import PTextButton from '@/controls/buttons/text-button/PTextButton.vue';
 import PContextMenu from '@/controls/context-menu/PContextMenu.vue';

--- a/packages/mirinae/src/utils/helpers.ts
+++ b/packages/mirinae/src/utils/helpers.ts
@@ -1,6 +1,7 @@
-import {
-    isEmpty, get, toString, sortBy,
-} from 'lodash';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import sortBy from 'lodash/sortBy';
+import toString from 'lodash/toString';
 
 import colors from '@/styles/colors.cjs';
 

--- a/packages/postcss-config-custom/tailwind.config.cjs
+++ b/packages/postcss-config-custom/tailwind.config.cjs
@@ -1,4 +1,4 @@
-const _ = require('lodash');
+const fromPairs = require('lodash/fromPairs');
 const defaultTheme = require('tailwindcss/defaultTheme');
 const plugin = require('tailwindcss/plugin');
 const colors = require('mirinae-foundation/colors.cjs');
@@ -8,18 +8,18 @@ const semanticFont = require('mirinae-foundation/font-size.cjs');
 const tailwindColors = {
     ...colors.semanticColors,
     ...colors.kebabColors,
-}
+};
 
 const rawSize = Array(32)
     .fill('')
     .map((value, idx) => [`${idx}`, `${idx * 0.25}rem`]);
-const size = _.fromPairs(rawSize);
+const size = fromPairs(rawSize);
 
 const rawPercent = [
     '1/2',
 ];
 
-const percent = _.fromPairs(rawPercent.map((value) => [value, `${eval(value) * 100}%`]));
+const percent = fromPairs(rawPercent.map((value) => [value, `${eval(value) * 100}%`]));
 module.exports = {
     theme: {
         borderRadius: {
@@ -45,7 +45,7 @@ module.exports = {
             ...defaultTheme.minWidth,
             ...theme('spacing'),
             ...percent,
-            'full': '100%',
+            full: '100%',
             '2xs': theme('screens.2xs.min'),
             xs: theme('screens.xs.min'),
             sm: theme('screens.sm.min'),
@@ -79,36 +79,36 @@ module.exports = {
             serif: ['Roboto'],
         },
         screens: {
-            '2xs': '375px' ,
-            xs: '478px' ,
-            sm: '576px' ,
-            md: '768px' ,
-            lg: '1024px' ,
-            xl: '1440px' ,
-            '2xl': '1920px' ,
-            '3xl': '2560px' ,
-            mobile: { max:`${screens.mobile.max}px`},
-            tablet: { max:`${screens.tablet.max}px`},
-            laptop: { max:`${screens.laptop.max}px`},
-            desktop: { max:`${screens.desktop.max}px`},
+            '2xs': '375px',
+            xs: '478px',
+            sm: '576px',
+            md: '768px',
+            lg: '1024px',
+            xl: '1440px',
+            '2xl': '1920px',
+            '3xl': '2560px',
+            mobile: { max: `${screens.mobile.max}px` },
+            tablet: { max: `${screens.tablet.max}px` },
+            laptop: { max: `${screens.laptop.max}px` },
+            desktop: { max: `${screens.desktop.max}px` },
         },
         fontSize: {
             ...defaultTheme.fontSize,
-            'display-2xl': semanticFont.semanticFontSize["display-2xl"],
-            'display-xl': semanticFont.semanticFontSize["display-xl"],
-            'display-lg': semanticFont.semanticFontSize["display-lg"],
-            'display-md': semanticFont.semanticFontSize["display-md"],
-            'display-sm': semanticFont.semanticFontSize["display-sm"],
-            'label-xl': semanticFont.semanticFontSize["label-xl"],
-            'label-lg': semanticFont.semanticFontSize["label-lg"],
-            'label-md': semanticFont.semanticFontSize["label-md"],
-            'label-sm': semanticFont.semanticFontSize["label-sm"],
-            'label-xs': semanticFont.semanticFontSize["label-xs"],
-            'paragraph-lg': semanticFont.semanticFontSize["paragraph-lg"],
-            'paragraph-md': semanticFont.semanticFontSize["paragraph-md"],
-            'paragraph-sm': semanticFont.semanticFontSize["paragraph-sm"],
-            'code-lg': semanticFont.semanticFontSize["code-lg"],
-            'code-md': semanticFont.semanticFontSize["code-md"],
+            'display-2xl': semanticFont.semanticFontSize['display-2xl'],
+            'display-xl': semanticFont.semanticFontSize['display-xl'],
+            'display-lg': semanticFont.semanticFontSize['display-lg'],
+            'display-md': semanticFont.semanticFontSize['display-md'],
+            'display-sm': semanticFont.semanticFontSize['display-sm'],
+            'label-xl': semanticFont.semanticFontSize['label-xl'],
+            'label-lg': semanticFont.semanticFontSize['label-lg'],
+            'label-md': semanticFont.semanticFontSize['label-md'],
+            'label-sm': semanticFont.semanticFontSize['label-sm'],
+            'label-xs': semanticFont.semanticFontSize['label-xs'],
+            'paragraph-lg': semanticFont.semanticFontSize['paragraph-lg'],
+            'paragraph-md': semanticFont.semanticFontSize['paragraph-md'],
+            'paragraph-sm': semanticFont.semanticFontSize['paragraph-sm'],
+            'code-lg': semanticFont.semanticFontSize['code-lg'],
+            'code-md': semanticFont.semanticFontSize['code-md'],
         },
     },
     variants: ['responsive', 'important', 'hover'],

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,9 +2,12 @@ import bytes from 'bytes';
 import dayjs from 'dayjs';
 import tz from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
-import {
-    isEmpty, flatten, sortBy, isEqualWith, isEqual, union,
-} from 'lodash';
+import flatten from 'lodash/flatten';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import isEqualWith from 'lodash/isEqualWith';
+import sortBy from 'lodash/sortBy';
+import union from 'lodash/union';
 import { format } from 'numfmt';
 
 dayjs.extend(tz);


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)

#### Per-method lodash imports

Lodash is a CommonJS-based package, which means that using
```js
import { get } from 'lodash';
```
can lead to the entire lodash library being bundled, even if only one function is used.
This prevents proper tree-shaking and unnecessarily increases bundle size.

By switching to per-method imports like
```js
import get from 'lodash/get';
```
we ensure that only the functions we actually use are included,
leading to a smaller, more optimized output.

In this case, the bundle size was reduced from 78.10 kB to 48.57 kB,
just by refactoring the lodash imports.

### Things to Talk About (optional)
