### PR TITLE
fix: show real created_at in trusted account attached general account table (CLO-1344)

### DIFF
--- a/apps/web/src/services/asset-inventory/components/ServiceAccountAttachedGeneralAccounts.vue
+++ b/apps/web/src/services/asset-inventory/components/ServiceAccountAttachedGeneralAccounts.vue
@@ -27,6 +27,7 @@ import { ACTION_ICON } from '@cloudforet/mirinae/src/inputs/link/type';
 import type { DataTableFieldType } from '@cloudforet/mirinae/types/data-display/tables/data-table/type';
 import type { ValueItem } from '@cloudforet/mirinae/types/inputs/search/query-search/type';
 import type { ToolboxOptions } from '@cloudforet/mirinae/types/navigation/toolbox/type';
+import { iso8601Formatter } from '@cloudforet/utils';
 
 
 import type { ListResponse } from '@/schema/_common/api-verbs/list';
@@ -367,7 +368,7 @@ watch(() => state.trustedAccountId, async (ta) => {
                     </span>
                 </template>
                 <template #col-created_at-format="{value}">
-                    {{ dayjs(value).tz(state.timezone).format('YYYY-MM-DD HH:mm:ss') }}
+                    {{ iso8601Formatter(value, state.timezone) }}
                 </template>
             </p-data-table>
         </div>

--- a/apps/web/src/services/asset-inventory/components/ServiceAccountAttachedGeneralAccounts.vue
+++ b/apps/web/src/services/asset-inventory/components/ServiceAccountAttachedGeneralAccounts.vue
@@ -367,7 +367,7 @@ watch(() => state.trustedAccountId, async (ta) => {
                     </span>
                 </template>
                 <template #col-created_at-format="{value}">
-                    {{ dayjs(value.data).tz(state.timezone).format('YYYY-MM-DD HH:mm:ss') }}
+                    {{ dayjs(value).tz(state.timezone).format('YYYY-MM-DD HH:mm:ss') }}
                 </template>
             </p-data-table>
         </div>


### PR DESCRIPTION
## CLO-1344

Trusted Account 상세 페이지의 **연결된 General Account 목록** 데이터테이블에서 `Created` 컬럼이 모든 행에 현재 시각으로 표시되던 버그를 수정합니다.

### 원인
`ServiceAccountAttachedGeneralAccounts.vue`의 `#col-created_at-format="{value}"` 슬롯은 `value`로 `created_at` 문자열(스칼라)을 직접 넘깁니다. 기존 코드는 존재하지 않는 `value.data`에 접근해 `undefined`가 되었고, `dayjs(undefined)`가 **현재 시각**을 반환해 모든 행이 동일한 현재 시간으로 표시되었습니다.

### 수정
- `dayjs(value.data)...` → `iso8601Formatter(value, state.timezone)`
- `iso8601Formatter`는 동일한 `YYYY-MM-DD HH:mm:ss` 포맷을 사용하면서 falsy 값에 대해 `''`를 반환(null-safe)합니다. 이 테이블은 `created_at`이 없을 수 있는 PENDING 계정도 노출하므로, `dayjs(value)` 단독보다 안전합니다.
- 참조 컴포넌트 `CollectorDetailAttachedServiceAccounts.vue`와 동일한 패턴입니다.

### 검증
- ESLint 통과 (import-order 포함)
- 코드 리뷰 APPROVE (Critical/Major/Minor 0건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
