### PR TITLE
fix(cloud-service-monitoring): solve wrong usage of data-loader in metric-chart

### DIFF
--- a/apps/web/src/common/modules/monitoring/MetricChart.vue
+++ b/apps/web/src/common/modules/monitoring/MetricChart.vue
@@ -83,7 +83,7 @@ const state = reactive({
         },
         series: state.chartData,
     })),
-    chartDataForDataLoader: computed<ChartData[]|undefined>(() => state.chartData?.filter((item) => item?.data?.length > 0) ?? undefined),
+    chartDataForDataLoader: computed<ChartData[]|undefined>(() => state.chartData?.filter((item) => !isEmpty(item?.data)) ?? undefined),
 });
 
 const drawChart = (rawData) => {

--- a/apps/web/src/common/modules/monitoring/MetricChart.vue
+++ b/apps/web/src/common/modules/monitoring/MetricChart.vue
@@ -83,6 +83,7 @@ const state = reactive({
         },
         series: state.chartData,
     })),
+    chartDataForDataLoader: computed<ChartData[]|undefined>(() => state.chartData?.filter((item) => item?.data?.length > 0) ?? undefined),
 });
 
 const drawChart = (rawData) => {
@@ -125,7 +126,7 @@ useResizeObserver(chartContext, throttle(() => {
             <p-spinner v-if="props.loading && state.chart" />
         </div>
         <p-data-loader :loading="loading && !state.chart"
-                       :data="state.chartData"
+                       :data="state.chartDataForDataLoader"
                        class="chart-wrapper"
                        show-data-from-scratch
         >


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
SSIA

- `state.chartData` is an array with at least one element in `MetricChart.vue`


### Things to Talk About (optional)
