### PR TITLE
feat(reference-data-model): refactor single pipeline for reference repository

### DIFF
--- a/apps/web/src/query/resource-query/reference-model/composables/use-reference-data-model.ts
+++ b/apps/web/src/query/resource-query/reference-model/composables/use-reference-data-model.ts
@@ -6,7 +6,7 @@ import {
 import { referenceQueryClient as queryClient } from '@/query/clients';
 import { useReferenceQueryKey } from '@/query/core/query-key/use-reference-query-key';
 import { useReferenceReactiveCache } from '@/query/resource-query/reference-model/composables/_internal/use-reference-reactive-cache';
-import ReferenceRepository from '@/query/resource-query/reference-model/core/reference-repository';
+import { getRepository } from '@/query/resource-query/reference-model/core/repository-registry';
 import type { ReferenceItem, ReferenceDataModelFetchConfig } from '@/query/resource-query/reference-model/types/reference-type';
 import { createEventEmitter } from '@/query/resource-query/reference-model/utils/create-event-emitter';
 import { makeReferenceProxy } from '@/query/resource-query/reference-model/utils/reference-proxy-helper';
@@ -23,13 +23,14 @@ export const useReferenceDataModel = <T extends Record<string, any>, R extends R
     const { key: queryKey } = useReferenceQueryKey(resourceKey);
     const idRequestBus = createEventEmitter();
 
-    const referenceRepository = new ReferenceRepository(
+    const referenceRepository = getRepository(
         resourceKey,
         queryClient,
         queryKey.value,
         fetchConfig.listFetcher,
         fetchConfig.query,
     );
+
 
     idRequestBus.on(ID_REQUEST_BUS_KEY, (id) => {
         referenceRepository.requestItem(id);

--- a/apps/web/src/query/resource-query/reference-model/core/repository-registry.ts
+++ b/apps/web/src/query/resource-query/reference-model/core/repository-registry.ts
@@ -1,4 +1,5 @@
-import type { QueryClient } from '@tanstack/query-core/build/modern';
+
+import type { QueryClient } from '@tanstack/query-core';
 
 import type { Query } from '@cloudforet/core-lib/space-connector/type';
 
@@ -7,9 +8,7 @@ import type { QueryKeyArray } from '@/query/core/query-key/types/query-key-type'
 import ReferenceRepository from '@/query/resource-query/reference-model/core/reference-repository';
 import type { ResourceKeyType } from '@/query/resource-query/shared/types/resource-type';
 
-
-
-const repositoryRegistry = new Map<Record<string, ReferenceRepository>>();
+const repositoryRegistry = new Map<ResourceKeyType, ReferenceRepository<any>>();
 
 
 export const getRepository = <T extends Record<string, any>>(

--- a/apps/web/src/query/resource-query/reference-model/core/repository-registry.ts
+++ b/apps/web/src/query/resource-query/reference-model/core/repository-registry.ts
@@ -1,0 +1,36 @@
+import type { QueryClient } from '@tanstack/query-core/build/modern';
+
+import type { Query } from '@cloudforet/core-lib/space-connector/type';
+
+import type { ListResponse } from '@/api-clients/_common/schema/api-verbs/list';
+import type { QueryKeyArray } from '@/query/core/query-key/types/query-key-type';
+import ReferenceRepository from '@/query/resource-query/reference-model/core/reference-repository';
+import type { ResourceKeyType } from '@/query/resource-query/shared/types/resource-type';
+
+
+
+const repositoryRegistry = new Map<Record<string, ReferenceRepository>>();
+
+
+export const getRepository = <T extends Record<string, any>>(
+    resourceKey: ResourceKeyType,
+    queryClient: QueryClient,
+    queryKey: QueryKeyArray,
+    listFetcher: (params: any) => Promise<ListResponse<T>>,
+    listQuery?: Query,
+): ReferenceRepository<T> => {
+    if (!repositoryRegistry.has(resourceKey)) {
+        if (import.meta.env.DEV) {
+            console.log(`Creating new Reference Repository for: [${resourceKey}] Resource`);
+        }
+        const repository = new ReferenceRepository<T>(
+            resourceKey,
+            queryClient,
+            queryKey,
+            listFetcher,
+            listQuery,
+        );
+        repositoryRegistry.set(resourceKey, repository);
+    }
+    return repositoryRegistry.get(resourceKey) as ReferenceRepository<T>;
+};


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)

#### Summary

- Fixed an issue where multiple `ReferenceRepository` instances were being created per resource, leading to redundant API calls.
- Introduced a **Repository Registry pattern** to ensure that each resource has a single shared `Repository` instance across the entire application.

#### Key Changes
- Added `repositoryRegistry.ts`, a centralized registry using a `Map` to store and reuse `ReferenceRepository` instances
- Replaced all `new ReferenceRepository(...)` instantiations with `getRepository(...)` calls
- This change ensures batching and deduplication happen at the global level
- Improves API efficiency, prevents redundant network requests, and maintains cache consistency

#### Impact
- Even when multiple components request the same resource at the same time, only **a single deduplicated API call** will be made
- Works seamlessly with `TanStack Query`'s caching system, while still supporting manual `getQueryData` / `setQueryData` flows

---

#### 요약
- `ReferenceRepository` 인스턴스가 리소스별로 중복 생성되면서, 중복된 API 요청이 발생하는 문제를 해결했습니다.
- 이를 위해 **"Repository Registry" 패턴**을 도입하여, 특정 리소스에 대한 Repository가 애플리케이션 전체에서 단일 인스턴스로 공유되도록 리팩토링했습니다.

#### 주요 변경사항
- `repositoryRegistry.ts`를 생성하여 중앙 등록소 역할을 하는 Map 구조 추가
- 기존의 `new ReferenceRepository(...)` 패턴을 `getRepository(...)` 호출로 변경
- `IdBatcher`도 Repository 내부에 포함되어 있으므로, 결과적으로 리소스별로 하나의 Batcher만 유지됨
- 중복 요청 방지, 네트워크 자원 효율화, 캐시 일관성 개선 효과

#### 기대 효과
- 동시에 여러 컴포넌트에서 동일한 리소스를 참조할 경우에도 중복 API 요청 없이 단일 요청으로 처리됨
- `TanStack Query`의 캐시 일관성을 유지하면서, 커스텀 로직(`getQueryData` → API 호출 → `setQueryData`)과도 충돌 없음

### Things to Talk About (optional)
