### PR TITLE
feat: Implement resource-cache synchronization Logic

### DIFF
--- a/apps/web/src/api-clients/alert-manager/escalation-policy/composables/use-escalation-policy-api.ts
+++ b/apps/web/src/api-clients/alert-manager/escalation-policy/composables/use-escalation-policy-api.ts
@@ -7,18 +7,20 @@ import type { EscalationPolicyGetParameters } from '@/api-clients/alert-manager/
 import type { EscalationPolicyListParameters } from '@/api-clients/alert-manager/escalation-policy/schema/api-verbs/list';
 import type { EscalationPolicyUpdateParameters } from '@/api-clients/alert-manager/escalation-policy/schema/api-verbs/update';
 import type { EscalationPolicyModel } from '@/api-clients/alert-manager/escalation-policy/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useEscalationPolicyApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('alertManagerEscalationPolicy');
+
     const actions = {
-        create: SpaceConnector.clientV2.alertManager.escalationPolicy.create<EscalationPolicyCreateParameters, EscalationPolicyModel>,
-        delete: SpaceConnector.clientV2.alertManager.escalationPolicy.delete<EscalationPolicyDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.escalationPolicy.create<EscalationPolicyCreateParameters, EscalationPolicyModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.escalationPolicy.delete<EscalationPolicyDeleteParameters>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.escalationPolicy.update<EscalationPolicyUpdateParameters, EscalationPolicyModel>),
         get: SpaceConnector.clientV2.alertManager.escalationPolicy.get<EscalationPolicyGetParameters, EscalationPolicyModel>,
         list: SpaceConnector.clientV2.alertManager.escalationPolicy.list<EscalationPolicyListParameters, ListResponse<EscalationPolicyModel>>,
-        update: SpaceConnector.clientV2.alertManager.escalationPolicy.update<EscalationPolicyUpdateParameters, EscalationPolicyModel>,
     };
 
     return {
         escalationPolicyAPI: actions,
     };
 };
-

--- a/apps/web/src/api-clients/alert-manager/service/composables/use-service-api.ts
+++ b/apps/web/src/api-clients/alert-manager/service/composables/use-service-api.ts
@@ -8,15 +8,18 @@ import type { ServiceGetParameters } from '@/api-clients/alert-manager/service/s
 import type { ServiceListParameters } from '@/api-clients/alert-manager/service/schema/api-verbs/list';
 import type { ServiceUpdateParameters } from '@/api-clients/alert-manager/service/schema/api-verbs/update';
 import type { ServiceModel } from '@/api-clients/alert-manager/service/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useServiceApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('service');
+
     const actions = {
-        changeMembers: SpaceConnector.clientV2.alertManager.service.changeMembers<ServiceChangeMembersParameters, ServiceModel>,
-        create: SpaceConnector.clientV2.alertManager.service.create<ServiceCreateParameters, ServiceModel>,
-        delete: SpaceConnector.clientV2.alertManager.service.delete<ServiceDeleteParameters>,
+        changeMembers: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.service.changeMembers<ServiceChangeMembersParameters, ServiceModel>),
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.service.create<ServiceCreateParameters, ServiceModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.service.delete<ServiceDeleteParameters>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.service.update<ServiceUpdateParameters, ServiceModel>),
         get: SpaceConnector.clientV2.alertManager.service.get<ServiceGetParameters, ServiceModel>,
         list: SpaceConnector.clientV2.alertManager.service.list<ServiceListParameters, ListResponse<ServiceModel>>,
-        update: SpaceConnector.clientV2.alertManager.service.update<ServiceUpdateParameters, ServiceModel>,
     };
 
     return {

--- a/apps/web/src/api-clients/alert-manager/webhook/composables/use-webhook-api.ts
+++ b/apps/web/src/api-clients/alert-manager/webhook/composables/use-webhook-api.ts
@@ -13,20 +13,23 @@ import type { WebhookUpdateMessageFormatParameters } from '@/api-clients/alert-m
 import type { WebhookUpdatePluginParameters } from '@/api-clients/alert-manager/webhook/schema/api-verbs/update-plugin';
 import type { WebhookVerifyPluginParameters } from '@/api-clients/alert-manager/webhook/schema/api-verbs/verify-plugin';
 import type { WebhookListErrorsModel, WebhookModel } from '@/api-clients/alert-manager/webhook/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useWebhookApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('alertManagerWebhook');
+
     const actions = {
-        create: SpaceConnector.clientV2.alertManager.webhook.create<WebhookCreateParameters, WebhookModel>,
-        delete: SpaceConnector.clientV2.alertManager.webhook.delete<WebhookDeleteParameters>,
-        disable: SpaceConnector.clientV2.alertManager.webhook.disable<WebhookDisableParameters>,
-        enable: SpaceConnector.clientV2.alertManager.webhook.enable<WebhookEnableParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.webhook.create<WebhookCreateParameters, WebhookModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.webhook.delete<WebhookDeleteParameters>),
+        disable: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.webhook.disable<WebhookDisableParameters>),
+        enable: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.webhook.enable<WebhookEnableParameters>),
         get: SpaceConnector.clientV2.alertManager.webhook.get<WebhookGetParameters, WebhookModel>,
         listErrors: SpaceConnector.clientV2.alertManager.webhook.listErrors<WebhookListErrorsParameters, ListResponse<WebhookListErrorsModel>>,
         list: SpaceConnector.clientV2.alertManager.webhook.list<WebhookListParameters, ListResponse<WebhookModel>>,
-        updateMessageFormat: SpaceConnector.clientV2.alertManager.webhook.updateMessageFormat<WebhookUpdateMessageFormatParameters, WebhookModel>,
-        updatePlugin: SpaceConnector.clientV2.alertManager.webhook.updatePlugin<WebhookUpdatePluginParameters, WebhookModel>,
-        update: SpaceConnector.clientV2.alertManager.webhook.update<WebhookUpdateParameters, WebhookModel>,
-        verifyPlugin: SpaceConnector.clientV2.alertManager.webhook.verifyPlugin<WebhookVerifyPluginParameters, WebhookModel>,
+        updateMessageFormat: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.webhook.updateMessageFormat<WebhookUpdateMessageFormatParameters, WebhookModel>),
+        updatePlugin: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.webhook.updatePlugin<WebhookUpdatePluginParameters, WebhookModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.webhook.update<WebhookUpdateParameters, WebhookModel>),
+        verifyPlugin: wrapResourceCacheRefresh(SpaceConnector.clientV2.alertManager.webhook.verifyPlugin<WebhookVerifyPluginParameters, WebhookModel>),
     };
 
     return {

--- a/apps/web/src/api-clients/cost-analysis/data-source/composables/use-data-source-api.ts
+++ b/apps/web/src/api-clients/cost-analysis/data-source/composables/use-data-source-api.ts
@@ -6,13 +6,16 @@ import type { CostDataSourceListParameters } from '@/api-clients/cost-analysis/d
 import type { CostDataSourceSyncParameters } from '@/api-clients/cost-analysis/data-source/schema/api-verbs/sync';
 import type { CostDataSourceUpdatePermissionsParameters } from '@/api-clients/cost-analysis/data-source/schema/api-verbs/update-permissions';
 import type { CostDataSourceModel } from '@/api-clients/cost-analysis/data-source/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useDataSourceApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('costDataSource');
+
     const actions = {
         get: SpaceConnector.clientV2.costAnalysis.dataSource.get<CostDataSourceGetParameters, CostDataSourceModel>,
         list: SpaceConnector.clientV2.costAnalysis.dataSource.list<CostDataSourceListParameters, ListResponse<CostDataSourceModel>>,
-        sync: SpaceConnector.clientV2.costAnalysis.dataSource.sync<CostDataSourceSyncParameters>,
-        updatePermissions: SpaceConnector.clientV2.costAnalysis.dataSource.updatePermissions<CostDataSourceUpdatePermissionsParameters, CostDataSourceModel>,
+        sync: wrapResourceCacheRefresh(SpaceConnector.clientV2.costAnalysis.dataSource.sync<CostDataSourceSyncParameters>),
+        updatePermissions: wrapResourceCacheRefresh(SpaceConnector.clientV2.costAnalysis.dataSource.updatePermissions<CostDataSourceUpdatePermissionsParameters, CostDataSourceModel>),
     };
 
     return {

--- a/apps/web/src/api-clients/identity/app/composables/use-app-api.ts
+++ b/apps/web/src/api-clients/identity/app/composables/use-app-api.ts
@@ -12,17 +12,20 @@ import type { AppListParameters } from '@/api-clients/identity/app/schema/api-ve
 import type { AppStatParameters } from '@/api-clients/identity/app/schema/api-verbs/stat';
 import type { AppUpdateParameters } from '@/api-clients/identity/app/schema/api-verbs/update';
 import type { AppModel } from '@/api-clients/identity/app/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useAppApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('app');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.app.create<AppCreateParameters, AppModel>,
-        update: SpaceConnector.clientV2.identity.app.update<AppUpdateParameters, AppModel>,
-        delete: SpaceConnector.clientV2.identity.app.delete<AppDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.app.create<AppCreateParameters, AppModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.app.update<AppUpdateParameters, AppModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.app.delete<AppDeleteParameters>),
         get: SpaceConnector.clientV2.identity.app.get<AppGetParameters, AppModel>,
         list: SpaceConnector.clientV2.identity.app.list<AppListParameters, ListResponse<AppModel>>,
-        enable: SpaceConnector.clientV2.identity.app.enable<AppEnableParameters, AppModel>,
-        disable: SpaceConnector.clientV2.identity.app.disable<AppDisableParameters, AppModel>,
-        generateClientSecret: SpaceConnector.clientV2.identity.app.generateClientSecret<AppGenerateClientSecretParameters>,
+        enable: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.app.enable<AppEnableParameters, AppModel>),
+        disable: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.app.disable<AppDisableParameters, AppModel>),
+        generateClientSecret: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.app.generateClientSecret<AppGenerateClientSecretParameters>),
         stat: SpaceConnector.clientV2.identity.app.stat<AppStatParameters, StatResponse>,
     };
 

--- a/apps/web/src/api-clients/identity/project-group/composables/use-project-group-api.ts
+++ b/apps/web/src/api-clients/identity/project-group/composables/use-project-group-api.ts
@@ -12,18 +12,21 @@ import type { ProjectGroupRemoveUsersParameters } from '@/api-clients/identity/p
 import type { ProjectGroupStatParameters } from '@/api-clients/identity/project-group/schema/api-verbs/stat';
 import type { ProjectGroupUpdateParameters } from '@/api-clients/identity/project-group/schema/api-verbs/update';
 import type { ProjectGroupModel } from '@/api-clients/identity/project-group/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 
 export const useProjectGroupApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('projectGroup');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.projectGroup.create<ProjectGroupCreateParameters, ProjectGroupModel>,
-        update: SpaceConnector.clientV2.identity.projectGroup.update<ProjectGroupUpdateParameters, ProjectGroupModel>,
-        delete: SpaceConnector.clientV2.identity.projectGroup.delete<ProjectGroupDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.projectGroup.create<ProjectGroupCreateParameters, ProjectGroupModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.projectGroup.update<ProjectGroupUpdateParameters, ProjectGroupModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.projectGroup.delete<ProjectGroupDeleteParameters>),
         get: SpaceConnector.clientV2.identity.projectGroup.get<ProjectGroupGetParameters, ProjectGroupModel>,
         list: SpaceConnector.clientV2.identity.projectGroup.list<ProjectGroupListParameters, ListResponse<ProjectGroupModel>>,
-        addUsers: SpaceConnector.clientV2.identity.projectGroup.addUsers<ProjectGroupAddUsersParameters, ProjectGroupModel>,
-        removeUsers: SpaceConnector.clientV2.identity.projectGroup.removeUsers<ProjectGroupRemoveUsersParameters, ProjectGroupModel>,
-        changeParentGroup: SpaceConnector.clientV2.identity.projectGroup.changeParentGroup<ProjectGroupChangeParentGroupParameters, ProjectGroupModel>,
+        addUsers: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.projectGroup.addUsers<ProjectGroupAddUsersParameters, ProjectGroupModel>),
+        removeUsers: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.projectGroup.removeUsers<ProjectGroupRemoveUsersParameters, ProjectGroupModel>),
+        changeParentGroup: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.projectGroup.changeParentGroup<ProjectGroupChangeParentGroupParameters, ProjectGroupModel>),
         stat: SpaceConnector.clientV2.identity.projectGroup.stat<ProjectGroupStatParameters, StatResponse>,
     };
 

--- a/apps/web/src/api-clients/identity/project/composables/use-project-api.ts
+++ b/apps/web/src/api-clients/identity/project/composables/use-project-api.ts
@@ -13,19 +13,22 @@ import type { ProjectStatParameters } from '@/api-clients/identity/project/schem
 import type { ProjectUpdateParameters } from '@/api-clients/identity/project/schema/api-verbs/udpate';
 import type { ProjectUpdateProjectTypeParameters } from '@/api-clients/identity/project/schema/api-verbs/update-project-type';
 import type { ProjectModel } from '@/api-clients/identity/project/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 
 export const useProjectApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('project');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.project.create<ProjectCreateParameters, ProjectModel>,
-        update: SpaceConnector.clientV2.identity.project.update<ProjectUpdateParameters, ProjectModel>,
-        delete: SpaceConnector.clientV2.identity.project.delete<ProjectDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.project.create<ProjectCreateParameters, ProjectModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.project.update<ProjectUpdateParameters, ProjectModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.project.delete<ProjectDeleteParameters>),
         get: SpaceConnector.clientV2.identity.project.get<ProjectGetParameters, ProjectModel>,
         list: SpaceConnector.clientV2.identity.project.list<ProjectListParameters, ListResponse<ProjectModel>>,
-        addUsers: SpaceConnector.clientV2.identity.project.addUsers<ProjectAddUsersParameters, ProjectModel>,
-        removeUsers: SpaceConnector.clientV2.identity.project.removeUsers<ProjectRemoveUsersParameters, ProjectModel>,
-        changeProjectGroup: SpaceConnector.clientV2.identity.project.changeProjectGroup<ProjectChangeProjectGroupParameters, ProjectModel>,
-        updateProjectType: SpaceConnector.clientV2.identity.project.updateProjectType<ProjectUpdateProjectTypeParameters, ProjectModel>,
+        addUsers: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.project.addUsers<ProjectAddUsersParameters, ProjectModel>),
+        removeUsers: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.project.removeUsers<ProjectRemoveUsersParameters, ProjectModel>),
+        changeProjectGroup: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.project.changeProjectGroup<ProjectChangeProjectGroupParameters, ProjectModel>),
+        updateProjectType: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.project.updateProjectType<ProjectUpdateProjectTypeParameters, ProjectModel>),
         stat: SpaceConnector.clientV2.identity.project.stat<ProjectStatParameters, StatResponse>,
     };
 

--- a/apps/web/src/api-clients/identity/provider/composables/use-provider-api.ts
+++ b/apps/web/src/api-clients/identity/provider/composables/use-provider-api.ts
@@ -9,13 +9,16 @@ import type { ProviderListParameters } from '@/api-clients/identity/provider/sch
 import type { ProviderStatParameters } from '@/api-clients/identity/provider/schema/api-verbs/stat';
 import type { ProviderUpdateParameters } from '@/api-clients/identity/provider/schema/api-verbs/update';
 import type { ProviderModel } from '@/api-clients/identity/provider/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 
 export const useProviderApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('provider');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.provider.create<ProviderCreateParameters, ProviderModel>,
-        update: SpaceConnector.clientV2.identity.provider.update<ProviderUpdateParameters, ProviderModel>,
-        delete: SpaceConnector.clientV2.identity.provider.delete<ProviderDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.provider.create<ProviderCreateParameters, ProviderModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.provider.update<ProviderUpdateParameters, ProviderModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.provider.delete<ProviderDeleteParameters>),
         get: SpaceConnector.clientV2.identity.provider.get<ProviderGetParameters, ProviderModel>,
         list: SpaceConnector.clientV2.identity.provider.list<ProviderListParameters, ListResponse<ProviderModel>>,
         stat: SpaceConnector.clientV2.identity.provider.stat<ProviderStatParameters, StatResponse>,

--- a/apps/web/src/api-clients/identity/role/composables/use-role-api.ts
+++ b/apps/web/src/api-clients/identity/role/composables/use-role-api.ts
@@ -10,16 +10,19 @@ import type { RoleListParameters } from '@/api-clients/identity/role/schema/api-
 import type { RoleListBasicRoleParameters } from '@/api-clients/identity/role/schema/api-verbs/list-basic-role';
 import type { RoleUpdateParameters } from '@/api-clients/identity/role/schema/api-verbs/update';
 import type { BasicRoleModel, RoleModel } from '@/api-clients/identity/role/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useRoleApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('role');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.role.create<RoleCreateParameters, RoleModel>,
-        update: SpaceConnector.clientV2.identity.role.update<RoleUpdateParameters, RoleModel>,
-        delete: SpaceConnector.clientV2.identity.role.delete<RoleDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.role.create<RoleCreateParameters, RoleModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.role.update<RoleUpdateParameters, RoleModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.role.delete<RoleDeleteParameters>),
         get: SpaceConnector.clientV2.identity.role.get<RoleGetParameters, RoleModel>,
         list: SpaceConnector.clientV2.identity.role.list<RoleListParameters, ListResponse<RoleModel>>,
-        enable: SpaceConnector.clientV2.identity.role.enable<RoleEnableParameters, RoleModel>,
-        disable: SpaceConnector.clientV2.identity.role.disable<RoleDisableParameters, RoleModel>,
+        enable: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.role.enable<RoleEnableParameters, RoleModel>),
+        disable: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.role.disable<RoleDisableParameters, RoleModel>),
         listBasicRole: SpaceConnector.clientV2.identity.role.listBasicRole<RoleListBasicRoleParameters, ListResponse<BasicRoleModel>>,
     };
 

--- a/apps/web/src/api-clients/identity/service-account/composables/use-service-account-api.ts
+++ b/apps/web/src/api-clients/identity/service-account/composables/use-service-account-api.ts
@@ -11,18 +11,21 @@ import type { ServiceAccountStatParameters } from '@/api-clients/identity/servic
 import type { ServiceAccountUpdateParameters } from '@/api-clients/identity/service-account/schema/api-verbs/update';
 import type { ServiceAccountUpdateSecretDataParameters } from '@/api-clients/identity/service-account/schema/api-verbs/update-secret-data';
 import type { ServiceAccountModel } from '@/api-clients/identity/service-account/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 
 export const useServiceAccountApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('serviceAccount');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.serviceAccount.create<ServiceAccountCreateParameters, ServiceAccountModel>,
-        update: SpaceConnector.clientV2.identity.serviceAccount.update<ServiceAccountUpdateParameters, ServiceAccountModel>,
-        delete: SpaceConnector.clientV2.identity.serviceAccount.delete<ServiceAccountDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.serviceAccount.create<ServiceAccountCreateParameters, ServiceAccountModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.serviceAccount.update<ServiceAccountUpdateParameters, ServiceAccountModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.serviceAccount.delete<ServiceAccountDeleteParameters>),
         get: SpaceConnector.clientV2.identity.serviceAccount.get<ServiceAccountGetParameters, ServiceAccountModel>,
         list: SpaceConnector.clientV2.identity.serviceAccount.list<ServiceAccountListParameters, ListResponse<ServiceAccountModel>>,
         stat: SpaceConnector.clientV2.identity.serviceAccount.stat<ServiceAccountStatParameters, StatResponse>,
-        updateSecretData: SpaceConnector.clientV2.identity.serviceAccount.updateSecretData<ServiceAccountUpdateSecretDataParameters, ServiceAccountModel>,
-        deleteSecretData: SpaceConnector.clientV2.identity.serviceAccount.deleteSecretData<ServiceAccountDeleteSecretDataParameters>,
+        updateSecretData: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.serviceAccount.updateSecretData<ServiceAccountUpdateSecretDataParameters, ServiceAccountModel>),
+        deleteSecretData: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.serviceAccount.deleteSecretData<ServiceAccountDeleteSecretDataParameters>),
     };
 
     return {

--- a/apps/web/src/api-clients/identity/trusted-account/composables/use-trusted-account-api.ts
+++ b/apps/web/src/api-clients/identity/trusted-account/composables/use-trusted-account-api.ts
@@ -11,19 +11,22 @@ import type { TrustedAccountSyncParameters } from '@/api-clients/identity/truste
 import type { TrustedAccountUpdateParameters } from '@/api-clients/identity/trusted-account/schema/api-verbs/update';
 import type { TrustedAccountUpdateSecretDataParameters } from '@/api-clients/identity/trusted-account/schema/api-verbs/update-secret-data';
 import type { TrustedAccountModel } from '@/api-clients/identity/trusted-account/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 
 
 export const useTrustedAccountApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('trustedAccount');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.trustedAccount.create<TrustedAccountCreateParameters, TrustedAccountModel>,
-        update: SpaceConnector.clientV2.identity.trustedAccount.update<TrustedAccountUpdateParameters, TrustedAccountModel>,
-        delete: SpaceConnector.clientV2.identity.trustedAccount.delete<TrustedAccountDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.trustedAccount.create<TrustedAccountCreateParameters, TrustedAccountModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.trustedAccount.update<TrustedAccountUpdateParameters, TrustedAccountModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.trustedAccount.delete<TrustedAccountDeleteParameters>),
         get: SpaceConnector.clientV2.identity.trustedAccount.get<TrustedAccountGetParameters, TrustedAccountModel>,
         list: SpaceConnector.clientV2.identity.trustedAccount.list<TrustedAccountListParameters, ListResponse<TrustedAccountModel>>,
         stat: SpaceConnector.clientV2.identity.trustedAccount.stat<TrustedAccountStatParameters, StatResponse>,
-        updateSecretData: SpaceConnector.clientV2.identity.trustedAccount.updateSecretData<TrustedAccountUpdateSecretDataParameters, TrustedAccountModel>,
-        sync: SpaceConnector.clientV2.identity.trustedAccount.sync<TrustedAccountSyncParameters>,
+        updateSecretData: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.trustedAccount.updateSecretData<TrustedAccountUpdateSecretDataParameters, TrustedAccountModel>),
+        sync: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.trustedAccount.sync<TrustedAccountSyncParameters>),
     };
 
     return {

--- a/apps/web/src/api-clients/identity/user-group/composables/use-user-group-api.ts
+++ b/apps/web/src/api-clients/identity/user-group/composables/use-user-group-api.ts
@@ -9,17 +9,20 @@ import type { UserGroupListParameters } from '@/api-clients/identity/user-group/
 import type { UserGroupRemoveUsersParameters } from '@/api-clients/identity/user-group/schema/api-verbs/remove-users';
 import type { UserGroupUpdateParameters } from '@/api-clients/identity/user-group/schema/api-verbs/update';
 import type { UserGroupModel } from '@/api-clients/identity/user-group/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 
 export const useUserGroupApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('userGroup');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.userGroup.create<UserGroupCreateParameters, UserGroupModel>,
-        update: SpaceConnector.clientV2.identity.userGroup.update<UserGroupUpdateParameters, UserGroupModel>,
-        delete: SpaceConnector.clientV2.identity.userGroup.delete<UserGroupDeleteUserGroupParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.userGroup.create<UserGroupCreateParameters, UserGroupModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.userGroup.update<UserGroupUpdateParameters, UserGroupModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.userGroup.delete<UserGroupDeleteUserGroupParameters>),
         get: SpaceConnector.clientV2.identity.userGroup.get<UserGroupGetParameters, UserGroupModel>,
         list: SpaceConnector.clientV2.identity.userGroup.list<UserGroupListParameters, ListResponse<UserGroupModel>>,
-        addUsers: SpaceConnector.clientV2.identity.userGroup.addUsers<UserGroupAddUsersParameters, UserGroupModel>,
-        removeUsers: SpaceConnector.clientV2.identity.userGroup.removeUsers<UserGroupRemoveUsersParameters, UserGroupModel>,
+        addUsers: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.userGroup.addUsers<UserGroupAddUsersParameters, UserGroupModel>),
+        removeUsers: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.userGroup.removeUsers<UserGroupRemoveUsersParameters, UserGroupModel>),
     };
 
     return {

--- a/apps/web/src/api-clients/identity/user/composables/use-user-api.ts
+++ b/apps/web/src/api-clients/identity/user/composables/use-user-api.ts
@@ -11,18 +11,21 @@ import type { UserListParameters } from '@/api-clients/identity/user/schema/api-
 import type { UserUpdateParameters } from '@/api-clients/identity/user/schema/api-verbs/update';
 import type { UserVerifyEmailParameters } from '@/api-clients/identity/user/schema/api-verbs/verify-email';
 import type { UserModel } from '@/api-clients/identity/user/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useUserApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('user');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.user.create<UserCreateParameters, UserModel>,
-        update: SpaceConnector.clientV2.identity.user.update<UserUpdateParameters, UserModel>,
-        delete: SpaceConnector.clientV2.identity.user.delete<UserDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.user.create<UserCreateParameters, UserModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.user.update<UserUpdateParameters, UserModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.user.delete<UserDeleteParameters>),
         get: SpaceConnector.clientV2.identity.user.get<UserGetParameters, UserModel>,
         list: SpaceConnector.clientV2.identity.user.list<UserListParameters, ListResponse<UserModel>>,
-        enable: SpaceConnector.clientV2.identity.user.enable<UserEnableParameters, UserModel>,
-        disable: SpaceConnector.clientV2.identity.user.disable<UserDisableParameters, UserModel>,
-        disableMfa: SpaceConnector.clientV2.identity.user.disableMfa<UserDisableMfaParameters, UserModel>,
-        verifyEmail: SpaceConnector.clientV2.identity.user.verifyEmail<UserVerifyEmailParameters, UserModel>,
+        enable: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.user.enable<UserEnableParameters, UserModel>),
+        disable: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.user.disable<UserDisableParameters, UserModel>),
+        disableMfa: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.user.disableMfa<UserDisableMfaParameters, UserModel>),
+        verifyEmail: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.user.verifyEmail<UserVerifyEmailParameters, UserModel>),
     };
 
     return {

--- a/apps/web/src/api-clients/identity/workspace-user/composables/use-workspace-user-api.ts
+++ b/apps/web/src/api-clients/identity/workspace-user/composables/use-workspace-user-api.ts
@@ -6,10 +6,13 @@ import type { FindWorkspaceUserParameters } from '@/api-clients/identity/workspa
 import type { WorkspaceUserGetParameters } from '@/api-clients/identity/workspace-user/schema/api-verbs/get';
 import type { WorkspaceUserListParameters } from '@/api-clients/identity/workspace-user/schema/api-verbs/list';
 import type { WorkspaceUserModel } from '@/api-clients/identity/workspace-user/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useWorkspaceUserApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('workspaceUser');
+
     const actions = {
-        create: SpaceConnector.clientV2.identity.workspaceUser.create<WorkspaceUserCreateParameters, WorkspaceUserModel>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.identity.workspaceUser.create<WorkspaceUserCreateParameters, WorkspaceUserModel>),
         get: SpaceConnector.clientV2.identity.workspaceUser.get<WorkspaceUserGetParameters, WorkspaceUserModel>,
         list: SpaceConnector.clientV2.identity.workspaceUser.list<WorkspaceUserListParameters, ListResponse<WorkspaceUserModel>>,
         find: SpaceConnector.clientV2.identity.workspaceUser.find<FindWorkspaceUserParameters, WorkspaceUserModel>,

--- a/apps/web/src/api-clients/inventory/collector/composables/use-collector-api.ts
+++ b/apps/web/src/api-clients/inventory/collector/composables/use-collector-api.ts
@@ -10,17 +10,21 @@ import type { CollectorUpdateParameters } from '@/api-clients/inventory/collecto
 import type { CollectorUpdatePluginParameters } from '@/api-clients/inventory/collector/schema/api-verbs/update-plugin';
 import type { CollectorModel } from '@/api-clients/inventory/collector/schema/model';
 import type { JobModel } from '@/api-clients/inventory/job/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 
 export const useCollectorApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('collector');
+
     const actions = {
-        collect: SpaceConnector.clientV2.inventory.collector.collect<CollectorCollectParameters, JobModel>,
-        create: SpaceConnector.clientV2.inventory.collector.create<CollectorCreateParameters, CollectorModel>,
-        delete: SpaceConnector.clientV2.inventory.collector.delete<CollectorDeleteParameters>,
+        collect: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.collector.collect<CollectorCollectParameters, JobModel>),
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.collector.create<CollectorCreateParameters, CollectorModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.collector.delete<CollectorDeleteParameters>),
+
         get: SpaceConnector.clientV2.inventory.collector.get<CollectorGetParameters, CollectorModel>,
         list: SpaceConnector.clientV2.inventory.collector.list<CollectorListParameters, ListResponse<CollectorModel>>,
-        update: SpaceConnector.clientV2.inventory.collector.update<CollectorUpdateParameters, CollectorModel>,
-        updatePlugin: SpaceConnector.clientV2.inventory.collector.updatePlugin<CollectorUpdatePluginParameters, CollectorModel>,
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.collector.update<CollectorUpdateParameters, CollectorModel>),
+        updatePlugin: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.collector.updatePlugin<CollectorUpdatePluginParameters, CollectorModel>),
     };
 
     return {

--- a/apps/web/src/api-clients/inventory/metric/composables/use-metric-api.ts
+++ b/apps/web/src/api-clients/inventory/metric/composables/use-metric-api.ts
@@ -8,14 +8,17 @@ import type { MetricListParameters } from '@/api-clients/inventory/metric/schema
 import type { MetricRunParameters } from '@/api-clients/inventory/metric/schema/api-verbs/run';
 import type { MetricUpdateParameters } from '@/api-clients/inventory/metric/schema/api-verbs/update';
 import type { MetricModel } from '@/api-clients/inventory/metric/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useMetricApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('metric');
+
     const actions = {
-        create: SpaceConnector.clientV2.inventory.metric.create<MetricCreateParameters, MetricModel>,
-        delete: SpaceConnector.clientV2.inventory.metric.delete<MetricDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.metric.create<MetricCreateParameters, MetricModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.metric.delete<MetricDeleteParameters>),
         get: SpaceConnector.clientV2.inventory.metric.get<MetricGetParameters, MetricModel>,
-        run: SpaceConnector.clientV2.inventory.metric.run<MetricRunParameters>,
-        update: SpaceConnector.clientV2.inventory.metric.update<MetricUpdateParameters, MetricModel>,
+        run: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.metric.run<MetricRunParameters>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.inventory.metric.update<MetricUpdateParameters, MetricModel>),
         list: SpaceConnector.clientV2.inventory.metric.list<MetricListParameters, ListResponse<MetricModel>>,
     };
 

--- a/apps/web/src/api-clients/monitoring/escalation-policy/composables/use-escalation-policy-api.ts
+++ b/apps/web/src/api-clients/monitoring/escalation-policy/composables/use-escalation-policy-api.ts
@@ -8,15 +8,18 @@ import type { EscalationPolicyListParameters } from '@/api-clients/monitoring/es
 import type { EscalationPolicySetDefaultParameters } from '@/api-clients/monitoring/escalation-policy/schema/api-verbs/set-default';
 import type { EscalationPolicyUpdateParameters } from '@/api-clients/monitoring/escalation-policy/schema/api-verbs/update';
 import type { EscalationPolicyModel } from '@/api-clients/monitoring/escalation-policy/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useEscalationPolicyApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('monitoringEscalationPolicy');
+
     const actions = {
-        create: SpaceConnector.clientV2.monitoring.escalationPolicy.create<EscalationPolicyCreateParameters, EscalationPolicyModel>,
-        delete: SpaceConnector.clientV2.monitoring.escalationPolicy.delete<EscalationPolicyDeleteParameters>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.escalationPolicy.create<EscalationPolicyCreateParameters, EscalationPolicyModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.escalationPolicy.delete<EscalationPolicyDeleteParameters>),
         get: SpaceConnector.clientV2.monitoring.escalationPolicy.get<EscalationPolicyGetParameters, EscalationPolicyModel>,
         list: SpaceConnector.clientV2.monitoring.escalationPolicy.list<EscalationPolicyListParameters, ListResponse<EscalationPolicyModel>>,
-        setDefault: SpaceConnector.clientV2.monitoring.escalationPolicy.setDefault<EscalationPolicySetDefaultParameters, EscalationPolicyModel>,
-        update: SpaceConnector.clientV2.monitoring.escalationPolicy.update<EscalationPolicyUpdateParameters, EscalationPolicyModel>,
+        setDefault: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.escalationPolicy.setDefault<EscalationPolicySetDefaultParameters, EscalationPolicyModel>),
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.escalationPolicy.update<EscalationPolicyUpdateParameters, EscalationPolicyModel>),
     };
     return {
         escalationPolicyAPI: actions,

--- a/apps/web/src/api-clients/monitoring/webhook/composables/use-webhook-api.ts
+++ b/apps/web/src/api-clients/monitoring/webhook/composables/use-webhook-api.ts
@@ -11,18 +11,21 @@ import type { WebhookUpdateParameters } from '@/api-clients/monitoring/webhook/s
 import type { WebhookUpdatePluginParameters } from '@/api-clients/monitoring/webhook/schema/api-verbs/update-plugin';
 import type { WebhookVerifyPluginParameters } from '@/api-clients/monitoring/webhook/schema/api-verbs/verify-plugin';
 import type { WebhookModel } from '@/api-clients/monitoring/webhook/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useWebhookApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('monitoringWebhook');
+
     const actions = {
-        create: SpaceConnector.clientV2.monitoring.webhook.create<WebhookCreateParameters, WebhookModel>,
-        delete: SpaceConnector.clientV2.monitoring.webhook.delete<WebhookDeleteParameters>,
-        disable: SpaceConnector.clientV2.monitoring.webhook.disable<WebhookDisableParameters, WebhookModel>,
-        enable: SpaceConnector.clientV2.monitoring.webhook.enable<WebhookEnableParameters, WebhookModel>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.webhook.create<WebhookCreateParameters, WebhookModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.webhook.delete<WebhookDeleteParameters>),
+        disable: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.webhook.disable<WebhookDisableParameters, WebhookModel>),
+        enable: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.webhook.enable<WebhookEnableParameters, WebhookModel>),
         get: SpaceConnector.clientV2.monitoring.webhook.get<WebhookGetParameters, WebhookModel>,
         list: SpaceConnector.clientV2.monitoring.webhook.list<WebhookListParameters, ListResponse<WebhookModel>>,
-        update: SpaceConnector.clientV2.monitoring.webhook.update<WebhookUpdateParameters, WebhookModel>,
-        updatePlugin: SpaceConnector.clientV2.monitoring.webhook.updatePlugin<WebhookUpdatePluginParameters, WebhookModel>,
-        verifyPlugin: SpaceConnector.clientV2.monitoring.webhook.verifyPlugin<WebhookVerifyPluginParameters, WebhookModel>,
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.webhook.update<WebhookUpdateParameters, WebhookModel>),
+        updatePlugin: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.webhook.updatePlugin<WebhookUpdatePluginParameters, WebhookModel>),
+        verifyPlugin: wrapResourceCacheRefresh(SpaceConnector.clientV2.monitoring.webhook.verifyPlugin<WebhookVerifyPluginParameters, WebhookModel>),
     };
     return {
         webhookAPI: actions,

--- a/apps/web/src/api-clients/notification/protocol/composables/use-protocol-api.ts
+++ b/apps/web/src/api-clients/notification/protocol/composables/use-protocol-api.ts
@@ -10,18 +10,20 @@ import type { ProtocolListParameters } from '@/api-clients/notification/protocol
 import type { ProtocolUpdateParameters } from '@/api-clients/notification/protocol/schema/api-verbs/update';
 import type { ProtocolUpdatePluginParameters } from '@/api-clients/notification/protocol/schema/api-verbs/update-plugin';
 import type { ProtocolModel } from '@/api-clients/notification/protocol/schema/model';
-
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useProtocolApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('protocol');
+
     const actions = {
-        create: SpaceConnector.clientV2.notification.protocol.create<ProtocolCreateParameters, ProtocolModel>,
-        delete: SpaceConnector.clientV2.notification.protocol.delete<ProtocolDeleteParameters>,
-        disable: SpaceConnector.clientV2.notification.protocol.disable<ProtocolDisableParameters, ProtocolModel>,
-        enable: SpaceConnector.clientV2.notification.protocol.enable<ProtocolEnableParameters, ProtocolModel>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.notification.protocol.create<ProtocolCreateParameters, ProtocolModel>),
+        delete: wrapResourceCacheRefresh(SpaceConnector.clientV2.notification.protocol.delete<ProtocolDeleteParameters>),
+        disable: wrapResourceCacheRefresh(SpaceConnector.clientV2.notification.protocol.disable<ProtocolDisableParameters, ProtocolModel>),
+        enable: wrapResourceCacheRefresh(SpaceConnector.clientV2.notification.protocol.enable<ProtocolEnableParameters, ProtocolModel>),
         get: SpaceConnector.clientV2.notification.protocol.get<ProtocolGetParameters, ProtocolModel>,
         list: SpaceConnector.clientV2.notification.protocol.list<ProtocolListParameters, ListResponse<ProtocolModel>>,
-        update: SpaceConnector.clientV2.notification.protocol.update<ProtocolUpdateParameters, ProtocolModel>,
-        updatePlugin: SpaceConnector.clientV2.notification.protocol.updatePlugin<ProtocolUpdatePluginParameters, ProtocolModel>,
+        update: wrapResourceCacheRefresh(SpaceConnector.clientV2.notification.protocol.update<ProtocolUpdateParameters, ProtocolModel>),
+        updatePlugin: wrapResourceCacheRefresh(SpaceConnector.clientV2.notification.protocol.updatePlugin<ProtocolUpdatePluginParameters, ProtocolModel>),
     };
     return {
         protocolAPI: actions,

--- a/apps/web/src/api-clients/secret/secret/composables/use-secret-api.ts
+++ b/apps/web/src/api-clients/secret/secret/composables/use-secret-api.ts
@@ -5,10 +5,13 @@ import type { SecretCreateParameters } from '@/api-clients/secret/secret/schema/
 import type { SecretGetParameters } from '@/api-clients/secret/secret/schema/api-verbs/get';
 import type { SecretListParameters } from '@/api-clients/secret/secret/schema/api-verbs/list';
 import type { SecretModel } from '@/api-clients/secret/secret/schema/model';
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
 
 export const useSecretApi = () => {
+    const { wrapResourceCacheRefresh } = useResourceCacheSync('secret');
+
     const actions = {
-        create: SpaceConnector.clientV2.secret.secret.create<SecretCreateParameters, SecretModel>,
+        create: wrapResourceCacheRefresh(SpaceConnector.clientV2.secret.secret.create<SecretCreateParameters, SecretModel>),
         get: SpaceConnector.clientV2.secret.secret.get<SecretGetParameters, SecretModel>,
         list: SpaceConnector.clientV2.secret.secret.list<SecretListParameters, ListResponse<SecretModel>>,
     };

--- a/apps/web/src/query/resource-query/shared/composable/__tests__/use-resource-cache-sync.test.ts
+++ b/apps/web/src/query/resource-query/shared/composable/__tests__/use-resource-cache-sync.test.ts
@@ -1,0 +1,140 @@
+import { QueryClient, useQueryClient } from '@tanstack/vue-query';
+import type * as VueQuery from '@tanstack/vue-query';
+import {
+    describe, it, expect, vi, beforeEach,
+} from 'vitest';
+
+import { useResourceCacheSync } from '@/query/resource-query/shared/composable/use-resource-cache-sync';
+
+vi.mock('@tanstack/vue-query', async (importOriginal) => {
+    const original = await importOriginal() as typeof VueQuery;
+    return {
+        ...original,
+        useQueryClient: vi.fn(),
+    };
+});
+
+// Mock app context store
+vi.mock('@/store/app-context/workspace/user-workspace-store', () => ({
+    useUserWorkspaceStore: () => ({
+        getters: {
+            currentWorkspaceId: 'workspace-123',
+        },
+    }),
+}));
+vi.mock('@/store/app-context/app-context-store', () => ({
+    useAppContextStore: () => ({
+        getters: {
+            isAdminMode: false,
+        },
+    }),
+}));
+// Mock useQueryKeyAppContext
+vi.mock('@/query/core/query-key/_composable/use-app-context-query-key', () => ({
+    useQueryKeyAppContext: () => ({
+        value: ['workspace', 'workspace-123'] as const,
+    }),
+}));
+
+describe('useResourceCacheSync', () => {
+    // isolate the test environment (queryClient)
+    let queryClient: QueryClient;
+    beforeEach(() => {
+        queryClient = new QueryClient({
+            defaultOptions: {
+                queries: {
+                    retry: false,
+                },
+            },
+        });
+        vi.mocked(useQueryClient).mockReturnValue(queryClient);
+        queryClient.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('1. wrapResourceCacheRefresh', () => {
+        it('should invalidate the cache of the resource after the function is successfully executed', async () => {
+            // Arrange
+            const { wrapResourceCacheRefresh } = useResourceCacheSync('project');
+            const mockApiFn = vi.fn().mockResolvedValue({ status: 'success' });
+            const wrappedFn = wrapResourceCacheRefresh(mockApiFn);
+            const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+            // Act
+            await wrappedFn({ name: 'new-project' });
+
+            // Assert
+            expect(mockApiFn).toHaveBeenCalledTimes(1);
+            expect(mockApiFn).toHaveBeenCalledWith({ name: 'new-project' });
+
+            expect(invalidateSpy).toHaveBeenCalledTimes(1);
+            expect(invalidateSpy).toHaveBeenCalledWith({
+                queryKey: ['workspace', 'workspace-123', 'project'],
+            });
+        });
+
+        it('should invalidate the cache of the resource even if the function fails', async () => {
+            // Arrange
+            const { wrapResourceCacheRefresh } = useResourceCacheSync('project');
+            const mockApiFn = vi.fn().mockRejectedValue(new Error('API Error'));
+            const wrappedFn = wrapResourceCacheRefresh(mockApiFn);
+            const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+            // Act & Assert
+            await expect(wrappedFn()).rejects.toThrow('API Error');
+
+            expect(invalidateSpy).toHaveBeenCalledTimes(1);
+            expect(invalidateSpy).toHaveBeenCalledWith({
+                queryKey: ['workspace', 'workspace-123', 'project'],
+            });
+        });
+    });
+
+    describe('2. wrapResourceCacheUpdate', () => {
+        const resourceType = 'project';
+        const resourceQueryKey = ['workspace', 'workspace-123', resourceType];
+
+        it('should create a new cache with the new data and invalidate the list/stat queries', async () => {
+            // Arrange
+            const { wrapResourceCacheUpdate } = useResourceCacheSync(resourceType);
+            const newProjectData = { project_id: 'project-new', name: 'New Project' };
+            const mockApiFn = vi.fn().mockResolvedValue(newProjectData);
+            const wrappedFn = wrapResourceCacheUpdate(mockApiFn);
+            const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+            // Act
+            await wrappedFn(newProjectData);
+
+            // Assert
+            const cachedData = queryClient.getQueryData<Record<string, any>>(resourceQueryKey);
+            expect(cachedData).toEqual({ 'project-new': newProjectData });
+
+            expect(invalidateSpy).toHaveBeenCalledTimes(2);
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [...resourceQueryKey, 'stat'] });
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [...resourceQueryKey, 'list'] });
+        });
+
+        it('should update the existing cache with the new data', async () => {
+            // Arrange
+            const { wrapResourceCacheUpdate } = useResourceCacheSync(resourceType);
+            const initialData = { project_id: 'project-123', name: 'Old Name' };
+            const updatedData = { project_id: 'project-123', name: 'Updated Name' };
+
+            queryClient.setQueryData(resourceQueryKey, { 'project-123': initialData });
+
+            const mockApiFn = vi.fn().mockResolvedValue(updatedData);
+            const wrappedFn = wrapResourceCacheUpdate(mockApiFn);
+
+            // Act
+            await wrappedFn(updatedData);
+
+            // Assert
+            const cachedData = queryClient.getQueryData<Record<string, any>>(resourceQueryKey);
+            expect(cachedData?.[updatedData.project_id]).toEqual(updatedData);
+            expect(Object.keys(cachedData ?? {}).length).toBe(1);
+        });
+    });
+});

--- a/apps/web/src/query/resource-query/shared/composable/use-resource-cache-sync.ts
+++ b/apps/web/src/query/resource-query/shared/composable/use-resource-cache-sync.ts
@@ -7,60 +7,56 @@ import type { ResourceCacheType, ResourceKeyType } from '@/query/resource-query/
 
 
 
-type MutationCallback<T> = () => Promise<T>;
-type callbackForReferenceRefresh = () => Promise<void>;
+type Obj = Record<string, any>;
+type AnyFn = (...args: any[]) => any;
+type AwaitedRet<F extends AnyFn> = Awaited<ReturnType<F>>;
 
-export const useResourceCacheSync = <T extends Record<string, any>>(resourceType: ResourceKeyType) => {
+
+export const useResourceCacheSync = (resourceType: ResourceKeyType) => {
     const queryClient = useQueryClient();
 
-    const mutateWithResourceCacheUpdate = async (
-        mutationCallback: MutationCallback<T>,
-    ): Promise<T> => {
-        const response = await mutationCallback();
-        await _updateResourceCache<T>(resourceType, response, queryClient);
-        return response;
-    };
-
-    const refreshResourceCache = async (
-        mutationCallback: callbackForReferenceRefresh,
-    ): Promise<void> => {
-        await mutationCallback();
+    const wrapResourceCacheRefresh = <F extends AnyFn>(fn: F) => async (...args: Parameters<F>): Promise<AwaitedRet<F>> => {
         const { key: referenceQueryKey } = useResourceQueryKey(resourceType);
-        await queryClient.invalidateQueries({ queryKey: referenceQueryKey.value });
+        try {
+            const res = await fn(...args);
+            return res;
+        } finally {
+            await queryClient.invalidateQueries({ queryKey: referenceQueryKey.value });
+        }
     };
 
-    return { mutateWithResourceCacheUpdate, refreshResourceCache };
+    const wrapResourceCacheUpdate = <F extends AnyFn>(fn: F) => async (...args: Parameters<F>): Promise<AwaitedRet<F>> => {
+        const res = await Promise.resolve(fn(...args));
+        await _updateResourceCache(resourceType, res as Obj, queryClient);
+        return res;
+    };
+
+    return { wrapResourceCacheRefresh, wrapResourceCacheUpdate };
 };
 
 
-const _updateResourceCache = async <T extends Record<string, any>>(
+const _updateResourceCache = async <T extends Obj>(
     resourceType: ResourceKeyType,
     newData: T,
     queryClient: QueryClient,
 ) => {
     const { key: referenceQueryKey, withSuffix } = useResourceQueryKey(resourceType);
-
-    const idKey = RESOURCE_CONFIG_MAP[resourceType].idKey;
+    const idKey = RESOURCE_CONFIG_MAP[resourceType].idKey as keyof T;
 
     if (!idKey || typeof newData !== 'object' || newData === null || !(idKey in newData)) {
         throw new Error(`Invalid resource key or data for type: ${resourceType}`);
     }
 
-    queryClient.setQueryData<ResourceCacheType<T>>(referenceQueryKey, (oldData: ResourceCacheType<T>|undefined) => {
-        const currentResults = oldData ?? {};
-        const newDataId = newData[idKey];
+    queryClient.setQueryData<ResourceCacheType<T>>(referenceQueryKey.value, (oldData) => {
+        const currentResults = (oldData ?? {}) as ResourceCacheType<T>;
+        const newDataId = newData[idKey] as PropertyKey;
 
         if (newDataId in currentResults) {
-            const updatedResults = { ...currentResults };
-            updatedResults[newDataId] = newData;
-            return updatedResults;
+            return { ...currentResults, [newDataId]: newData };
         }
-
-        return {
-            ...currentResults,
-            [newDataId]: newData,
-        };
+        return { ...currentResults, [newDataId]: newData };
     });
+
     await Promise.all([
         queryClient.invalidateQueries({ queryKey: withSuffix('stat') }),
         queryClient.invalidateQueries({ queryKey: withSuffix('list') }),


### PR DESCRIPTION
### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)

Introduce centralized composable, `useResourceCacheSync`, to manage consistency of resource query cache.

Previously, there was no standard way to update or invalidate the client-side cache after data-mutating operations (Create, Update, Delete), which could lead to stale data being displayed in the UI. This new utility provides a robust and reusable solution to keep the cache synchronized with the server state.

#### Changes:

- Added useResourceCacheSync Composable:
  - Created a new composable that provides higher-order functions to wrap API calls.
  - `wrapResourceCacheRefresh`: Invalidates the relevant resource cache after an API call is settled, ensuring fresh data is fetched on the next query.
  - `wrapResourceCacheUpdate`: Directly updates the resource cache with the response data from an API call, providing a more immediate UI update without a full refetch.

- Applied Cache Wrappers to API Clients:
  - Integrated the `wrapResourceCacheRefresh` and `wrapResourceCacheUpdate` functions into the CUD (Create, Update, Delete) methods within the `api-clients` composables (e.g., useProjectApi, useUserApi, useCollectorApi, etc.).
  - This automates the cache synchronization process, making the data flow more predictable and reliable across the application.

---

`useResourceCacheSync` 도입

기존에는 데이터 변경(생성, 수정, 삭제) 작업 후 클라이언트 캐시를 업데이트하거나 무효화하는 표준화된 방법이 없어 UI에 오래된(stale) 데이터가 표시될 위험이 있었습니다. 이 유틸리티는 캐시와 서버 상태의 동기화를 제공합니다.

#### 주요 변경 사항:
- `useResourceCacheSync` Composable 추가:
  - API 호출을 감싸는(wrap) 고차 함수를 제공하는 신규 Composable을 구현
  - `wrapResourceCacheRefresh`: API 호출이 완료된 후 관련 리소스 캐시를 무효화(invalidate)하여, 다음번 조회 시 최신 데이터를 가져오도록 보장함
  - `wrapResourceCacheUpdate`: API 호출의 응답 데이터로 캐시를 직접 업데이트하여, 전체 목록을 다시 가져오지 않고도 즉각적인 UI 변경을 제공함

- API 클라이언트에 캐시 래퍼 적용:
  - `api-clients` 내의 Composable(예: useProjectApi, useUserApi, useCollectorApi 등)에서 CUD(생성, 수정, 삭제) 관련 메서드에 `wrapResourceCacheRefresh` 및 `wrapResourceCacheUpdate` 함수를 적용
  - 이는 캐시 동기화 프로세스를 자동화하여 애플리케이션 전반에 걸쳐 데이터 흐름의 예측 가능성 보장


### Things to Talk About (optional)
