### PR TITLE
feat(alert-service): enhance pagination logic in service page

### DIFF
--- a/apps/web/src/services/alert-manager/v2/components/ServiceList.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useEventListener } from '@vueuse/core';
 import {
     onMounted, reactive, watch, computed,
 } from 'vue';
@@ -198,6 +199,7 @@ const handleNavigateToDetail = (serviceId: string) => {
 };
 
 onMounted(async () => {
+    serviceListPageStore.updateHealthyPageSizeByWindowWidth();
     const { serviceName, unhealthyPage, healthyPage } = route.query;
 
     if (serviceName && typeof serviceName === 'string') {
@@ -234,6 +236,16 @@ onMounted(async () => {
     await fetchBothLists();
 });
 
+// ✅ event listener to change healthy page size (6 -> 8) when window width is 1920px or more
+let prevHealthyPageSize = serviceListPageStore.healthyPageSize;
+useEventListener(window, 'resize', () => {
+    serviceListPageStore.updateHealthyPageSizeByWindowWidth();
+    if (serviceListPageStore.healthyPageSize !== prevHealthyPageSize) {
+        prevHealthyPageSize = serviceListPageStore.healthyPageSize;
+        fetchHealthyServiceList();
+    }
+});
+
 watch(() => serviceListPageStore.unhealthyThisPage, (val) => {
     if (!queryTags.value.some((tag) => tag.key?.name === 'name')) {
         replaceUrlQuery({
@@ -254,7 +266,7 @@ watch(() => serviceListPageStore.healthyThisPage, (val) => {
     handleHealthyPageChange();
 });
 
-watch(async () => route.query.serviceName, async (newServiceName) => {
+watch(async () => route.query.serviceName, async (newServiceName: any) => {
     if (typeof newServiceName === 'string') {
         const nameValues = newServiceName.split(',').map((name) => ({
             key: { name: 'name' },

--- a/apps/web/src/services/alert-manager/v2/components/ServiceListContent.vue
+++ b/apps/web/src/services/alert-manager/v2/components/ServiceListContent.vue
@@ -121,7 +121,7 @@ const handleClickEscalationPolicy = (id: string, escalationPolicyId: string) => 
             />
             <span>{{ state.title }}</span>
         </div>
-        <div class="collapsible-contents flex flex-wrap gap-4">
+        <div class="collapsible-contents">
             <p-select-card v-for="(item, idx) in props.list"
                            :key="`service-item-${idx}`"
                            class="card"
@@ -253,7 +253,34 @@ const handleClickEscalationPolicy = (id: string, escalationPolicyId: string) => 
     .collapsible-contents {
         opacity: 1;
         transition: opacity 0.3s ease, visibility 0.3s ease;
+
+        @apply grid grid-cols-3 gap-4;
     }
+
+    @media (min-width: 120rem) {
+        .collapsible-contents {
+            @apply grid grid-cols-4 gap-4;
+        }
+    }
+
+    @screen laptop {
+        .collapsible-contents {
+            @apply grid grid-cols-3 gap-4;
+        }
+    }
+
+    @screen tablet {
+        .collapsible-contents {
+            @apply grid grid-cols-2 gap-4;
+        }
+    }
+
+    @screen mobile {
+        .collapsible-contents {
+            @apply grid grid-cols-1 gap-4;
+        }
+    }
+
     &.is-collapsed {
         .collapsible-title {
             .arrow-button {
@@ -270,8 +297,7 @@ const handleClickEscalationPolicy = (id: string, escalationPolicyId: string) => 
         }
     }
     .card {
-        width: 28rem;
-        max-width: 28rem;
+        min-width: 25rem;
         padding: 1.25rem 1.5rem 1rem 1.5rem;
         box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.06);
         .card-inner-wrapper {

--- a/apps/web/src/services/alert-manager/v2/stores/service-list-page-store.ts
+++ b/apps/web/src/services/alert-manager/v2/stores/service-list-page-store.ts
@@ -20,10 +20,8 @@ export const useServiceListPageStore = defineStore('page-service-list', {
         setSearchFilters(filters: ConsoleFilter[]) {
             this.searchFilters = filters;
         },
-        updateHealthyPageSizeByWindowWidth() {
-            const width = window.innerWidth;
-            if (width > 1920) this.healthyPageSize = 8;
-            else this.healthyPageSize = 6;
+        setHealthyPageSize(size: number) {
+            this.healthyPageSize = size;
         },
     },
 });

--- a/apps/web/src/services/alert-manager/v2/stores/service-list-page-store.ts
+++ b/apps/web/src/services/alert-manager/v2/stores/service-list-page-store.ts
@@ -5,7 +5,7 @@ import type { ConsoleFilter } from '@cloudforet/core-lib/query/type';
 export const useServiceListPageStore = defineStore('page-service-list', {
     state: () => ({
         unhealthyThisPage: 1,
-        unhealthyPageSize: 10,
+        unhealthyPageSize: 12,
         healthyThisPage: 1,
         healthyPageSize: 6,
         searchFilters: [] as ConsoleFilter[],
@@ -19,6 +19,11 @@ export const useServiceListPageStore = defineStore('page-service-list', {
         },
         setSearchFilters(filters: ConsoleFilter[]) {
             this.searchFilters = filters;
+        },
+        updateHealthyPageSizeByWindowWidth() {
+            const width = window.innerWidth;
+            if (width > 1920) this.healthyPageSize = 8;
+            else this.healthyPageSize = 6;
         },
     },
 });


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
**Update pagination behavior for better UX:**
- Unhealthy services: fixed to 12 items per page
- Healthy services: now responsive — 6 or 8 items per page based on window size

- desktop size
![image](https://github.com/user-attachments/assets/54c8c4c0-195a-4047-9d73-702bf2446d1d)
- laptop size
![image](https://github.com/user-attachments/assets/069f705b-3ba1-48cb-a2d5-cc5b7a6c65d1)



This change addresses feedback that the previous fixed pagination (10/6 items) felt buggy or inconsistent.

### Things to Talk About (optional)
