### PR TITLE
chore: add common vscode setting option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,10 @@ node_modules.nosync/
 
 # Dev tools
 .DS_Store
-.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+
 .idea
 *.swp
 *.bak
@@ -16,6 +19,9 @@ node_modules.nosync/
 ## Cursor rules : Ignore all files in .cursor directory except specific file (rules)
 .cursor/*
 !.cursor/generate-new-api-clients.mdc
+
+# VS Code workspace files
+*.code-workspace
 
 # Turborepo
 .turbo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "always"
+    },
+    "editor.quickSuggestions": {
+        "strings": true
+    },
+    "eslint.format.enable": true,
+    "eslint.workingDirectories": [{ "mode": "auto" }],
+    "typescript.updateImportsOnFileMove.enabled": "always",
+    "javascript.updateImportsOnFileMove.enabled": "always",
+    "vue.server.hybridMode": "typeScriptPluginOnly",
+    "[typescript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[vue]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,51 @@
+// .vscode/tasks.json
+{
+    "version": "2.0.0",
+    "tasks": [
+      // web
+      {
+        "label": "web:dev",
+        "type": "shell",
+        "command": "npm run dev -- --filter=web",
+      },
+      {
+        "label": "start:web",
+        "type": "shell",
+        "command": "npm run start:web",
+      },
+      // mirinae
+      {
+        "label": "mirinae:build",
+        "type": "shell",
+        "command": "npm run build -- --filter=@cloudforet/mirinae",
+      },
+      {
+        "label": "mirinae:dev",
+        "type": "shell",
+        "command": "npm run dev -- --filter=@cloudforet/mirinae",
+      },
+      // core-lib, util
+      {
+        "label": "core-lib:build",
+        "type": "shell",
+        "command": "npm run build -- --filter=@cloudforet/core-lib",
+      },
+      {
+        "label": "utils:build",
+        "type": "shell",
+        "command": "npm run build -- --filter=@cloudforet/utils",
+      },
+      // storybook
+      {
+        "label": "mirinae-storybook:dev",
+        "type": "shell",
+        "command": "npm run dev -- --filter=mirinae-storybook",
+      },
+      // api-doc
+      {
+        "label": "api-doc",
+        "type": "shell",
+        "command": "npm run api-doc -- --filter=web",
+      },
+    ]
+  }

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
     root: false,
-    extends: ["custom"],
+    extends: ['custom'],
 
     rules: {
         // eslint-plugin-import rules
@@ -77,10 +77,14 @@ module.exports = {
     ignorePatterns: ['src/assets/**', '**/node_modules/**', 'public/lottie.js'],
     settings: {
         'import/parsers': {
-            '@typescript-eslint/parser': ['.ts'],
+            '@typescript-eslint/parser': ['.ts', '.tsx'],
+            'vue-eslint-parser': ['.vue'],
         },
         'import/resolver': {
-            typescript: {},
+            node: {
+                extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue'],
+                moduleDirectory: ['node_modules', '../../node_modules'],
+            },
         },
     },
 };

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -82,8 +82,7 @@ module.exports = {
         },
         'import/resolver': {
             node: {
-                extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue'],
-                moduleDirectory: ['node_modules', '../../node_modules'],
+                extensions: ['.js', '.ts', '.vue'],
             },
         },
     },

--- a/apps/web/src/services/ops-flow/components/TaskCategoryDeleteModal.vue
+++ b/apps/web/src/services/ops-flow/components/TaskCategoryDeleteModal.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
 
-import { PButtonModal } from '@cloudforet/mirinae/';
+import { PButtonModal } from '@cloudforet/mirinae';
 
 import { useTaskCategoryApi } from '@/api-clients/opsflow/task-category/composables/use-task-category-api';
 import type { TaskModel } from '@/api-clients/opsflow/task/schema/model';


### PR DESCRIPTION
### Skip Review (optional)
- [x] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
I have added a `.vscode/settings.json` file to establish a baseline development environment for working in VS Code or Cursor.

For those who wish to apply their own personal settings, you can use the VS Code [Code Workspace](https://www.google.com/search?q=https://code.visualstudio.com/docs/editing/workspaces) feature. This allows you to add or override settings locally without modifying the shared project files.

#### Custom Settings Usage
Instead of opening the project folder directly, you should now open the project using the .code-workspace file. You can do this via File > Open Workspace from File... in the VS Code menu, or by running code my-project.code-workspace in your terminal.

When you open the project this way, VS Code first loads the shared settings from `.vscode/settings.json` and then applies your personal settings from the `.code-workspace` file, overriding any shared settings where conflicts exist. This allows you to manage your personal preferences freely without worrying about committing them to the repository.

**Example Usage**
```json
// .vscode/console.code-workspace
{
	"folders": [
		{
			"path": ".."
		}
	],
	"settings": {
		    // personal custom settings
			"editor.fontSize": 14,
			"debug.console.fontSize": 15,
			"scm.inputFontSize": 14,
			"chat.editor.fontSize": 14,
			"files.autoSave": "afterDelay",
	}
}
```

---


vscode 또는 cursor로 작업 시, 개발환경 기본 세팅에대한 가이드를 남기기 위해 settings.json을 추가하였습니다.

이후 로컬에서 개인적인 세팅을 원하시는 분들은 vscode의 [Code Workspace](https://code.visualstudio.com/docs/editing/workspaces/workspaces)기능을 사용하여 추가적인 settings.json 설정이 가능합니다.

#### Custom Settings Usage

이제부터 프로젝트를 열 때 폴더를 직접 여는 대신, `my-project.code-workspace` 파일을 통해 VS Code를 실행해야 합니다 (파일 > 워크스페이스 열기... 또는 터미널에서 `code my-project.code-workspace`).

이렇게 하면 VS Code는 `.vscode/settings.json`의 공유 설정을 먼저 불러온 뒤, `*.code-workspace` 파일의 개인 설정을 그 위에 덮어쓰게 됩니다. 따라서 커밋 걱정 없이 자유롭게 개인 설정을 관리할 수 있습니다.

**사용 예시**
```json
// .vscode/console.code-workspace
{
	"folders": [
		{
			"path": ".."
		}
	],
	"settings": {
		    // 개인 세팅
			"editor.fontSize": 14,
			"debug.console.fontSize": 15,
			"scm.inputFontSize": 14,
			"chat.editor.fontSize": 14,
			"files.autoSave": "afterDelay",
	}
}
```

### Things to Talk About (optional)
