### PR TITLE
fix(trusted-account): solve trusted-account auto-sync additional option update bug

### DIFF
--- a/apps/web/src/services/service-account/components/ServiceAccountAutoSyncForm.vue
+++ b/apps/web/src/services/service-account/components/ServiceAccountAutoSyncForm.vue
@@ -38,7 +38,6 @@ const state = reactive({
             .hour(utcHour).tz(state.timezone)
             .get('hour')).sort((a, b) => a - b);
     }),
-    additionalOptions: {},
     isScheduleHoursValid: computed(() => ((state.isAutoSyncEnabled) ? !!serviceAccountPageFormState.scheduleHours.length : true)),
     isAdditionalOptionsValid: false,
     isAllValid: computed(() => {
@@ -83,10 +82,9 @@ const handleChangeToggle = (e:boolean) => {
         _state.formState.isAutoSyncEnabled = e;
     });
 };
-
-watch(() => state.additionalOptions, (additionalOptions) => {
-    serviceAccountPageStore.setFormState('additionalOptions', additionalOptions);
-});
+const handleChangeAdditionalOptions = (formData: Record<string, any>) => {
+    serviceAccountPageStore.setFormState('additionalOptions', formData);
+};
 
 watch(() => state.isAllValid, (isAllValid) => {
     serviceAccountPageStore.$patch((_state) => {
@@ -118,9 +116,10 @@ watch(() => state.isAllValid, (isAllValid) => {
                 <p-pane-layout class="p-4 mb-8">
                     <p-json-schema-form v-if="serviceAccountPageStore.getters.autoSyncAdditionalOptionsSchema"
                                         class="p-json-schema-form"
-                                        :form-data.sync="state.additionalOptions"
+                                        :form-data="serviceAccountPageFormState.additionalOptions"
                                         :schema="serviceAccountPageStore.getters.autoSyncAdditionalOptionsSchema"
                                         :language="state.language"
+                                        @update:form-data="handleChangeAdditionalOptions"
                                         @validate="handleAdditionalOptionsValidate"
                     />
                 </p-pane-layout>


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [x] Self-merge allowed for solo developers or urgent changes

### Description (optional)

- Problem: saved values for additional options in Trusted Account auto-sync settings were not displayed in the form due to missing initial value initialization.
- Solution: replaced redundant local state with direct usage of store-managed formState to ensure proper value initialization.

### Things to Talk About (optional)
