### PR TITLE
fix: fix reset password toggle logic for local users

### DIFF
--- a/apps/web/src/services/iam/components/UserManagementAddModal.vue
+++ b/apps/web/src/services/iam/components/UserManagementAddModal.vue
@@ -111,12 +111,11 @@ const handleChangeInput = (items) => {
         state.localUserItem = state.userList.filter((item) => item.auth_type === 'EMAIL' || item.auth_type === 'ID');
         state.resetPasswordVisible = state.localUserItem.length > 0 && newUserItem.length > 0;
         const emailUsers = state.userList.filter((item) => item.auth_type === 'EMAIL');
-        if (userPageState.isAdminMode) {
-            if (state.userList.length === 0) {
-                state.isResetPassword = true;
-            } else if (!state.isResetPassword && (emailUsers.length === state.userList.length) && storeState.smtpEnabled) {
-                state.isResetPassword = false;
-            }
+
+        if (state.userList.length === 0) {
+            state.isResetPassword = true;
+        } else if (!state.isResetPassword && (emailUsers.length === state.userList.length) && storeState.smtpEnabled) {
+            state.isResetPassword = false;
         } else {
             const hasNonEmailLocalUser = state.userList.some((item) => (item.auth_type === 'ID' || item.auth_type === 'LOCAL') && !item.user_id?.includes('@'));
             state.isResetPassword = !hasNonEmailLocalUser && emailUsers.length > 0 && storeState.smtpEnabled;

--- a/apps/web/src/services/iam/components/UserManagementAddModal.vue
+++ b/apps/web/src/services/iam/components/UserManagementAddModal.vue
@@ -111,10 +111,15 @@ const handleChangeInput = (items) => {
         state.localUserItem = state.userList.filter((item) => item.auth_type === 'EMAIL' || item.auth_type === 'ID');
         state.resetPasswordVisible = state.localUserItem.length > 0 && newUserItem.length > 0;
         const emailUsers = state.userList.filter((item) => item.auth_type === 'EMAIL');
-        if (state.userList.length === 0) {
-            state.isResetPassword = true;
-        } else if (!state.isResetPassword && (emailUsers.length === state.userList.length) && storeState.smtpEnabled) {
-            state.isResetPassword = false;
+        if (userPageState.isAdminMode) {
+            if (state.userList.length === 0) {
+                state.isResetPassword = true;
+            } else if (!state.isResetPassword && (emailUsers.length === state.userList.length) && storeState.smtpEnabled) {
+                state.isResetPassword = false;
+            }
+        } else {
+            const hasNonEmailLocalUser = state.userList.some((item) => (item.auth_type === 'ID' || item.auth_type === 'LOCAL') && !item.user_id?.includes('@'));
+            state.isResetPassword = !hasNonEmailLocalUser && emailUsers.length > 0 && storeState.smtpEnabled;
         }
         state.disabledResetPassword = (emailUsers.length !== state.userList.length) || !storeState.smtpEnabled;
     }

--- a/apps/web/src/services/iam/components/UserManagementAddModal.vue
+++ b/apps/web/src/services/iam/components/UserManagementAddModal.vue
@@ -112,9 +112,7 @@ const handleChangeInput = (items) => {
         state.resetPasswordVisible = state.localUserItem.length > 0 && newUserItem.length > 0;
         const emailUsers = state.userList.filter((item) => item.auth_type === 'EMAIL');
 
-        if (state.userList.length === 0) {
-            state.isResetPassword = true;
-        } else if (!state.isResetPassword && (emailUsers.length === state.userList.length) && storeState.smtpEnabled) {
+        if (!state.isResetPassword && (emailUsers.length === state.userList.length) && storeState.smtpEnabled) {
             state.isResetPassword = false;
         } else {
             const hasNonEmailLocalUser = state.userList.some((item) => (item.auth_type === 'ID' || item.auth_type === 'LOCAL') && !item.user_id?.includes('@'));


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)
- Fixed a bug where the “Send password reset link” toggle was incorrectly enabled when inviting a Local ID user from the workspace user page. The toggle should remain off for non-email users.

### Things to Talk About (optional)
