### PR TITLE
fix: show real created_at in trusted account attached general account…

### DIFF
--- a/apps/web/src/services/asset-inventory/components/ServiceAccountAttachedGeneralAccounts.vue
+++ b/apps/web/src/services/asset-inventory/components/ServiceAccountAttachedGeneralAccounts.vue
@@ -27,6 +27,7 @@ import { ACTION_ICON } from '@cloudforet/mirinae/src/inputs/link/type';
 import type { DataTableFieldType } from '@cloudforet/mirinae/types/data-display/tables/data-table/type';
 import type { ValueItem } from '@cloudforet/mirinae/types/inputs/search/query-search/type';
 import type { ToolboxOptions } from '@cloudforet/mirinae/types/navigation/toolbox/type';
+import { iso8601Formatter } from '@cloudforet/utils';
 
 
 import type { ListResponse } from '@/schema/_common/api-verbs/list';
@@ -367,7 +368,7 @@ watch(() => state.trustedAccountId, async (ta) => {
                     </span>
                 </template>
                 <template #col-created_at-format="{value}">
-                    {{ dayjs(value.data).tz(state.timezone).format('YYYY-MM-DD HH:mm:ss') }}
+                    {{ iso8601Formatter(value, state.timezone) }}
                 </template>
             </p-data-table>
         </div>


### PR DESCRIPTION
… table (CLO-1344) (#6147)

* fix: show real created_at in trusted account attached general account table (CLO-1344)

The Created column in the connected General Account list rendered dayjs(value.data), but the PDataTable format slot passes the created_at string directly as value. Accessing .data on a string yielded undefined, so dayjs(undefined) produced the current time for every row. Use dayjs(value) to format the actual created_at value.




* refactor: use iso8601Formatter for attached general account Created column (CLO-1344)

Follow-up hardening from code review. This table can list PENDING accounts whose created_at may be absent; bare dayjs(value) would render 'Invalid Date' or, if undefined, silently reintroduce the current-time bug. iso8601Formatter null-guards (returns '') and uses the same 'YYYY-MM-DD HH:mm:ss' format, matching the sibling CollectorDetailAttachedServiceAccounts component.




---------

### Skip Review (optional)
- [ ] Minor changes that don't affect the functionality (e.g. `style`, `chore`, `ci`, `test`, `docs`)
- [ ] Previously reviewed in feature branch, further review is not mandatory
- [ ] Self-merge allowed for solo developers or urgent changes

### Description (optional)

### Things to Talk About (optional)
